### PR TITLE
Sync des variables d'env de dev depuis Vercel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,25 +9,28 @@ updates:
       time: "09:00"
       timezone: "America/Montreal"
     open-pull-requests-limit: 10
-    # Grouper les mises à jour pour éviter trop de PRs
+    # Grouper les mises à jour pour éviter trop de PRs.
+    # Ordre = priorité : une dépendance va dans le PREMIER groupe qui la capture.
     groups:
-      # Mises à jour mineures et patches groupées
+      # Framework critique en premier : isolé, toutes versions, pour review attentive
+      nextjs:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+      # Tout le reste en minor + patch : 1 seule PR (idéale pour l'auto-merge)
       minor-and-patch:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          - "next"
-          - "react"
-          - "react-dom"
-      # Framework Next.js séparé (peut casser des choses)
-      nextjs:
+      # Tout le reste en major : 1 seule PR groupée (breaking, à reviewer ensemble)
+      major:
         patterns:
-          - "next"
-          - "react"
-          - "react-dom"
+          - "*"
+        update-types:
+          - "major"
     labels:
       - "dependencies"
       - "automated"
@@ -39,6 +42,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Toutes les actions dans une seule PR groupée au lieu d'une PR par action
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "ci"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ cp .env.example .env.local
 
 See [`.env.example`](.env.example) for all variables. Required: `DATABASE_URL` (pooled) + `DATABASE_URL_UNPOOLED` (direct, for migrations), `BETTER_AUTH_SECRET`. Optional: Google OAuth, AWS SES, Stripe, AWS S3, Sentry.
 
+> **Team shortcut — sync env from Vercel.** Instead of filling `.env.local` by hand, pull the shared **development** environment from Vercel on any machine:
+>
+> ```bash
+> vercel login                 # once per machine
+> vercel link                  # select team rinkhimeras-projects → project nomaqbank
+> bun run env:sync             # writes a grouped .env.local from Vercel's Development scope
+> ```
+>
+> `bun run env:sync` regenerates `.env.local` (organized into commented sections) from Vercel's `Development` scope only — preview/production are never touched. It is safe to re-run, and **refuses to overwrite** if your local file has keys not yet on Vercel (add those with `vercel env add <KEY> development`, then re-run). Re-pull at the start of a session if the Vercel OIDC token (~12 h) has expired.
+
 4. **Apply database migrations**
 
 ```bash
@@ -129,6 +139,7 @@ NOMAQbanq/
 
 ```bash
 bun dev                  # Start dev server with Turbopack
+bun run env:sync         # Pull & regroup .env.local from Vercel (development scope)
 bun run build            # Production build
 bun run check            # Type check + lint (before commit)
 bun run lint:fix         # Automatically fix lint errors

--- a/docs/superpowers/plans/2026-06-27-sync-env-dev-vercel.md
+++ b/docs/superpowers/plans/2026-06-27-sync-env-dev-vercel.md
@@ -1,0 +1,645 @@
+# Sync des env de dev depuis Vercel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconstruire `.env.local` à l'identique (et rangé par sections) sur n'importe quel PC via `bun run env:sync`, depuis le scope **Development** de Vercel, sans jamais toucher preview/prod.
+
+**Architecture:** Le scope `Development` de Vercel devient la source de vérité unique et un **sur-ensemble** de `.env.local`. Un script d'amorçage unique y pousse les 13 clés locales encore absentes (en `development` seulement). Un wrapper `scripts/sync-env.ts` fait `vercel env pull` puis **regroupe** le fichier plat en sections (fonctionnel + tag de tier 🟢/🟡), avec un **garde-fou anti-écrasement** (refuse d'écraser si des clés locales manquent côté Vercel).
+
+**Tech Stack:** Bun (exécute le TS directement), `dotenv` (parse des valeurs), `node:child_process` (spawn de la CLI Vercel v54.x), Vitest (tests des fonctions pures). Spec : `docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md`.
+
+**⚠️ Ordre critique d'exécution :** construire les scripts (Tasks 1-5) → **amorcer Vercel** (Task 6) → **seulement ensuite** lancer `bun run env:sync` (Task 7). Lancer le sync avant l'amorçage effacerait les 12 clés locales absentes de Vercel (le garde-fou de Task 2 le bloque, mais l'ordre reste impératif).
+
+---
+
+## File Structure
+
+- **Create** `scripts/sync-env.ts` — pull `development` + regroupement en sections + garde-fou anti-écrasement. Exporte les fonctions pures `parseRawLines`, `groupEnv`, `keysOnlyIn` ; `main()` gardé (non exécuté à l'import).
+- **Create** `scripts/seed-vercel-dev-env.ts` — amorçage unique des clés locales absentes de Vercel Dev. Exporte la fonction pure `keysToSeed` ; `main()` gardé.
+- **Create** `tests/scripts/sync-env.test.ts` — tests unitaires de `groupEnv` / `parseRawLines` / `keysOnlyIn`.
+- **Create** `tests/scripts/seed-vercel-dev-env.test.ts` — tests unitaires de `keysToSeed`.
+- **Modify** `package.json:21` — ajouter le script `"env:sync"`.
+- **Modify** `README.md` — sous-section « Sync env from Vercel » (Installation) + entrée dans « Available Scripts ».
+- **Modify** `.env.local` (gitignored, jamais commité) — ajouter `EMAIL_OVERRIDE_TO=dixiades@gmail.com` avant l'amorçage.
+
+Convention respectée (cf. `scripts/neon-api.ts`) : ESM, top-level guard `process.argv[1]?.endsWith("...")`, pas de shebang, lancé via `bun scripts/X.ts`.
+
+---
+
+## Task 1: Cœur de regroupement (`groupEnv`) — TDD
+
+**Files:**
+- Create: `scripts/sync-env.ts`
+- Test: `tests/scripts/sync-env.test.ts`
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Create `tests/scripts/sync-env.test.ts` :
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { groupEnv, keysOnlyIn, parseRawLines } from "@/scripts/sync-env"
+
+describe("parseRawLines", () => {
+  it("ignore commentaires et lignes vides, garde la ligne brute", () => {
+    const map = parseRawLines("# c\n\nDATABASE_URL=postgres://a&b=c")
+    expect(map.size).toBe(1)
+    expect(map.get("DATABASE_URL")).toBe("DATABASE_URL=postgres://a&b=c")
+  })
+})
+
+describe("groupEnv", () => {
+  it("regroupe par section, préserve la valeur brute, respecte l'ordre", () => {
+    const flat = [
+      'EMAIL_FROM="NOMAQbanq <noreply@nomaqbanq.ca>"',
+      "DATABASE_URL=postgres://a&b=c",
+      "BETTER_AUTH_SECRET=xyz",
+    ].join("\n")
+    const out = groupEnv(flat)
+    expect(out).toContain("# === Base de données — Neon")
+    expect(out).toContain("DATABASE_URL=postgres://a&b=c")
+    expect(out).toContain('EMAIL_FROM="NOMAQbanq <noreply@nomaqbanq.ca>"')
+    expect(out.indexOf("DATABASE_URL")).toBeLessThan(
+      out.indexOf("BETTER_AUTH_SECRET"),
+    )
+    expect(out.indexOf("BETTER_AUTH_SECRET")).toBeLessThan(
+      out.indexOf("EMAIL_FROM"),
+    )
+  })
+
+  it("met les clés inconnues en « Non classé »", () => {
+    const out = groupEnv("FOO_UNKNOWN=1\nDATABASE_URL=x")
+    expect(out).toContain("# === Non classé")
+    expect(out).toContain("FOO_UNKNOWN=1")
+  })
+})
+
+describe("keysOnlyIn", () => {
+  it("retourne les clés de a absentes de b, triées", () => {
+    expect(keysOnlyIn(["B", "A", "C"], new Set(["A"]))).toEqual(["B", "C"])
+  })
+})
+```
+
+- [ ] **Step 2: Lancer le test, vérifier l'échec**
+
+Run: `bun run test -- sync-env`
+Expected: FAIL — `Cannot find module '@/scripts/sync-env'`.
+
+- [ ] **Step 3: Implémenter `scripts/sync-env.ts`**
+
+Create `scripts/sync-env.ts` :
+
+```ts
+/**
+ * Reconstruit .env.local depuis le scope « Development » de Vercel, regroupé en
+ * sections (fonctionnel + tag de tier). `vercel env pull` produit un fichier
+ * plat ; ce script le post-traite. Lancé via `bun run env:sync`.
+ *
+ * Garde-fou : si .env.local contient des clés ABSENTES du pull, on REFUSE
+ * d'écraser (perte de données) — amorcer ces clés dans Vercel d'abord
+ * (scripts/seed-vercel-dev-env.ts), ou forcer avec --force.
+ */
+import { spawnSync } from "node:child_process"
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+type Group = { title: string; tier: string; keys: readonly string[] }
+
+// Carte de groupes = point unique de catégorisation (alignée sur .env.example).
+const GROUP_MAP: readonly Group[] = [
+  {
+    title: "Base de données — Neon",
+    tier: "🟢 runtime, REQUIS",
+    keys: ["DATABASE_URL", "DATABASE_URL_UNPOOLED"],
+  },
+  {
+    title: "Better Auth",
+    tier: "🟢 runtime, REQUIS",
+    keys: ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL"],
+  },
+  {
+    title: "OAuth Google",
+    tier: "🟢 runtime",
+    keys: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+  },
+  {
+    title: "AWS SES — emails",
+    tier: "🟢 runtime",
+    keys: [
+      "SES_REGION",
+      "SES_ACCESS_KEY_ID",
+      "SES_SECRET_ACCESS_KEY",
+      "EMAIL_FROM",
+      "SES_CONFIGURATION_SET",
+      "EMAIL_OVERRIDE_TO",
+    ],
+  },
+  {
+    title: "AWS S3 + CloudFront — médias",
+    tier: "🟢 runtime",
+    keys: [
+      "S3_REGION",
+      "S3_BUCKET",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "NEXT_PUBLIC_CDN_HOSTNAME",
+    ],
+  },
+  { title: "Cron Vercel", tier: "🟢 runtime", keys: ["CRON_SECRET"] },
+  {
+    title: "Sentry — monitoring",
+    tier: "🟡 build + 🟢 runtime",
+    keys: ["SENTRY_AUTH_TOKEN", "NEXT_PUBLIC_SENTRY_DSN"],
+  },
+  {
+    title: "Tests d'intégration — Neon API",
+    tier: "🟡 outillage",
+    keys: ["NEON_API_KEY", "NEON_PROJECT_ID"],
+  },
+  {
+    title: "Tests E2E — Playwright",
+    tier: "🟡 tests",
+    keys: [
+      "E2E_ADMIN_EMAIL",
+      "E2E_ADMIN_PASSWORD",
+      "E2E_USER_EMAIL",
+      "E2E_USER_PASSWORD",
+      "E2E_RESET_SECRET",
+    ],
+  },
+  {
+    title: "Vercel (auto-injecté)",
+    tier: "—",
+    keys: ["VERCEL_OIDC_TOKEN"],
+  },
+]
+
+const HEADER =
+  "# ⚠️  Généré par `bun run env:sync` — source de vérité : Vercel scope Development.\n" +
+  "# Ne pas éditer à la main : toute nouvelle var doit être ajoutée sur Vercel\n" +
+  "# (`vercel env add <KEY> development`), sinon le prochain sync l'efface.\n"
+
+/** Map clé -> ligne brute (préservée telle quelle, jamais re-quotée). */
+export const parseRawLines = (content: string): Map<string, string> => {
+  const map = new Map<string, string>()
+  for (const line of content.split(/\r?\n/)) {
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=/.exec(line)
+    if (m) map.set(m[1], line)
+  }
+  return map
+}
+
+/** Clés de `a` absentes de `b`, triées. */
+export const keysOnlyIn = (a: Iterable<string>, b: Set<string>): string[] =>
+  [...a].filter((k) => !b.has(k)).sort()
+
+/** Regroupe le contenu plat d'un pull en sections (fonctionnel + tier). */
+export const groupEnv = (content: string): string => {
+  const lines = parseRawLines(content)
+  const used = new Set<string>()
+  const blocks: string[] = []
+
+  for (const group of GROUP_MAP) {
+    const body: string[] = []
+    for (const k of group.keys) {
+      const raw = lines.get(k)
+      if (raw === undefined) continue
+      body.push(raw)
+      used.add(k)
+    }
+    if (body.length > 0)
+      blocks.push(
+        `# === ${group.title}  (${group.tier}) ===\n${body.join("\n")}`,
+      )
+  }
+
+  const leftovers = [...lines.keys()].filter((k) => !used.has(k)).sort()
+  if (leftovers.length > 0)
+    blocks.push(
+      `# === Non classé  (à ajouter à la carte de groupes) ===\n${leftovers
+        .map((k) => lines.get(k) ?? "")
+        .join("\n")}`,
+    )
+
+  return `${HEADER}\n${blocks.join("\n\n")}\n`
+}
+
+const main = (): void => {
+  const force = process.argv.includes("--force")
+  const tmp = join(mkdtempSync(join(tmpdir(), "env-sync-")), "pulled.env")
+
+  console.log("→ vercel env pull (development)…")
+  const pull = spawnSync(
+    `vercel env pull "${tmp}" --environment=development --yes`,
+    { shell: true, stdio: ["ignore", "inherit", "inherit"] },
+  )
+  if (pull.status !== 0) {
+    console.error(
+      "✗ `vercel env pull` a échoué. Connecté (`vercel login`) et lié (`vercel link`) ?",
+    )
+    process.exit(1)
+  }
+
+  const pulledContent = readFileSync(tmp, "utf8")
+  rmSync(tmp, { recursive: true, force: true })
+  const pulledKeys = new Set(parseRawLines(pulledContent).keys())
+
+  if (existsSync(".env.local")) {
+    const localKeys = parseRawLines(readFileSync(".env.local", "utf8")).keys()
+    const wouldWipe = keysOnlyIn(localKeys, pulledKeys)
+    if (wouldWipe.length > 0 && !force) {
+      console.error(
+        `✗ Refus d'écraser .env.local : ${wouldWipe.length} clé(s) locale(s) absente(s) de Vercel Dev seraient perdues :\n  ${wouldWipe.join(
+          "\n  ",
+        )}\n→ Amorce-les (\`bun scripts/seed-vercel-dev-env.ts\`) puis relance, ou force avec --force.`,
+      )
+      process.exit(1)
+    }
+  }
+
+  writeFileSync(".env.local", groupEnv(pulledContent))
+
+  const unclassified = keysOnlyIn(
+    pulledKeys,
+    new Set(GROUP_MAP.flatMap((g) => g.keys)),
+  )
+  console.log(`✓ .env.local régénéré : ${pulledKeys.size} variables.`)
+  if (unclassified.length > 0)
+    console.log(
+      `ℹ ${unclassified.length} en « Non classé » : ${unclassified.join(", ")}`,
+    )
+}
+
+const isDirectRun = process.argv[1]?.endsWith("sync-env.ts") ?? false
+if (isDirectRun) main()
+```
+
+- [ ] **Step 4: Lancer le test, vérifier le succès**
+
+Run: `bun run test -- sync-env`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sync-env.ts tests/scripts/sync-env.test.ts
+git commit -m "feat(env): script sync-env (pull + regroupement par sections)"
+```
+
+---
+
+## Task 2: Câbler `env:sync` dans package.json
+
+**Files:**
+- Modify: `package.json:21`
+
+- [ ] **Step 1: Ajouter le script**
+
+Dans `package.json`, après la ligne `"generate-favicons": "bun scripts/generate-favicons.mjs",` ajouter :
+
+```json
+    "env:sync": "bun scripts/sync-env.ts",
+```
+
+- [ ] **Step 2: Vérifier que la commande est reconnue (sans l'exécuter à fond)**
+
+Run: `bun run env:sync --help` n'existe pas ; à la place vérifier le câblage avec :
+`bun pm ls >/dev/null 2>&1; grep -q '"env:sync"' package.json && echo OK`
+Expected: `OK`.
+
+> ⚠️ NE PAS lancer `bun run env:sync` maintenant : l'amorçage (Task 6) n'a pas eu lieu, le garde-fou refuserait (ou, avec --force, on perdrait des clés). Le vrai run est en Task 7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "feat(env): script npm env:sync"
+```
+
+---
+
+## Task 3: Script d'amorçage (`keysToSeed` + seed) — TDD
+
+**Files:**
+- Create: `scripts/seed-vercel-dev-env.ts`
+- Test: `tests/scripts/seed-vercel-dev-env.test.ts`
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Create `tests/scripts/seed-vercel-dev-env.test.ts` :
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { keysToSeed } from "@/scripts/seed-vercel-dev-env"
+
+describe("keysToSeed", () => {
+  it("retourne les clés locales absentes de Vercel, triées", () => {
+    expect(keysToSeed({ B: "2", A: "1", C: "3" }, new Set(["A"]))).toEqual([
+      "B",
+      "C",
+    ])
+  })
+  it("ignore les valeurs vides", () => {
+    expect(keysToSeed({ X: "", Y: "v" }, new Set())).toEqual(["Y"])
+  })
+  it("ne retourne rien si tout est déjà présent", () => {
+    expect(keysToSeed({ A: "1" }, new Set(["A"]))).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Lancer le test, vérifier l'échec**
+
+Run: `bun run test -- seed-vercel-dev-env`
+Expected: FAIL — `Cannot find module '@/scripts/seed-vercel-dev-env'`.
+
+- [ ] **Step 3: Implémenter `scripts/seed-vercel-dev-env.ts`**
+
+Create `scripts/seed-vercel-dev-env.ts` :
+
+```ts
+/**
+ * Amorçage UNIQUE : pousse dans le scope « Development » de Vercel toutes les
+ * clés présentes dans .env.local mais encore absentes côté Vercel, pour que
+ * `bun run env:sync` reproduise ensuite le fichier complet sur n'importe quel
+ * PC. N'écrit QUE dans `development` (preview/prod jamais touchés). Idempotent.
+ * Valeurs lues dans .env.local, passées par stdin (jamais en argv).
+ *
+ * Lancer une fois depuis le PC qui possède le .env.local complet :
+ *   bun scripts/seed-vercel-dev-env.ts
+ */
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { parse } from "dotenv"
+
+import { parseRawLines } from "./sync-env"
+
+/** Clés à amorcer = présentes en local (valeur non vide) et absentes de Vercel. */
+export const keysToSeed = (
+  localValues: Record<string, string>,
+  existingKeys: Set<string>,
+): string[] =>
+  Object.entries(localValues)
+    .filter(([k, v]) => v.trim() !== "" && !existingKeys.has(k))
+    .map(([k]) => k)
+    .sort()
+
+const pullExistingKeys = (): Set<string> => {
+  const tmp = join(mkdtempSync(join(tmpdir(), "env-seed-")), "pulled.env")
+  const res = spawnSync(
+    `vercel env pull "${tmp}" --environment=development --yes`,
+    { shell: true, stdio: ["ignore", "inherit", "inherit"] },
+  )
+  if (res.status !== 0)
+    throw new Error("`vercel env pull` a échoué (login/link OK ?).")
+  const keys = new Set(parseRawLines(readFileSync(tmp, "utf8")).keys())
+  rmSync(tmp, { recursive: true, force: true })
+  return keys
+}
+
+const addVar = (key: string, value: string): void => {
+  const res = spawnSync(`vercel env add ${key} development --yes`, {
+    shell: true,
+    input: value,
+    stdio: ["pipe", "inherit", "inherit"],
+  })
+  if (res.status !== 0)
+    throw new Error(`vercel env add ${key} → exit ${res.status}`)
+}
+
+const main = (): void => {
+  const localValues = parse(readFileSync(".env.local", "utf8"))
+  const existing = pullExistingKeys()
+  const toAdd = keysToSeed(localValues, existing)
+
+  if (toAdd.length === 0) {
+    console.log(
+      "✓ Rien à amorcer : Vercel Dev contient déjà toutes les clés locales.",
+    )
+    return
+  }
+
+  console.log(
+    `→ Amorçage de ${toAdd.length} clé(s) dans Vercel Dev : ${toAdd.join(", ")}`,
+  )
+  for (const key of toAdd) {
+    addVar(key, localValues[key])
+    console.log(`  ✓ ${key}`)
+  }
+  console.log("✓ Amorçage terminé. Vérifie : `vercel env ls development`.")
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith("seed-vercel-dev-env.ts") ?? false
+if (isDirectRun) main()
+```
+
+- [ ] **Step 4: Lancer le test, vérifier le succès**
+
+Run: `bun run test -- seed-vercel-dev-env`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/seed-vercel-dev-env.ts tests/scripts/seed-vercel-dev-env.test.ts
+git commit -m "feat(env): script d'amorçage seed-vercel-dev-env"
+```
+
+---
+
+## Task 4: Documentation README
+
+**Files:**
+- Modify: `README.md` (section « 🛠️ Installation » et « 🎨 Available Scripts »)
+
+- [ ] **Step 1: Ajouter la sous-section de sync dans Installation**
+
+Dans `README.md`, juste après le bloc de l'étape 3 (la ligne se terminant par `Optional: Google OAuth, AWS SES, Stripe, AWS S3, Sentry.`), insérer :
+
+```markdown
+> **Team shortcut — sync env from Vercel.** Instead of filling `.env.local` by hand, pull the shared **development** environment from Vercel on any machine:
+>
+> ```bash
+> vercel login                 # once per machine
+> vercel link                  # select team rinkhimeras-projects → project nomaqbank
+> bun run env:sync             # writes a grouped .env.local from Vercel's Development scope
+> ```
+>
+> `bun run env:sync` regenerates `.env.local` (organized into commented sections) from Vercel's `Development` scope only — preview/production are never touched. It is safe to re-run, and **refuses to overwrite** if your local file has keys not yet on Vercel (add those with `vercel env add <KEY> development`, then re-run). Re-pull at the start of a session if the Vercel OIDC token (~12 h) has expired.
+```
+
+- [ ] **Step 2: Ajouter l'entrée dans « Available Scripts »**
+
+Dans le bloc ```` ```bash ```` de la section « 🎨 Available Scripts », après la ligne `bun dev                  # Start dev server with Turbopack`, insérer :
+
+```
+bun run env:sync         # Pull & regroup .env.local from Vercel (development scope)
+```
+
+- [ ] **Step 3: Vérifier le formatage**
+
+Run: `bun run format:check`
+Expected: pas d'erreur sur `README.md` (sinon `bun run format`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(env): documente le workflow bun run env:sync"
+```
+
+---
+
+## Task 5: Vérification globale (check) du code livré
+
+**Files:** aucun nouveau ; corrige au besoin les 4 fichiers créés.
+
+- [ ] **Step 1: Formatter + lint-fix**
+
+Run: `bun run format && bun run lint:fix`
+Expected: imports triés (1. `node:*` 2. `dotenv` 3. relatif `./sync-env`), aucune erreur résiduelle.
+
+- [ ] **Step 2: Check complet**
+
+Run: `bun run check`
+Expected: PASS (prettier + tsc + eslint `--max-warnings 0`). Corriger tout type/lint sur `scripts/*.ts` et `tests/scripts/*.test.ts` jusqu'au vert.
+
+- [ ] **Step 3: Suite de tests**
+
+Run: `bun run test`
+Expected: tous les tests passent, dont les 7 nouveaux (`tests/scripts/**`). La couverture n'est pas affectée (`scripts/**` hors `coverage.include`).
+
+- [ ] **Step 4: Commit (si des corrections check ont eu lieu)**
+
+```bash
+git add -A
+git commit -m "chore(env): format/lint des scripts env"
+```
+
+---
+
+## Task 6: Amorçage réel de Vercel Dev (exécution, côté PC actuel)
+
+**Files:**
+- Modify: `.env.local` (gitignored — **ne sera pas commité**)
+
+> Pré-requis : être sur le PC qui possède le `.env.local` complet, `vercel login` + lien actifs (déjà le cas : projet `nomaqbank`, team `rinkhimeras-projects`). Cette tâche **mute le scope Development de Vercel** (écritures `development` uniquement).
+
+- [ ] **Step 1: Compléter `.env.local` avec EMAIL_OVERRIDE_TO**
+
+Ajouter dans `.env.local`, sous le bloc AWS SES, la ligne :
+
+```
+EMAIL_OVERRIDE_TO=dixiades@gmail.com
+```
+
+- [ ] **Step 2: Lancer l'amorçage**
+
+Run: `bun scripts/seed-vercel-dev-env.ts`
+Expected (ordre des clés indifférent) :
+
+```
+→ Amorçage de 13 clé(s) dans Vercel Dev : AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD, E2E_RESET_SECRET, E2E_USER_EMAIL, E2E_USER_PASSWORD, EMAIL_OVERRIDE_TO, NEON_API_KEY, NEON_PROJECT_ID, NEXT_PUBLIC_CDN_HOSTNAME, S3_BUCKET, S3_REGION
+  ✓ AWS_ACCESS_KEY_ID
+  ... (13 lignes ✓)
+✓ Amorçage terminé. Vérifie : `vercel env ls development`.
+```
+
+> Si une ligne échoue (`vercel env add … → exit N`) : c'est probablement que la clé existe déjà (re-run partiel) — l'amorçage re-filtre les existantes au prochain run, relancer suffit.
+
+- [ ] **Step 3: Vérifier côté Vercel**
+
+Run: `vercel env ls development`
+Expected: les 13 clés apparaissent en plus des 14 initiales (dont `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME`, `NEON_API_KEY`, `NEON_PROJECT_ID`, les 5 `E2E_*`, `EMAIL_OVERRIDE_TO`), toutes scopées **Development** uniquement.
+
+---
+
+## Task 7: Acceptation — reproduire `.env.local` via le sync
+
+**Files:** `.env.local` (gitignored, régénéré).
+
+- [ ] **Step 1: Sauvegarder le `.env.local` courant**
+
+```bash
+cp .env.local .env.local.bak
+```
+
+- [ ] **Step 2: Lancer le sync (le vrai, post-amorçage)**
+
+Run: `bun run env:sync`
+Expected :
+
+```
+→ vercel env pull (development)…
+✓ .env.local régénéré : 28 variables.
+```
+
+(Pas de ligne « Non classé » : si elle apparaît, ajouter la/les clé(s) au `GROUP_MAP` de `scripts/sync-env.ts`.)
+
+- [ ] **Step 3: Vérifier le regroupement et la complétude**
+
+Run (aucune clé du backup perdue, et fichier bien sectionné) :
+
+```bash
+grep -c '^# === ' .env.local                 # > 0 : sections présentes
+comm -23 \
+  <(grep -oE '^[A-Za-z_][A-Za-z0-9_]*' .env.local.bak | sort -u) \
+  <(grep -oE '^[A-Za-z_][A-Za-z0-9_]*' .env.local | sort -u)      # vide = aucune clé perdue
+```
+
+Expected : premier `> 0` ; second **vide** (toutes les clés du backup sont présentes ; le nouveau fichier ajoute en plus `CRON_SECRET`, `NEXT_PUBLIC_SENTRY_DSN`, `VERCEL_OIDC_TOKEN`).
+
+- [ ] **Step 4: Vérifier que l'app démarre avec le fichier régénéré**
+
+Run: `bun run check`
+Expected: PASS (l'env Zod `lib/env/schema.ts` valide : `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `BETTER_AUTH_SECRET` présents, refines S3/Stripe satisfaits).
+
+Optionnel (smoke manuel) : `bun dev` démarre sans erreur d'env, puis arrêter.
+
+- [ ] **Step 5: Nettoyer la sauvegarde**
+
+```bash
+rm .env.local.bak
+```
+
+> `.env.local` et `.env.local.bak` sont couverts par `.gitignore` (`.env*`, sauf `!.env.example`) : rien de tout cela n'est commité. Aucun secret ne quitte la machine sauf vers Vercel (déjà la source de vérité).
+
+---
+
+## Notes de conception
+
+- **Le garde-fou de Task 2 remplace le « script de vérif jetable » (d) de la spec** : la sécurité anti-écrasement est désormais *intégrée et permanente* dans `env:sync` (refus si des clés locales manquent côté Vercel, override `--force`), plutôt qu'un script à part. Le critère d'acceptation #2 de la spec (« zéro clé effaçable ») se traduit par « `bun run env:sync` réussit sans `--force` » (Task 7, Step 2-3).
+- **Isolement preview/prod** : `seed` ne fait que `vercel env add <KEY> development` ; `sync` ne fait que `vercel env pull --environment=development`. Aucune commande ne cible preview/prod.
+- **Secrets hors argv** : `seed` passe chaque valeur via stdin (`input`), pas via `--value`, pour ne pas exposer les secrets dans la liste des process.
+- **Multiplateforme** : `spawnSync(..., { shell: true })` + chemin temp entre guillemets ; requis sous Windows pour exécuter `vercel.cmd` (Node récent bloque les `.cmd` sans `shell:true`).
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+- Source de vérité = Vercel Dev sur-ensemble → Tasks 1-3 + amorçage Task 6. ✅
+- Amorçage des 13 clés (12 + EMAIL_OVERRIDE_TO=dixiades@gmail.com) en `development` seul → Task 6. ✅
+- Wrapper `bun run env:sync` (pull + regroupement hybride fonctionnel/tier, « Non classé ») → Tasks 1-2. ✅
+- Doc bootstrap README → Task 4. ✅
+- Préservation des valeurs brutes (pas de re-quote) → `parseRawLines`/`groupEnv` (Task 1) + test valeur `postgres://a&b=c`. ✅
+- Garde-fou anti-écrasement (remplace la vérif jetable) → Task 2 + acceptation Task 7. ✅
+- Acceptation (`vercel env ls`, zéro clé effaçable, `bun run check`/`bun dev`) → Tasks 6-7. ✅
+- Mortes BUNNY supprimées naturellement → régénération Task 7 (commentaires non repris). ✅
+
+**2. Placeholder scan** : aucun TBD/TODO ; tout le code et toutes les commandes sont complets.
+
+**3. Type/nom consistency** : `parseRawLines` (défini Task 1, réimporté Task 3), `groupEnv`, `keysOnlyIn`, `keysToSeed` — signatures cohérentes entre tasks et tests. `GROUP_MAP` interne à `sync-env.ts`. Garde `isDirectRun` identique au pattern `neon-api.ts`.

--- a/docs/superpowers/plans/2026-06-27-sync-env-dev-vercel.md
+++ b/docs/superpowers/plans/2026-06-27-sync-env-dev-vercel.md
@@ -29,6 +29,7 @@ Convention respectée (cf. `scripts/neon-api.ts`) : ESM, top-level guard `proces
 ## Task 1: Cœur de regroupement (`groupEnv`) — TDD
 
 **Files:**
+
 - Create: `scripts/sync-env.ts`
 - Test: `tests/scripts/sync-env.test.ts`
 
@@ -38,7 +39,6 @@ Create `tests/scripts/sync-env.test.ts` :
 
 ```ts
 import { describe, expect, it } from "vitest"
-
 import { groupEnv, keysOnlyIn, parseRawLines } from "@/scripts/sync-env"
 
 describe("parseRawLines", () => {
@@ -300,6 +300,7 @@ git commit -m "feat(env): script sync-env (pull + regroupement par sections)"
 ## Task 2: Câbler `env:sync` dans package.json
 
 **Files:**
+
 - Modify: `package.json:21`
 
 - [ ] **Step 1: Ajouter le script**
@@ -330,6 +331,7 @@ git commit -m "feat(env): script npm env:sync"
 ## Task 3: Script d'amorçage (`keysToSeed` + seed) — TDD
 
 **Files:**
+
 - Create: `scripts/seed-vercel-dev-env.ts`
 - Test: `tests/scripts/seed-vercel-dev-env.test.ts`
 
@@ -339,7 +341,6 @@ Create `tests/scripts/seed-vercel-dev-env.test.ts` :
 
 ```ts
 import { describe, expect, it } from "vitest"
-
 import { keysToSeed } from "@/scripts/seed-vercel-dev-env"
 
 describe("keysToSeed", () => {
@@ -378,12 +379,11 @@ Create `scripts/seed-vercel-dev-env.ts` :
  * Lancer une fois depuis le PC qui possède le .env.local complet :
  *   bun scripts/seed-vercel-dev-env.ts
  */
+import { parse } from "dotenv"
 import { spawnSync } from "node:child_process"
 import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { parse } from "dotenv"
-
 import { parseRawLines } from "./sync-env"
 
 /** Clés à amorcer = présentes en local (valeur non vide) et absentes de Vercel. */
@@ -441,8 +441,7 @@ const main = (): void => {
   console.log("✓ Amorçage terminé. Vérifie : `vercel env ls development`.")
 }
 
-const isDirectRun =
-  process.argv[1]?.endsWith("seed-vercel-dev-env.ts") ?? false
+const isDirectRun = process.argv[1]?.endsWith("seed-vercel-dev-env.ts") ?? false
 if (isDirectRun) main()
 ```
 
@@ -463,13 +462,14 @@ git commit -m "feat(env): script d'amorçage seed-vercel-dev-env"
 ## Task 4: Documentation README
 
 **Files:**
+
 - Modify: `README.md` (section « 🛠️ Installation » et « 🎨 Available Scripts »)
 
 - [ ] **Step 1: Ajouter la sous-section de sync dans Installation**
 
 Dans `README.md`, juste après le bloc de l'étape 3 (la ligne se terminant par `Optional: Google OAuth, AWS SES, Stripe, AWS S3, Sentry.`), insérer :
 
-```markdown
+````markdown
 > **Team shortcut — sync env from Vercel.** Instead of filling `.env.local` by hand, pull the shared **development** environment from Vercel on any machine:
 >
 > ```bash
@@ -479,11 +479,11 @@ Dans `README.md`, juste après le bloc de l'étape 3 (la ligne se terminant par 
 > ```
 >
 > `bun run env:sync` regenerates `.env.local` (organized into commented sections) from Vercel's `Development` scope only — preview/production are never touched. It is safe to re-run, and **refuses to overwrite** if your local file has keys not yet on Vercel (add those with `vercel env add <KEY> development`, then re-run). Re-pull at the start of a session if the Vercel OIDC token (~12 h) has expired.
-```
+````
 
 - [ ] **Step 2: Ajouter l'entrée dans « Available Scripts »**
 
-Dans le bloc ```` ```bash ```` de la section « 🎨 Available Scripts », après la ligne `bun dev                  # Start dev server with Turbopack`, insérer :
+Dans le bloc ` ```bash ` de la section « 🎨 Available Scripts », après la ligne `bun dev                  # Start dev server with Turbopack`, insérer :
 
 ```
 bun run env:sync         # Pull & regroup .env.local from Vercel (development scope)
@@ -534,6 +534,7 @@ git commit -m "chore(env): format/lint des scripts env"
 ## Task 6: Amorçage réel de Vercel Dev (exécution, côté PC actuel)
 
 **Files:**
+
 - Modify: `.env.local` (gitignored — **ne sera pas commité**)
 
 > Pré-requis : être sur le PC qui possède le `.env.local` complet, `vercel login` + lien actifs (déjà le cas : projet `nomaqbank`, team `rinkhimeras-projects`). Cette tâche **mute le scope Development de Vercel** (écritures `development` uniquement).
@@ -621,7 +622,7 @@ rm .env.local.bak
 
 ## Notes de conception
 
-- **Le garde-fou de Task 2 remplace le « script de vérif jetable » (d) de la spec** : la sécurité anti-écrasement est désormais *intégrée et permanente* dans `env:sync` (refus si des clés locales manquent côté Vercel, override `--force`), plutôt qu'un script à part. Le critère d'acceptation #2 de la spec (« zéro clé effaçable ») se traduit par « `bun run env:sync` réussit sans `--force` » (Task 7, Step 2-3).
+- **Le garde-fou de Task 2 remplace le « script de vérif jetable » (d) de la spec** : la sécurité anti-écrasement est désormais _intégrée et permanente_ dans `env:sync` (refus si des clés locales manquent côté Vercel, override `--force`), plutôt qu'un script à part. Le critère d'acceptation #2 de la spec (« zéro clé effaçable ») se traduit par « `bun run env:sync` réussit sans `--force` » (Task 7, Step 2-3).
 - **Isolement preview/prod** : `seed` ne fait que `vercel env add <KEY> development` ; `sync` ne fait que `vercel env pull --environment=development`. Aucune commande ne cible preview/prod.
 - **Secrets hors argv** : `seed` passe chaque valeur via stdin (`input`), pas via `--value`, pour ne pas exposer les secrets dans la liste des process.
 - **Multiplateforme** : `spawnSync(..., { shell: true })` + chemin temp entre guillemets ; requis sous Windows pour exécuter `vercel.cmd` (Node récent bloque les `.cmd` sans `shell:true`).
@@ -631,6 +632,7 @@ rm .env.local.bak
 ## Self-Review
 
 **1. Spec coverage**
+
 - Source de vérité = Vercel Dev sur-ensemble → Tasks 1-3 + amorçage Task 6. ✅
 - Amorçage des 13 clés (12 + EMAIL_OVERRIDE_TO=dixiades@gmail.com) en `development` seul → Task 6. ✅
 - Wrapper `bun run env:sync` (pull + regroupement hybride fonctionnel/tier, « Non classé ») → Tasks 1-2. ✅

--- a/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
+++ b/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
@@ -21,7 +21,7 @@ variables `Preview` ou `Production`. Au passage : classifier les variables d'env
   dev pour l'instant (YAGNI).
 - **Wrapper** : nom `bun run env:sync` confirmé.
 - **Format du fichier généré** : `.env.local` **regroupé en sections** par
-  `scripts/sync-env.ts` (post-traitement du *pull*). Schéma **hybride** :
+  `scripts/sync-env.ts` (post-traitement du _pull_). Schéma **hybride** :
   sections fonctionnelles (BD, Auth, SES, S3, Tests…) + **tag de tier 🟢/🟡**
   dans chaque en-tête. Clés inconnues → section « Non classé » (rien de perdu).
 - **Script de vérif (d)** : **validation jetable, non commitée** (scratchpad),
@@ -29,27 +29,27 @@ variables `Preview` ou `Production`. Au passage : classifier les variables d'env
 
 ## Contexte (état réel constaté le 2026-06-27)
 
-Projet Vercel lié en mode *repo* : `nomaqbank`
+Projet Vercel lié en mode _repo_ : `nomaqbank`
 (`prj_ZOmANdfKfJ9jm34HT5xVM4uLguyg`, team `rinkhimeras-projects` /
 `team_0TjTQybtkyhHcGIxbju0GM3e`). CLI Vercel v54.11.1. `.vercel/` est gitignored
 (donc absent après un `git clone`).
 
-### Déjà dans Vercel scope `Development` (se *pull* avec leurs valeurs — pas de souci « sensitive »)
+### Déjà dans Vercel scope `Development` (se _pull_ avec leurs valeurs — pas de souci « sensitive »)
 
 `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
 `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `SES_REGION`, `SES_ACCESS_KEY_ID`,
 `SES_SECRET_ACCESS_KEY`, `EMAIL_FROM`, `SES_CONFIGURATION_SET`,
 `SENTRY_AUTH_TOKEN`, `CRON_SECRET` (absent du `.env.local` local),
 `NEXT_PUBLIC_SENTRY_DSN` (absent du `.env.local` local). Plus `VERCEL_OIDC_TOKEN`
-auto-injecté par le *pull* (~12 h).
+auto-injecté par le _pull_ (~12 h).
 
 ### Dans `.env.local` mais PAS dans Vercel Dev — **un `pull` les effacerait** (à amorcer)
 
-| Var | Catégorie |
-| --- | --- |
-| `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME` | Médias S3 dev (clés statiques dev) |
-| `NEON_API_KEY`, `NEON_PROJECT_ID` | Tests d'intégration (`scripts/neon-api.ts`) |
-| `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_RESET_SECRET` | Tests E2E Playwright |
+| Var                                                                                                | Catégorie                                   |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME` | Médias S3 dev (clés statiques dev)          |
+| `NEON_API_KEY`, `NEON_PROJECT_ID`                                                                  | Tests d'intégration (`scripts/neon-api.ts`) |
+| `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_RESET_SECRET` | Tests E2E Playwright                        |
 
 → **13 clés à amorcer** (ces 12 + `EMAIL_OVERRIDE_TO`).
 
@@ -75,7 +75,7 @@ auto-injecté par le *pull* (~12 h).
 
 `BUNNY_STORAGE_ZONE_NAME`, `BUNNY_STORAGE_API_KEY`, `BUNNY_CDN_HOSTNAME`
 (commentées) — migration Bunny → S3/CloudFront **terminée**, code mort. Elles
-disparaissent naturellement (le *pull* régénère le fichier sans elles).
+disparaissent naturellement (le _pull_ régénère le fichier sans elles).
 
 ### ⚪ Absentes de `.env.local`, décision prise
 
@@ -106,7 +106,7 @@ par construction.
 ### (a) Script d'amorçage unique — `scripts/seed-vercel-dev-env.ts`
 
 - Bun/tsx, **multiplateforme** (évite le couple `.ps1` + `.sh` et l'enfer du
-  *quoting* PowerShell/bash).
+  _quoting_ PowerShell/bash).
 - Lit les valeurs depuis le `.env.local` **actuel** ; pour chacune des 13 clés
   manquantes, exécute `vercel env add <KEY> development` en **non-sensitive**.
 - **Valeur passée par stdin**, jamais en argument positionnel (gère `+ / & =` des
@@ -128,7 +128,7 @@ Lancé via le script `package.json` :
 
 `vercel env pull` écrit un fichier **plat** (pas de commentaires ni de
 regroupement). Pour obtenir un `.env.local` rangé sur chaque PC, le script
-post-traite le *pull* :
+post-traite le _pull_ :
 
 1. `vercel env pull` vers un fichier **temporaire** (scope `development`).
 2. Parse chaque ligne en `(clé, ligne brute)` — la **ligne brute est réutilisée
@@ -140,23 +140,23 @@ post-traite le *pull* :
    (rien n'est perdu silencieusement ; `log` du nombre de clés non classées).
 5. Écrit `.env.local`.
 
-*La* commande à retenir, identique sur chaque PC.
+_La_ commande à retenir, identique sur chaque PC.
 
 #### Carte de groupes (hybride fonctionnel + tier)
 
-| Section (en-tête) | Tier | Clés |
-| --- | --- | --- |
-| Base de données — Neon | 🟢 REQUIS | `DATABASE_URL`, `DATABASE_URL_UNPOOLED` |
-| Better Auth | 🟢 REQUIS | `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` |
-| OAuth Google | 🟢 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
-| AWS SES — emails | 🟢 | `SES_REGION`, `SES_ACCESS_KEY_ID`, `SES_SECRET_ACCESS_KEY`, `EMAIL_FROM`, `SES_CONFIGURATION_SET`, `EMAIL_OVERRIDE_TO` |
-| AWS S3 + CloudFront — médias | 🟢 | `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME` |
-| Cron Vercel | 🟢 | `CRON_SECRET` |
-| Sentry — monitoring | 🟡 build + 🟢 runtime | `SENTRY_AUTH_TOKEN` (build), `NEXT_PUBLIC_SENTRY_DSN` (runtime) |
-| Tests d'intégration — Neon API | 🟡 outillage | `NEON_API_KEY`, `NEON_PROJECT_ID` |
-| Tests E2E — Playwright | 🟡 tests | `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_RESET_SECRET` |
-| Vercel (auto-injecté) | — | `VERCEL_OIDC_TOKEN` |
-| Non classé | — | (toute clé inconnue, en fin de fichier) |
+| Section (en-tête)              | Tier                  | Clés                                                                                                                   |
+| ------------------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Base de données — Neon         | 🟢 REQUIS             | `DATABASE_URL`, `DATABASE_URL_UNPOOLED`                                                                                |
+| Better Auth                    | 🟢 REQUIS             | `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`                                                                                |
+| OAuth Google                   | 🟢                    | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`                                                                             |
+| AWS SES — emails               | 🟢                    | `SES_REGION`, `SES_ACCESS_KEY_ID`, `SES_SECRET_ACCESS_KEY`, `EMAIL_FROM`, `SES_CONFIGURATION_SET`, `EMAIL_OVERRIDE_TO` |
+| AWS S3 + CloudFront — médias   | 🟢                    | `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME`                     |
+| Cron Vercel                    | 🟢                    | `CRON_SECRET`                                                                                                          |
+| Sentry — monitoring            | 🟡 build + 🟢 runtime | `SENTRY_AUTH_TOKEN` (build), `NEXT_PUBLIC_SENTRY_DSN` (runtime)                                                        |
+| Tests d'intégration — Neon API | 🟡 outillage          | `NEON_API_KEY`, `NEON_PROJECT_ID`                                                                                      |
+| Tests E2E — Playwright         | 🟡 tests              | `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_RESET_SECRET`                     |
+| Vercel (auto-injecté)          | —                     | `VERCEL_OIDC_TOKEN`                                                                                                    |
+| Non classé                     | —                     | (toute clé inconnue, en fin de fichier)                                                                                |
 
 La carte est le **point unique de catégorisation** ; la garder alignée sur
 `.env.example` quand une section est ajoutée.
@@ -174,13 +174,13 @@ bun run env:sync
 
 ### (d) Validation jetable — script de vérif (non commité, scratchpad)
 
-*Pull* dans un fichier temporaire, diffe les **clés** (pas les valeurs) contre
+_Pull_ dans un fichier temporaire, diffe les **clés** (pas les valeurs) contre
 `.env.local`, échoue s'il existe une clé « qui serait effacée » (présente en
 local, absente de Vercel Dev). **Non commité** : créé dans le scratchpad, joué
 ponctuellement, puis supprimé. Sert à confirmer l'amorçage (zéro clé effaçable).
 
 > **Validé le 2026-06-27** (avant amorçage) : 24 clés locales / 15 clés Vercel
-> Dev → le script détecte correctement les 3 clés ajoutées par le *pull*
+> Dev → le script détecte correctement les 3 clés ajoutées par le _pull_
 > (`CRON_SECRET`, `NEXT_PUBLIC_SENTRY_DSN`, `VERCEL_OIDC_TOKEN`) et les **12**
 > clés à amorcer. Logique de diff confirmée fonctionnelle.
 
@@ -188,9 +188,9 @@ ponctuellement, puis supprimé. Sert à confirmer l'amorçage (zéro clé effaç
 
 - **`vercel env pull` remplace tout le fichier** → désormais **sûr** car Vercel
   est le sur-ensemble. **Discipline** : toute nouvelle var dev doit être créée
-  AUSSI sur Vercel (`vercel env add … development`), sinon le prochain *pull*
+  AUSSI sur Vercel (`vercel env add … development`), sinon le prochain _pull_
   l'efface. Le script (d) sert de filet.
-- **Sensitivity** : ajouter en **non-sensitive** pour que les *pull* renvoient
+- **Sensitivity** : ajouter en **non-sensitive** pour que les _pull_ renvoient
   les valeurs — cohérent avec les 14 vars déjà en place. Confirmer le flag exact
   via `vercel env add --help` au moment de coder (la valeur par défaut et le nom
   du flag — `--sensitive` opt-in vs `--no-sensitive` — varient selon la version
@@ -218,7 +218,7 @@ ponctuellement, puis supprimé. Sert à confirmer l'amorçage (zéro clé effaç
 
 Tous les secrets dev (dont `NEON_API_KEY`, clés AWS) vivent dans Vercel Dev —
 lisibles par qui a accès `Development` au projet. `.env.local` reste gitignored.
-*Optionnel (suite)* : rotation des secrets qui ont traîné en clair sur plusieurs
+_Optionnel (suite)_ : rotation des secrets qui ont traîné en clair sur plusieurs
 copies de `.env.local`.
 
 ## Hors scope (YAGNI)

--- a/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
+++ b/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
@@ -1,0 +1,178 @@
+# Sync des variables d'environnement de dev depuis Vercel
+
+**Date** : 2026-06-27
+**Statut** : Design validé (prêt pour plan d'implémentation)
+
+## Objectif
+
+Pouvoir reconstruire `.env.local` à l'identique sur **n'importe quel PC** via une
+seule commande, en tirant les valeurs **depuis Vercel**, sans jamais toucher les
+variables `Preview` ou `Production`. Au passage : classifier les variables d'env
+(utilisées / utiles / inutiles) et nettoyer les mortes.
+
+## Décisions prises
+
+- **Portée** : « tout, une seule commande ». Le scope `Development` de Vercel
+  devient la **source de vérité unique** et un **sur-ensemble** de `.env.local`.
+- **`NEON_API_KEY`** (accès API au compte Neon entier) : **stockée dans Vercel
+  Dev** comme les autres (vrai « tout »). Risque accepté.
+- **Extras** : on ajoute `EMAIL_OVERRIDE_TO` à l'amorçage (redirige tous les
+  emails dev vers une adresse de test vérifiée). **Pas** de Stripe dev pour
+  l'instant (YAGNI).
+
+## Contexte (état réel constaté le 2026-06-27)
+
+Projet Vercel lié en mode *repo* : `nomaqbank`
+(`prj_ZOmANdfKfJ9jm34HT5xVM4uLguyg`, team `rinkhimeras-projects` /
+`team_0TjTQybtkyhHcGIxbju0GM3e`). CLI Vercel v54.11.1. `.vercel/` est gitignored
+(donc absent après un `git clone`).
+
+### Déjà dans Vercel scope `Development` (se *pull* avec leurs valeurs — pas de souci « sensitive »)
+
+`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
+`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `SES_REGION`, `SES_ACCESS_KEY_ID`,
+`SES_SECRET_ACCESS_KEY`, `EMAIL_FROM`, `SES_CONFIGURATION_SET`,
+`SENTRY_AUTH_TOKEN`, `CRON_SECRET` (absent du `.env.local` local),
+`NEXT_PUBLIC_SENTRY_DSN` (absent du `.env.local` local). Plus `VERCEL_OIDC_TOKEN`
+auto-injecté par le *pull* (~12 h).
+
+### Dans `.env.local` mais PAS dans Vercel Dev — **un `pull` les effacerait** (à amorcer)
+
+| Var | Catégorie |
+| --- | --- |
+| `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME` | Médias S3 dev (clés statiques dev) |
+| `NEON_API_KEY`, `NEON_PROJECT_ID` | Tests d'intégration (`scripts/neon-api.ts`) |
+| `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_RESET_SECRET` | Tests E2E Playwright |
+
+→ **13 clés à amorcer** (ces 12 + `EMAIL_OVERRIDE_TO`).
+
+## Classification des variables (livrable demandé)
+
+### 🟢 Runtime de l'app — à utiliser (cœur du « dev », consommé par `bun dev`)
+
+`DATABASE_URL` / `DATABASE_URL_UNPOOLED` (requis), `BETTER_AUTH_SECRET` (requis),
+`BETTER_AUTH_URL` (override dev = `http://localhost:3000`), `GOOGLE_CLIENT_ID` /
+`GOOGLE_CLIENT_SECRET`, `SES_*` + `EMAIL_FROM` + `SES_CONFIGURATION_SET`,
+`S3_REGION` / `S3_BUCKET` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`,
+`NEXT_PUBLIC_CDN_HOSTNAME`, `E2E_RESET_SECRET` (protège `/api/e2e`),
+`NEXT_PUBLIC_SENTRY_DSN`, `CRON_SECRET`.
+
+### 🟡 Outillage / build / tests — utiles, mais PAS du runtime app
+
+- `SENTRY_AUTH_TOKEN` — upload des source maps **au build** (pas pour `bun dev`).
+- `NEON_API_KEY` / `NEON_PROJECT_ID` — tests d'intégration (sensibilité **élevée**).
+- `E2E_ADMIN_*` / `E2E_USER_*` — tests Playwright (faux comptes `@nomaqtest.local`,
+  sensibilité faible).
+
+### 🔴 Inutiles — à supprimer
+
+`BUNNY_STORAGE_ZONE_NAME`, `BUNNY_STORAGE_API_KEY`, `BUNNY_CDN_HOSTNAME`
+(commentées) — migration Bunny → S3/CloudFront **terminée**, code mort. Elles
+disparaissent naturellement (le *pull* régénère le fichier sans elles).
+
+### ⚪ Absentes de `.env.local`, décision prise
+
+- `EMAIL_OVERRIDE_TO` — **on l'ajoute** (valeur = adresse de test vérifiée SES, fournie par l'utilisateur).
+- `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` — **non** (paiements dev hors scope).
+- `MAINTENANCE_MODE` / `MAINTENANCE_BYPASS_TOKEN`, `NEXT_PUBLIC_BASE_URL`,
+  `AWS_ROLE_ARN`, `INTEGRATION_*`, `PLAYWRIGHT_BASE_URL` — non requis en dev local
+  (générés au runtime / propres à prod-preview / valeurs par défaut OK).
+
+## Architecture
+
+Le scope `Development` de Vercel = source unique et sur-ensemble de `.env.local`.
+Toute lecture/écriture reste **scopée `development`**, donc preview/prod intacts
+par construction.
+
+```
+[PC actuel, .env.local complet]
+   │ amorçage unique : vercel env add <KEY> development  (non-sensitive)
+   ▼
+[Vercel scope "Development"]  ← source de vérité (sur-ensemble de .env.local)
+   │ vercel env pull .env.local --environment=development --yes
+   ▼
+[n'importe quel PC : .env.local reconstruit]
+```
+
+## Composants (4 livrables, chacun à responsabilité unique)
+
+### (a) Script d'amorçage unique — `scripts/seed-vercel-dev-env.ts`
+
+- Bun/tsx, **multiplateforme** (évite le couple `.ps1` + `.sh` et l'enfer du
+  *quoting* PowerShell/bash).
+- Lit les valeurs depuis le `.env.local` **actuel** ; pour chacune des 13 clés
+  manquantes, exécute `vercel env add <KEY> development` en **non-sensitive**.
+- **Valeur passée par stdin**, jamais en argument positionnel (gère `+ / & =` des
+  secrets AWS / `DATABASE_URL` et suit l'avertissement CLI « do NOT pass
+  NAME=value as positional »).
+- **Idempotent** : lit `vercel env ls development` d'abord et saute les clés déjà
+  présentes.
+- Lancé **une seule fois**, depuis le PC qui possède le `.env.local` complet.
+- `EMAIL_OVERRIDE_TO` : si absente de `.env.local`, le script demande/exige une
+  valeur (adresse vérifiée SES) avant de l'ajouter.
+
+### (b) Wrapper de synchro — script `package.json`
+
+```json
+"env:sync": "vercel env pull .env.local --environment=development --yes"
+```
+
+*La* commande à retenir, identique sur chaque PC.
+
+### (c) Doc bootstrap (section README)
+
+Sur un PC neuf, après `git clone` (`.vercel/` absent car gitignored) :
+
+```bash
+bun install
+vercel login
+vercel link            # team rinkhimeras-projects → projet nomaqbank
+bun run env:sync
+```
+
+### (d) Script de vérif — `scripts/check-env-sync.ts`
+
+*Pull* dans un fichier temporaire, diffe les **clés** (pas les valeurs) contre
+`.env.local`, échoue s'il existe une clé « qui serait effacée » (présente en
+local, absente de Vercel Dev). Fige en garde-fou le diagnostic manuel utilisé
+pendant le design.
+
+## Garde-fous & edge cases
+
+- **`vercel env pull` remplace tout le fichier** → désormais **sûr** car Vercel
+  est le sur-ensemble. **Discipline** : toute nouvelle var dev doit être créée
+  AUSSI sur Vercel (`vercel env add … development`), sinon le prochain *pull*
+  l'efface. Le script (d) sert de filet.
+- **Sensitivity** : ajouter en **non-sensitive** pour que les *pull* renvoient
+  les valeurs — cohérent avec les 14 vars déjà en place. Confirmer le flag exact
+  via `vercel env add --help` au moment de coder (la valeur par défaut et le nom
+  du flag — `--sensitive` opt-in vs `--no-sensitive` — varient selon la version
+  CLI ; vérifier sur v54.x).
+- **Token OIDC** (`VERCEL_OIDC_TOKEN`, ~12 h) : re-`bun run env:sync` en début de
+  session si une auth OIDC échoue. Non bloquant en dev (clés AWS statiques).
+- **`EMAIL_OVERRIDE_TO`** : exige une adresse vérifiée dans SES (fournie par
+  l'utilisateur).
+- **Caractères spéciaux** dans les valeurs (AWS secrets `+`/`/`, `DATABASE_URL`
+  `&`/`=`) : gérés par le passage stdin du script (a).
+
+## Tests / acceptation
+
+1. Après amorçage : `vercel env ls development` liste l'ensemble des clés
+   attendues (~28).
+2. `scripts/check-env-sync.ts` → **zéro** clé « effaçable ».
+3. Critère final : sauvegarder puis supprimer `.env.local`, lancer
+   `bun run env:sync`, et `bun dev` + `bun run check` passent.
+
+## Sécurité (acceptée)
+
+Tous les secrets dev (dont `NEON_API_KEY`, clés AWS) vivent dans Vercel Dev —
+lisibles par qui a accès `Development` au projet. `.env.local` reste gitignored.
+*Optionnel (suite)* : rotation des secrets qui ont traîné en clair sur plusieurs
+copies de `.env.local`.
+
+## Hors scope (YAGNI)
+
+- Stripe dev (`STRIPE_*`).
+- Script de fusion préservant des vars locales hors-Vercel (approche ② —
+  pertinent seulement si on décidait de garder `NEON_API_KEY` hors de Vercel).
+- dotenvx / SOPS (dotenv chiffré commité) — l'utilisateur veut « depuis Vercel ».

--- a/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
+++ b/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
@@ -16,9 +16,12 @@ variables `Preview` ou `Production`. Au passage : classifier les variables d'env
   devient la **source de vérité unique** et un **sur-ensemble** de `.env.local`.
 - **`NEON_API_KEY`** (accès API au compte Neon entier) : **stockée dans Vercel
   Dev** comme les autres (vrai « tout »). Risque accepté.
-- **Extras** : on ajoute `EMAIL_OVERRIDE_TO` à l'amorçage (redirige tous les
-  emails dev vers une adresse de test vérifiée). **Pas** de Stripe dev pour
-  l'instant (YAGNI).
+- **Extras** : on ajoute `EMAIL_OVERRIDE_TO=dixiades@gmail.com` à l'amorçage
+  (redirige tous les emails dev vers cette adresse de test). **Pas** de Stripe
+  dev pour l'instant (YAGNI).
+- **Wrapper** : nom `bun run env:sync` confirmé.
+- **Script de vérif (d)** : **validation jetable, non commitée** (scratchpad),
+  jouée une fois pour confirmer le résultat — pas un livrable du repo.
 
 ## Contexte (état réel constaté le 2026-06-27)
 
@@ -72,7 +75,7 @@ disparaissent naturellement (le *pull* régénère le fichier sans elles).
 
 ### ⚪ Absentes de `.env.local`, décision prise
 
-- `EMAIL_OVERRIDE_TO` — **on l'ajoute** (valeur = adresse de test vérifiée SES, fournie par l'utilisateur).
+- `EMAIL_OVERRIDE_TO` — **on l'ajoute**, valeur `dixiades@gmail.com` (adresse de test ; doit être vérifiée dans SES).
 - `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` — **non** (paiements dev hors scope).
 - `MAINTENANCE_MODE` / `MAINTENANCE_BYPASS_TOKEN`, `NEXT_PUBLIC_BASE_URL`,
   `AWS_ROLE_ARN`, `INTEGRATION_*`, `PLAYWRIGHT_BASE_URL` — non requis en dev local
@@ -94,7 +97,7 @@ par construction.
 [n'importe quel PC : .env.local reconstruit]
 ```
 
-## Composants (4 livrables, chacun à responsabilité unique)
+## Composants (3 livrables commités + 1 validation jetable)
 
 ### (a) Script d'amorçage unique — `scripts/seed-vercel-dev-env.ts`
 
@@ -130,12 +133,17 @@ vercel link            # team rinkhimeras-projects → projet nomaqbank
 bun run env:sync
 ```
 
-### (d) Script de vérif — `scripts/check-env-sync.ts`
+### (d) Validation jetable — script de vérif (non commité, scratchpad)
 
 *Pull* dans un fichier temporaire, diffe les **clés** (pas les valeurs) contre
 `.env.local`, échoue s'il existe une clé « qui serait effacée » (présente en
-local, absente de Vercel Dev). Fige en garde-fou le diagnostic manuel utilisé
-pendant le design.
+local, absente de Vercel Dev). **Non commité** : créé dans le scratchpad, joué
+ponctuellement, puis supprimé. Sert à confirmer l'amorçage (zéro clé effaçable).
+
+> **Validé le 2026-06-27** (avant amorçage) : 24 clés locales / 15 clés Vercel
+> Dev → le script détecte correctement les 3 clés ajoutées par le *pull*
+> (`CRON_SECRET`, `NEXT_PUBLIC_SENTRY_DSN`, `VERCEL_OIDC_TOKEN`) et les **12**
+> clés à amorcer. Logique de diff confirmée fonctionnelle.
 
 ## Garde-fous & edge cases
 
@@ -159,7 +167,7 @@ pendant le design.
 
 1. Après amorçage : `vercel env ls development` liste l'ensemble des clés
    attendues (~28).
-2. `scripts/check-env-sync.ts` → **zéro** clé « effaçable ».
+2. La validation jetable (d) → **zéro** clé « effaçable ».
 3. Critère final : sauvegarder puis supprimer `.env.local`, lancer
    `bun run env:sync`, et `bun dev` + `bun run check` passent.
 

--- a/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
+++ b/docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md
@@ -20,6 +20,10 @@ variables `Preview` ou `Production`. Au passage : classifier les variables d'env
   (redirige tous les emails dev vers cette adresse de test). **Pas** de Stripe
   dev pour l'instant (YAGNI).
 - **Wrapper** : nom `bun run env:sync` confirmé.
+- **Format du fichier généré** : `.env.local` **regroupé en sections** par
+  `scripts/sync-env.ts` (post-traitement du *pull*). Schéma **hybride** :
+  sections fonctionnelles (BD, Auth, SES, S3, Tests…) + **tag de tier 🟢/🟡**
+  dans chaque en-tête. Clés inconnues → section « Non classé » (rien de perdu).
 - **Script de vérif (d)** : **validation jetable, non commitée** (scratchpad),
   jouée une fois pour confirmer le résultat — pas un livrable du repo.
 
@@ -114,13 +118,48 @@ par construction.
 - `EMAIL_OVERRIDE_TO` : si absente de `.env.local`, le script demande/exige une
   valeur (adresse vérifiée SES) avant de l'ajouter.
 
-### (b) Wrapper de synchro — script `package.json`
+### (b) Wrapper de synchro **avec regroupement** — `scripts/sync-env.ts`
+
+Lancé via le script `package.json` :
 
 ```json
-"env:sync": "vercel env pull .env.local --environment=development --yes"
+"env:sync": "bun run scripts/sync-env.ts"
 ```
 
+`vercel env pull` écrit un fichier **plat** (pas de commentaires ni de
+regroupement). Pour obtenir un `.env.local` rangé sur chaque PC, le script
+post-traite le *pull* :
+
+1. `vercel env pull` vers un fichier **temporaire** (scope `development`).
+2. Parse chaque ligne en `(clé, ligne brute)` — la **ligne brute est réutilisée
+   telle quelle** (jamais de re-quoting → préserve `+ / & =` des secrets).
+3. Réordonne selon la **carte de groupes** (ci-dessous) et insère des en-têtes
+   `# === … (tier) ===` — schéma **hybride** : sections fonctionnelles + tag de
+   classification 🟢/🟡 dans l'en-tête.
+4. Toute clé absente de la carte → section **« Non classé »** en fin de fichier
+   (rien n'est perdu silencieusement ; `log` du nombre de clés non classées).
+5. Écrit `.env.local`.
+
 *La* commande à retenir, identique sur chaque PC.
+
+#### Carte de groupes (hybride fonctionnel + tier)
+
+| Section (en-tête) | Tier | Clés |
+| --- | --- | --- |
+| Base de données — Neon | 🟢 REQUIS | `DATABASE_URL`, `DATABASE_URL_UNPOOLED` |
+| Better Auth | 🟢 REQUIS | `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` |
+| OAuth Google | 🟢 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
+| AWS SES — emails | 🟢 | `SES_REGION`, `SES_ACCESS_KEY_ID`, `SES_SECRET_ACCESS_KEY`, `EMAIL_FROM`, `SES_CONFIGURATION_SET`, `EMAIL_OVERRIDE_TO` |
+| AWS S3 + CloudFront — médias | 🟢 | `S3_REGION`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_CDN_HOSTNAME` |
+| Cron Vercel | 🟢 | `CRON_SECRET` |
+| Sentry — monitoring | 🟡 build + 🟢 runtime | `SENTRY_AUTH_TOKEN` (build), `NEXT_PUBLIC_SENTRY_DSN` (runtime) |
+| Tests d'intégration — Neon API | 🟡 outillage | `NEON_API_KEY`, `NEON_PROJECT_ID` |
+| Tests E2E — Playwright | 🟡 tests | `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_RESET_SECRET` |
+| Vercel (auto-injecté) | — | `VERCEL_OIDC_TOKEN` |
+| Non classé | — | (toute clé inconnue, en fin de fichier) |
+
+La carte est le **point unique de catégorisation** ; la garder alignée sur
+`.env.example` quand une section est ajoutée.
 
 ### (c) Doc bootstrap (section README)
 
@@ -170,6 +209,10 @@ ponctuellement, puis supprimé. Sert à confirmer l'amorçage (zéro clé effaç
 2. La validation jetable (d) → **zéro** clé « effaçable ».
 3. Critère final : sauvegarder puis supprimer `.env.local`, lancer
    `bun run env:sync`, et `bun dev` + `bun run check` passent.
+4. Le `.env.local` généré est **regroupé en sections** avec en-têtes + tags de
+   tier ; section « Non classé » **vide** (sinon = une clé à ajouter à la carte).
+   Diff des **valeurs** (pas seulement des clés) avant/après `env:sync` =
+   identique (le regroupement ne modifie aucune valeur).
 
 ## Sécurité (acceptée)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:integration": "bun scripts/test-integration.ts",
     "test:integration:keep": "bun scripts/test-integration.ts --keep",
     "generate-favicons": "bun scripts/generate-favicons.mjs",
+    "env:sync": "bun scripts/sync-env.ts",
     "test:e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",

--- a/scripts/seed-vercel-dev-env.ts
+++ b/scripts/seed-vercel-dev-env.ts
@@ -1,0 +1,76 @@
+/**
+ * Amorçage UNIQUE : pousse dans le scope « Development » de Vercel toutes les
+ * clés présentes dans .env.local mais encore absentes côté Vercel, pour que
+ * `bun run env:sync` reproduise ensuite le fichier complet sur n'importe quel
+ * PC. N'écrit QUE dans `development` (preview/prod jamais touchés). Idempotent.
+ * Valeurs lues dans .env.local, passées par stdin (jamais en argv).
+ *
+ * Lancer une fois depuis le PC qui possède le .env.local complet :
+ *   bun scripts/seed-vercel-dev-env.ts
+ */
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { parse } from "dotenv"
+
+import { parseRawLines } from "./sync-env"
+
+/** Clés à amorcer = présentes en local (valeur non vide) et absentes de Vercel. */
+export const keysToSeed = (
+  localValues: Record<string, string>,
+  existingKeys: Set<string>,
+): string[] =>
+  Object.entries(localValues)
+    .filter(([k, v]) => v.trim() !== "" && !existingKeys.has(k))
+    .map(([k]) => k)
+    .sort()
+
+const pullExistingKeys = (): Set<string> => {
+  const tmp = join(mkdtempSync(join(tmpdir(), "env-seed-")), "pulled.env")
+  const res = spawnSync(
+    `vercel env pull "${tmp}" --environment=development --yes`,
+    { shell: true, stdio: ["ignore", "inherit", "inherit"] },
+  )
+  if (res.status !== 0)
+    throw new Error("`vercel env pull` a échoué (login/link OK ?).")
+  const keys = new Set(parseRawLines(readFileSync(tmp, "utf8")).keys())
+  rmSync(tmp, { recursive: true, force: true })
+  return keys
+}
+
+const addVar = (key: string, value: string): void => {
+  const res = spawnSync(`vercel env add ${key} development --yes`, {
+    shell: true,
+    input: value,
+    stdio: ["pipe", "inherit", "inherit"],
+  })
+  if (res.status !== 0)
+    throw new Error(`vercel env add ${key} → exit ${res.status}`)
+}
+
+const main = (): void => {
+  const localValues = parse(readFileSync(".env.local", "utf8"))
+  const existing = pullExistingKeys()
+  const toAdd = keysToSeed(localValues, existing)
+
+  if (toAdd.length === 0) {
+    console.log(
+      "✓ Rien à amorcer : Vercel Dev contient déjà toutes les clés locales.",
+    )
+    return
+  }
+
+  console.log(
+    `→ Amorçage de ${toAdd.length} clé(s) dans Vercel Dev : ${toAdd.join(", ")}`,
+  )
+  for (const key of toAdd) {
+    addVar(key, localValues[key])
+    console.log(`  ✓ ${key}`)
+  }
+  console.log("✓ Amorçage terminé. Vérifie : `vercel env ls development`.")
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith("seed-vercel-dev-env.ts") ?? false
+if (isDirectRun) main()

--- a/scripts/seed-vercel-dev-env.ts
+++ b/scripts/seed-vercel-dev-env.ts
@@ -8,12 +8,11 @@
  * Lancer une fois depuis le PC qui possède le .env.local complet :
  *   bun scripts/seed-vercel-dev-env.ts
  */
+import { parse } from "dotenv"
 import { spawnSync } from "node:child_process"
 import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { parse } from "dotenv"
-
 import { parseRawLines } from "./sync-env"
 
 /** Clés à amorcer = présentes en local (valeur non vide) et absentes de Vercel. */
@@ -71,6 +70,5 @@ const main = (): void => {
   console.log("✓ Amorçage terminé. Vérifie : `vercel env ls development`.")
 }
 
-const isDirectRun =
-  process.argv[1]?.endsWith("seed-vercel-dev-env.ts") ?? false
+const isDirectRun = process.argv[1]?.endsWith("seed-vercel-dev-env.ts") ?? false
 if (isDirectRun) main()

--- a/scripts/sync-env.ts
+++ b/scripts/sync-env.ts
@@ -1,0 +1,189 @@
+/**
+ * Reconstruit .env.local depuis le scope « Development » de Vercel, regroupé en
+ * sections (fonctionnel + tag de tier). `vercel env pull` produit un fichier
+ * plat ; ce script le post-traite. Lancé via `bun run env:sync`.
+ *
+ * Garde-fou : si .env.local contient des clés ABSENTES du pull, on REFUSE
+ * d'écraser (perte de données) — amorcer ces clés dans Vercel d'abord
+ * (scripts/seed-vercel-dev-env.ts), ou forcer avec --force.
+ */
+import { spawnSync } from "node:child_process"
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+type Group = { title: string; tier: string; keys: readonly string[] }
+
+// Carte de groupes = point unique de catégorisation (alignée sur .env.example).
+const GROUP_MAP: readonly Group[] = [
+  {
+    title: "Base de données — Neon",
+    tier: "🟢 runtime, REQUIS",
+    keys: ["DATABASE_URL", "DATABASE_URL_UNPOOLED"],
+  },
+  {
+    title: "Better Auth",
+    tier: "🟢 runtime, REQUIS",
+    keys: ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL"],
+  },
+  {
+    title: "OAuth Google",
+    tier: "🟢 runtime",
+    keys: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+  },
+  {
+    title: "AWS SES — emails",
+    tier: "🟢 runtime",
+    keys: [
+      "SES_REGION",
+      "SES_ACCESS_KEY_ID",
+      "SES_SECRET_ACCESS_KEY",
+      "EMAIL_FROM",
+      "SES_CONFIGURATION_SET",
+      "EMAIL_OVERRIDE_TO",
+    ],
+  },
+  {
+    title: "AWS S3 + CloudFront — médias",
+    tier: "🟢 runtime",
+    keys: [
+      "S3_REGION",
+      "S3_BUCKET",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "NEXT_PUBLIC_CDN_HOSTNAME",
+    ],
+  },
+  { title: "Cron Vercel", tier: "🟢 runtime", keys: ["CRON_SECRET"] },
+  {
+    title: "Sentry — monitoring",
+    tier: "🟡 build + 🟢 runtime",
+    keys: ["SENTRY_AUTH_TOKEN", "NEXT_PUBLIC_SENTRY_DSN"],
+  },
+  {
+    title: "Tests d'intégration — Neon API",
+    tier: "🟡 outillage",
+    keys: ["NEON_API_KEY", "NEON_PROJECT_ID"],
+  },
+  {
+    title: "Tests E2E — Playwright",
+    tier: "🟡 tests",
+    keys: [
+      "E2E_ADMIN_EMAIL",
+      "E2E_ADMIN_PASSWORD",
+      "E2E_USER_EMAIL",
+      "E2E_USER_PASSWORD",
+      "E2E_RESET_SECRET",
+    ],
+  },
+  {
+    title: "Vercel (auto-injecté)",
+    tier: "—",
+    keys: ["VERCEL_OIDC_TOKEN"],
+  },
+]
+
+const HEADER =
+  "# ⚠️  Généré par `bun run env:sync` — source de vérité : Vercel scope Development.\n" +
+  "# Ne pas éditer à la main : toute nouvelle var doit être ajoutée sur Vercel\n" +
+  "# (`vercel env add <KEY> development`), sinon le prochain sync l'efface.\n"
+
+/** Map clé -> ligne brute (préservée telle quelle, jamais re-quotée). */
+export const parseRawLines = (content: string): Map<string, string> => {
+  const map = new Map<string, string>()
+  for (const line of content.split(/\r?\n/)) {
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=/.exec(line)
+    if (m) map.set(m[1], line)
+  }
+  return map
+}
+
+/** Clés de `a` absentes de `b`, triées. */
+export const keysOnlyIn = (a: Iterable<string>, b: Set<string>): string[] =>
+  [...a].filter((k) => !b.has(k)).sort()
+
+/** Regroupe le contenu plat d'un pull en sections (fonctionnel + tier). */
+export const groupEnv = (content: string): string => {
+  const lines = parseRawLines(content)
+  const used = new Set<string>()
+  const blocks: string[] = []
+
+  for (const group of GROUP_MAP) {
+    const body: string[] = []
+    for (const k of group.keys) {
+      const raw = lines.get(k)
+      if (raw === undefined) continue
+      body.push(raw)
+      used.add(k)
+    }
+    if (body.length > 0)
+      blocks.push(
+        `# === ${group.title}  (${group.tier}) ===\n${body.join("\n")}`,
+      )
+  }
+
+  const leftovers = [...lines.keys()].filter((k) => !used.has(k)).sort()
+  if (leftovers.length > 0)
+    blocks.push(
+      `# === Non classé  (à ajouter à la carte de groupes) ===\n${leftovers
+        .map((k) => lines.get(k) ?? "")
+        .join("\n")}`,
+    )
+
+  return `${HEADER}\n${blocks.join("\n\n")}\n`
+}
+
+const main = (): void => {
+  const force = process.argv.includes("--force")
+  const tmp = join(mkdtempSync(join(tmpdir(), "env-sync-")), "pulled.env")
+
+  console.log("→ vercel env pull (development)…")
+  const pull = spawnSync(
+    `vercel env pull "${tmp}" --environment=development --yes`,
+    { shell: true, stdio: ["ignore", "inherit", "inherit"] },
+  )
+  if (pull.status !== 0) {
+    console.error(
+      "✗ `vercel env pull` a échoué. Connecté (`vercel login`) et lié (`vercel link`) ?",
+    )
+    process.exit(1)
+  }
+
+  const pulledContent = readFileSync(tmp, "utf8")
+  rmSync(tmp, { recursive: true, force: true })
+  const pulledKeys = new Set(parseRawLines(pulledContent).keys())
+
+  if (existsSync(".env.local")) {
+    const localKeys = parseRawLines(readFileSync(".env.local", "utf8")).keys()
+    const wouldWipe = keysOnlyIn(localKeys, pulledKeys)
+    if (wouldWipe.length > 0 && !force) {
+      console.error(
+        `✗ Refus d'écraser .env.local : ${wouldWipe.length} clé(s) locale(s) absente(s) de Vercel Dev seraient perdues :\n  ${wouldWipe.join(
+          "\n  ",
+        )}\n→ Amorce-les (\`bun scripts/seed-vercel-dev-env.ts\`) puis relance, ou force avec --force.`,
+      )
+      process.exit(1)
+    }
+  }
+
+  writeFileSync(".env.local", groupEnv(pulledContent))
+
+  const unclassified = keysOnlyIn(
+    pulledKeys,
+    new Set(GROUP_MAP.flatMap((g) => g.keys)),
+  )
+  console.log(`✓ .env.local régénéré : ${pulledKeys.size} variables.`)
+  if (unclassified.length > 0)
+    console.log(
+      `ℹ ${unclassified.length} en « Non classé » : ${unclassified.join(", ")}`,
+    )
+}
+
+const isDirectRun = process.argv[1]?.endsWith("sync-env.ts") ?? false
+if (isDirectRun) main()

--- a/tests/scripts/seed-vercel-dev-env.test.ts
+++ b/tests/scripts/seed-vercel-dev-env.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest"
-
 import { keysToSeed } from "@/scripts/seed-vercel-dev-env"
 
 describe("keysToSeed", () => {

--- a/tests/scripts/seed-vercel-dev-env.test.ts
+++ b/tests/scripts/seed-vercel-dev-env.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { keysToSeed } from "@/scripts/seed-vercel-dev-env"
+
+describe("keysToSeed", () => {
+  it("retourne les clés locales absentes de Vercel, triées", () => {
+    expect(keysToSeed({ B: "2", A: "1", C: "3" }, new Set(["A"]))).toEqual([
+      "B",
+      "C",
+    ])
+  })
+  it("ignore les valeurs vides", () => {
+    expect(keysToSeed({ X: "", Y: "v" }, new Set())).toEqual(["Y"])
+  })
+  it("ne retourne rien si tout est déjà présent", () => {
+    expect(keysToSeed({ A: "1" }, new Set(["A"]))).toEqual([])
+  })
+})

--- a/tests/scripts/sync-env.test.ts
+++ b/tests/scripts/sync-env.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { groupEnv, keysOnlyIn, parseRawLines } from "@/scripts/sync-env"
+
+describe("parseRawLines", () => {
+  it("ignore commentaires et lignes vides, garde la ligne brute", () => {
+    const map = parseRawLines("# c\n\nDATABASE_URL=postgres://a&b=c")
+    expect(map.size).toBe(1)
+    expect(map.get("DATABASE_URL")).toBe("DATABASE_URL=postgres://a&b=c")
+  })
+})
+
+describe("groupEnv", () => {
+  it("regroupe par section, préserve la valeur brute, respecte l'ordre", () => {
+    const flat = [
+      'EMAIL_FROM="NOMAQbanq <noreply@nomaqbanq.ca>"',
+      "DATABASE_URL=postgres://a&b=c",
+      "BETTER_AUTH_SECRET=xyz",
+    ].join("\n")
+    const out = groupEnv(flat)
+    expect(out).toContain("# === Base de données — Neon")
+    expect(out).toContain("DATABASE_URL=postgres://a&b=c")
+    expect(out).toContain('EMAIL_FROM="NOMAQbanq <noreply@nomaqbanq.ca>"')
+    expect(out.indexOf("DATABASE_URL")).toBeLessThan(
+      out.indexOf("BETTER_AUTH_SECRET"),
+    )
+    expect(out.indexOf("BETTER_AUTH_SECRET")).toBeLessThan(
+      out.indexOf("EMAIL_FROM"),
+    )
+  })
+
+  it("met les clés inconnues en « Non classé »", () => {
+    const out = groupEnv("FOO_UNKNOWN=1\nDATABASE_URL=x")
+    expect(out).toContain("# === Non classé")
+    expect(out).toContain("FOO_UNKNOWN=1")
+  })
+})
+
+describe("keysOnlyIn", () => {
+  it("retourne les clés de a absentes de b, triées", () => {
+    expect(keysOnlyIn(["B", "A", "C"], new Set(["A"]))).toEqual(["B", "C"])
+  })
+})

--- a/tests/scripts/sync-env.test.ts
+++ b/tests/scripts/sync-env.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest"
-
 import { groupEnv, keysOnlyIn, parseRawLines } from "@/scripts/sync-env"
 
 describe("parseRawLines", () => {


### PR DESCRIPTION
## Objectif

Reproduire `.env.local` (dev) à l'identique et **rangé par sections** sur n'importe quel PC, depuis le scope **Development** de Vercel, sans jamais toucher preview/prod.

## Ce que ça apporte

- `bun run env:sync` → régénère `.env.local` depuis Vercel Dev, regroupé en **10 sections** taguées 🟢 runtime / 🟡 outillage-tests, valeurs préservées telles quelles (pas de re-quoting).
- **Garde-fou anti-écrasement** : refuse d'écraser si une clé locale manque côté Vercel (override `--force`).
- `scripts/seed-vercel-dev-env.ts` : amorçage **idempotent** des clés manquantes (scope `development` uniquement, valeurs via stdin → pas de fuite en argv).
- Vercel Dev devient la **source de vérité** (sur-ensemble de `.env.local`, 13 clés amorcées).

## Détails

- Spec : `docs/superpowers/specs/2026-06-27-sync-env-dev-vercel-design.md` + plan `docs/superpowers/plans/2026-06-27-sync-env-dev-vercel.md`.
- Inclut la **classification** des variables (à utiliser / utiles hors-runtime / mortes).
- Tests unitaires des fonctions pures (`groupEnv`, `keysToSeed`). 862 tests verts, `bun run check` vert.
- Aucun secret commité (`.env.local` gitignored).

## Vérifié

- 13 clés amorcées en `development` **uniquement** (preview/prod intacts).
- `bun run env:sync` → 0 clé perdue, 0 « Non classé », env Zod de l'app valide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)