### PR TITLE
feat: gestion du rôle administrateur depuis la fiche utilisateur

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -83,7 +83,7 @@ storagePath,order}` pour rester assignable aux composants partagés
 
 ## Gates
 
-- `bun run check` = `tsc --noEmit && eslint --max-warnings 0`. **SonarLint**
+- `bun run check` = `prettier --check . && tsc --noEmit && eslint --max-warnings 0`. **SonarLint**
   (codes `typescript:Sxxxx` : S3776 complexité cognitive, S6759 readonly-props,
   S7749 littéraux numériques…) est **IDE-only** et ne casse PAS `check` — ne pas
   refactorer pour les satisfaire.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Next.js 16 (App Router) · React 19 · TypeScript · Drizzle ORM · Neon Postgre
 ```bash
 bun dev                  # Serveur dev (Turbopack)
 bun run build            # Build production
-bun run check            # tsc + eslint (avant commit)
+bun run check            # prettier --check + tsc + eslint (avant commit)
 bun run lint             # ESLint strict (--max-warnings 0)
 bun run lint:fix         # Auto-fix ESLint
 bun run format           # Prettier write

--- a/app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx
+++ b/app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import { ShieldCheck, ShieldOff } from "lucide-react"
+import { motion } from "motion/react"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { updateUserRole } from "@/features/users/actions"
+import type { AdminUserDetail } from "@/features/users/dal"
+
+interface UserRoleSectionProps {
+  user: Pick<AdminUserDetail, "id" | "name" | "email" | "role">
+  currentUserId: string
+}
+
+export const UserRoleSection = ({
+  user,
+  currentUserId,
+}: UserRoleSectionProps) => {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const isSelf = user.id === currentUserId
+  const isAdmin = user.role === "admin"
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      const result = await updateUserRole({
+        userId: user.id,
+        role: isAdmin ? "user" : "admin",
+      })
+      if (result.success) {
+        toast.success(
+          isAdmin
+            ? "Rôle administrateur retiré."
+            : "Utilisateur promu administrateur.",
+        )
+        setOpen(false)
+        router.refresh()
+      } else {
+        toast.error(result.error ?? "Une erreur est survenue.")
+      }
+    })
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.1 }}
+      className="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-lg dark:border-gray-700/50 dark:bg-gray-900"
+    >
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="h-5 w-5 text-slate-600 dark:text-slate-400" />
+        <h3 className="font-semibold text-gray-900 dark:text-white">
+          Rôle administrateur
+        </h3>
+      </div>
+      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+        {isAdmin
+          ? "Cet utilisateur a un accès complet au back-office : questions, examens, utilisateurs et transactions."
+          : "Promouvoir cet utilisateur lui donne un accès complet au back-office : questions, examens, utilisateurs et transactions."}
+      </p>
+
+      {isSelf ? (
+        <p
+          data-testid="role-self-note"
+          className="mt-4 text-sm text-gray-400 italic dark:text-gray-500"
+        >
+          Vous ne pouvez pas modifier votre propre rôle.
+        </p>
+      ) : (
+        <>
+          <Button
+            data-testid="role-toggle-open"
+            variant={isAdmin ? "outline" : "default"}
+            className={
+              isAdmin
+                ? "mt-4 w-full rounded-xl border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/30"
+                : "mt-4 w-full rounded-xl"
+            }
+            onClick={() => setOpen(true)}
+          >
+            {isAdmin ? (
+              <ShieldOff className="mr-2 h-4 w-4" />
+            ) : (
+              <ShieldCheck className="mr-2 h-4 w-4" />
+            )}
+            {isAdmin
+              ? "Retirer le rôle administrateur"
+              : "Promouvoir administrateur"}
+          </Button>
+
+          <AlertDialog open={open} onOpenChange={setOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {isAdmin
+                    ? "Retirer le rôle administrateur ?"
+                    : "Promouvoir administrateur ?"}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {user.name} ({user.email}){" "}
+                  {isAdmin
+                    ? "perdra immédiatement l'accès au back-office."
+                    : "obtiendra un accès complet au back-office."}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isPending}>
+                  Annuler
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  data-testid="role-toggle-confirm"
+                  disabled={isPending}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    handleConfirm()
+                  }}
+                  className={
+                    isAdmin ? "bg-red-600 text-white hover:bg-red-700" : ""
+                  }
+                >
+                  {isAdmin ? "Retirer le rôle" : "Promouvoir"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
+    </motion.div>
+  )
+}

--- a/app/(admin)/admin/utilisateurs/[id]/page.tsx
+++ b/app/(admin)/admin/utilisateurs/[id]/page.tsx
@@ -17,7 +17,7 @@ export default async function AdminUserDetailPage({
 }) {
   // H3 (IDOR) : garde admin explicite avant de manipuler un userId arbitraire,
   // en plus du layout admin et des gardes internes du DAL.
-  await requireRole(["admin"])
+  const session = await requireRole(["admin"])
   const { id } = await params
 
   const user = await getUserForAdmin(id)
@@ -59,6 +59,7 @@ export default async function AdminUserDetailPage({
   return (
     <UserDetailClient
       user={user}
+      currentUserId={session.user.id}
       initialAccess={access ?? { examAccess: null, trainingAccess: null }}
       initialTransactions={txPage.items}
       initialCursor={txPage.nextCursor}

--- a/app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx
+++ b/app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx
@@ -30,9 +30,11 @@ import type {
 import type { AdminUserDetail, SelectableUser } from "@/features/users/dal"
 import { UserAccessSection } from "./_components/user-access-section"
 import { UserInfoCard } from "./_components/user-info-card"
+import { UserRoleSection } from "./_components/user-role-section"
 
 interface UserDetailClientProps {
   user: AdminUserDetail
+  currentUserId: string
   initialAccess: AccessStatus
   initialTransactions: AdminTransactionView[]
   initialCursor: string | null
@@ -42,6 +44,7 @@ interface UserDetailClientProps {
 
 export function UserDetailClient({
   user,
+  currentUserId,
   initialAccess,
   initialTransactions,
   initialCursor,
@@ -100,8 +103,9 @@ export function UserDetailClient({
 
       {/* Main content */}
       <div className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-1">
+        <div className="space-y-6 lg:col-span-1">
           <UserInfoCard user={user} />
+          <UserRoleSection user={user} currentUserId={currentUserId} />
         </div>
 
         <div className="space-y-6 lg:col-span-2">

--- a/docs/superpowers/plans/2026-07-05-gestion-role-admin.md
+++ b/docs/superpowers/plans/2026-07-05-gestion-role-admin.md
@@ -1,0 +1,867 @@
+# Gestion du rôle administrateur — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettre à un admin de promouvoir/rétrograder n'importe quel utilisateur depuis la fiche `/admin/utilisateurs/[id]`, avec l'invariant « jamais zéro admin actif ».
+
+**Architecture:** Une Server Action `updateUserRole` (guard → zod → transaction avec verrous `for update` sur appelant + cible → revalidation) et une carte client `UserRoleSection` dans la fiche utilisateur (AlertDialog de confirmation → action → `router.refresh()`). Les 15 endpoints HTTP inutilisés du plugin admin Better Auth sont fermés via `disabledPaths` pour que l'action soit l'unique chemin de mutation du rôle. Aucun changement de schéma DB.
+
+**Tech Stack:** Next.js 16 Server Actions, Drizzle/Neon, zod, shadcn AlertDialog, Vitest (integration Neon éphémère + frontend happy-dom).
+
+**Spec:** `docs/superpowers/specs/2026-07-05-gestion-role-admin-design.md`
+
+**Rappels projet :** messages de commit conventionnels SANS attribution Claude ; `bun run test` (jamais `bun test`) ; on part de `main` propre → créer une branche d'abord.
+
+---
+
+### Task 0: Branche de travail
+
+- [ ] **Step 1: Créer la branche**
+
+```bash
+git checkout -b feat/gestion-role-admin
+```
+
+---
+
+### Task 1: Schéma zod `updateUserRoleSchema`
+
+**Files:**
+
+- Modify: `features/users/schemas.ts` (append à la fin)
+
+- [ ] **Step 1: Ajouter le schéma**
+
+```ts
+export const updateUserRoleSchema = z.object({
+  userId: z.string().min(1, "Utilisateur requis"),
+  role: z.enum(["user", "admin"]),
+})
+```
+
+(Pas de test dédié : le schéma est couvert par les tests d'intégration de l'action en Task 2/3.)
+
+- [ ] **Step 2: Vérifier la compile**
+
+Run: `bun run check`
+Expected: PASS (0 erreur, 0 warning). NB : `check` inclut `prettier --check .`
+(AGENTS.md a été corrigé en ce sens) — spec et plan sont déjà formatés ; si un
+doc est retouché en cours de route, `bun run format` avant de relancer.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add features/users/schemas.ts
+git commit -m "feat: schema zod updateUserRole"
+```
+
+---
+
+### Task 2: Tests d'intégration de `updateUserRole` (rouges)
+
+**Files:**
+
+- Create: `tests/integration/users-role.test.ts`
+
+Conventions copiées de `tests/integration/users-account.test.ts` : le projet `integration` tourne sur une branche Neon éphémère (`bun run test:integration` = créer branche → migrer → vitest → détruire). Les guards sont mockés ; le mock factory de `@/lib/auth-guards` doit exporter **requireSession ET requireRole** (les deux sont importés par `actions.ts`).
+
+- [ ] **Step 1: Écrire le fichier de test complet**
+
+```ts
+import { eq } from "drizzle-orm"
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+import { db } from "@/db"
+import { user } from "@/db/schema"
+import { updateUserRole } from "@/features/users/actions"
+import { requireRole } from "@/lib/auth-guards"
+import { createId } from "@/lib/ids"
+
+// Mêmes stubs que users-account.test.ts : on ne charge pas la stack Better Auth,
+// et les guards sont pilotés par le test (le re-check transactionnel, lui, lit la
+// vraie base — c'est précisément ce qu'on teste).
+vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/auth", () => ({ auth: { api: {} } }))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+const adminId = createId()
+const targetId = createId()
+const adminEmail = `role-admin-${adminId}@test.invalid`
+const targetEmail = `role-target-${targetId}@test.invalid`
+
+const mockCallerSession = () =>
+  vi.mocked(requireRole).mockResolvedValue({
+    user: { id: adminId, email: adminEmail, role: "admin" },
+    session: { id: createId() },
+  } as never)
+
+const getUserRow = async (id: string) => {
+  const [row] = await db
+    .select({ role: user.role, updatedAt: user.updatedAt })
+    .from(user)
+    .where(eq(user.id, id))
+    .limit(1)
+  return row
+}
+
+const getRole = async (id: string) => (await getUserRow(id))?.role
+
+beforeAll(async () => {
+  await db.insert(user).values([
+    {
+      id: adminId,
+      name: "Admin Test",
+      email: adminEmail,
+      emailVerified: true,
+      role: "admin",
+    },
+    {
+      id: targetId,
+      name: "Cible Test",
+      email: targetEmail,
+      emailVerified: true,
+    },
+  ])
+})
+
+afterAll(async () => {
+  await db.delete(user).where(eq(user.id, adminId))
+  await db.delete(user).where(eq(user.id, targetId))
+})
+
+beforeEach(async () => {
+  // Remet l'état de référence : appelant admin actif, cible user active.
+  await db
+    .update(user)
+    .set({ role: "admin", deletedAt: null })
+    .where(eq(user.id, adminId))
+  await db
+    .update(user)
+    .set({ role: "user", deletedAt: null })
+    .where(eq(user.id, targetId))
+  mockCallerSession()
+})
+
+describe("updateUserRole", () => {
+  it("promeut un utilisateur en admin", async () => {
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result).toEqual({ success: true })
+    expect(await getRole(targetId)).toBe("admin")
+  })
+
+  it("rétrograde un admin en utilisateur", async () => {
+    await db.update(user).set({ role: "admin" }).where(eq(user.id, targetId))
+    const result = await updateUserRole({ userId: targetId, role: "user" })
+    expect(result).toEqual({ success: true })
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("est idempotent si le rôle est déjà celui demandé (aucune écriture)", async () => {
+    const before = await getUserRow(targetId)
+    const result = await updateUserRole({ userId: targetId, role: "user" })
+    expect(result).toEqual({ success: true })
+    const after = await getUserRow(targetId)
+    expect(after?.role).toBe("user")
+    // `updatedAt` a $onUpdate (db/schema/auth.ts) : tout UPDATE le bump —
+    // l'égalité prouve qu'aucune écriture n'a eu lieu.
+    expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime())
+  })
+
+  it("refuse l'auto-modification", async () => {
+    const result = await updateUserRole({ userId: adminId, role: "user" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Vous ne pouvez pas modifier votre propre rôle.")
+    expect(await getRole(adminId)).toBe("admin")
+  })
+
+  it("refuse si l'appelant n'est plus admin actif en base (re-check transactionnel)", async () => {
+    // La session mockée dit encore « admin », mais la base a changé entre-temps.
+    await db.update(user).set({ role: "user" }).where(eq(user.id, adminId))
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe(
+      "Votre compte n'a plus les droits administrateur.",
+    )
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("refuse si l'appelant est soft-deleted", async () => {
+    await db
+      .update(user)
+      .set({ deletedAt: new Date() })
+      .where(eq(user.id, adminId))
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result.success).toBe(false)
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("refuse une cible inexistante", async () => {
+    const result = await updateUserRole({ userId: createId(), role: "admin" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Utilisateur introuvable.")
+  })
+
+  it("refuse une cible soft-deleted", async () => {
+    await db
+      .update(user)
+      .set({ deletedAt: new Date() })
+      .where(eq(user.id, targetId))
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Utilisateur introuvable.")
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("refuse un rôle hors enum (zod)", async () => {
+    const result = await updateUserRole({
+      userId: targetId,
+      role: "superadmin" as never,
+    })
+    expect(result.success).toBe(false)
+    expect(await getRole(targetId)).toBe("user")
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test:integration`
+Expected: FAIL — `users-role.test.ts` échoue à l'import (`updateUserRole` n'existe pas encore dans `@/features/users/actions`). Les autres fichiers d'intégration restent verts.
+
+(Coût : chaque run crée/migre/détruit une branche Neon, ~1-2 min — pas d'itération fine ici, un run rouge + un run vert en Task 3 suffisent.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/users-role.test.ts
+git commit -m "test: couverture integration updateUserRole (rouge)"
+```
+
+---
+
+### Task 3: Server Action `updateUserRole`
+
+**Files:**
+
+- Modify: `features/users/actions.ts` (imports + nouvelle action, à placer après `loadUserPanelData`)
+
+- [ ] **Step 1: Étendre les imports drizzle et schémas**
+
+Ligne 3, ajouter `inArray` :
+
+```ts
+import { and, eq, inArray, isNull, ne } from "drizzle-orm"
+```
+
+Ligne 15, importer le nouveau schéma :
+
+```ts
+import { profileSchema, updateUserRoleSchema } from "@/features/users/schemas"
+```
+
+- [ ] **Step 2: Écrire l'action**
+
+Réutilise `AccountActionResult` (défini dans ce même fichier, ligne ~225 : `{ success: boolean; error?: string }`).
+
+```ts
+// [Admin] Change le rôle d'un utilisateur. Invariant « jamais zéro admin
+// actif » garanti sans compter les admins : l'auto-modification est interdite
+// ET l'appelant est re-vérifié admin actif sous verrou dans la transaction —
+// après l'écriture il reste donc toujours au moins lui. Le verrou couvre la
+// race « l'appelant vient d'être rétrogradé » (requireRole est hors
+// transaction). Pas de révocation de sessions : sans cookieCache, Better Auth
+// relit le rôle en base à chaque requête.
+export const updateUserRole = async (input: {
+  userId: string
+  role: "user" | "admin"
+}): Promise<AccountActionResult> => {
+  const authSession = await requireRole(["admin"])
+
+  const parsed = updateUserRoleSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Données invalides",
+    }
+  }
+  const { userId: targetId, role } = parsed.data
+
+  if (targetId === authSession.user.id) {
+    return {
+      success: false,
+      error: "Vous ne pouvez pas modifier votre propre rôle.",
+    }
+  }
+
+  const result = await db.transaction(async (tx) => {
+    // Un seul SELECT ... FOR UPDATE trié par id : verrouille appelant + cible
+    // dans un ordre déterministe (pas de deadlock entre deux appels croisés).
+    const rows = await tx
+      .select({ id: user.id, role: user.role, deletedAt: user.deletedAt })
+      .from(user)
+      .where(inArray(user.id, [authSession.user.id, targetId]))
+      .orderBy(user.id)
+      .for("update")
+
+    const caller = rows.find((r) => r.id === authSession.user.id)
+    if (!caller || caller.role !== "admin" || caller.deletedAt !== null) {
+      return {
+        ok: false as const,
+        error: "Votre compte n'a plus les droits administrateur.",
+      }
+    }
+
+    const target = rows.find((r) => r.id === targetId)
+    if (!target || target.deletedAt !== null) {
+      return { ok: false as const, error: "Utilisateur introuvable." }
+    }
+
+    if (target.role !== role) {
+      await tx.update(user).set({ role }).where(eq(user.id, targetId))
+    }
+    return { ok: true as const }
+  })
+
+  if (!result.ok) {
+    return { success: false, error: result.error }
+  }
+
+  revalidatePath("/admin/utilisateurs")
+  revalidatePath(`/admin/utilisateurs/${targetId}`)
+  return { success: true }
+}
+```
+
+Piège TS connu (cf. `.claude/rules/data-layer.md`) : la valeur est retournée
+DEPUIS le callback de `db.transaction` (pas via un `let` capturé), sinon le
+narrowing après `if (!result.ok)` casse.
+
+- [ ] **Step 3: Vérifier compile + lint**
+
+Run: `bun run check`
+Expected: PASS
+
+- [ ] **Step 4: Vérifier le vert**
+
+Run: `bun run test:integration`
+Expected: PASS — les 9 tests de `users-role.test.ts` verts, le reste de la suite inchangé.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/users/actions.ts
+git commit -m "feat: server action updateUserRole (promotion/retrogradation admin)"
+```
+
+---
+
+### Task 4: Fermer les endpoints HTTP du plugin admin Better Auth
+
+**Files:**
+
+- Modify: `lib/auth.ts` (config `betterAuth`, juste avant `plugins:`)
+
+Contexte (revue adversariale du 2026-07-05, constat #2) : le plugin admin
+n'est là que pour le champ `role`, mais il expose 15 endpoints HTTP via
+`app/api/auth/[...all]` — dont `POST /admin/set-role` (aucune garde
+self/dernier-admin : lock-out en un fetch) et `POST /admin/remove-user`
+(suppression dure contournant la garde de `deleteMyAccount`). Aucun code de
+l'app ne les utilise. `disabledPaths` (vérifié sur better-auth 1.6.20 :
+match exact au routeur → 404, `better-auth/dist/api/index.mjs:164-166`)
+ferme la surface.
+
+- [ ] **Step 1: Ajouter `disabledPaths` dans `lib/auth.ts`**
+
+Insérer juste avant la ligne `  plugins: [` :
+
+```ts
+  // Le plugin admin n'est configuré que pour porter `role` sur session.user :
+  // ses endpoints HTTP ne sont pas utilisés par l'app et contournent les
+  // gardes applicatives (auto-modification, dernier admin) de updateUserRole /
+  // deleteMyAccount → fermés au routeur (404). Match EXACT : re-vérifier la
+  // liste à chaque montée de version de better-auth.
+  disabledPaths: [
+    "/admin/set-role",
+    "/admin/get-user",
+    "/admin/create-user",
+    "/admin/update-user",
+    "/admin/list-users",
+    "/admin/list-user-sessions",
+    "/admin/unban-user",
+    "/admin/ban-user",
+    "/admin/impersonate-user",
+    "/admin/stop-impersonating",
+    "/admin/revoke-user-session",
+    "/admin/revoke-user-sessions",
+    "/admin/remove-user",
+    "/admin/set-user-password",
+    "/admin/has-permission",
+  ],
+```
+
+- [ ] **Step 2: Vérifier compile + lint**
+
+Run: `bun run check`
+Expected: PASS
+
+- [ ] **Step 3: Vérifier le 404 (rapide, sans session)**
+
+```bash
+bun dev
+# dans un autre terminal :
+curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:3000/api/auth/admin/set-role -H "Content-Type: application/json" -d "{}"
+```
+
+Expected: `404` (sans `disabledPaths`, cet appel non authentifié répondrait
+401). Arrêter le serveur dev ensuite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/auth.ts
+git commit -m "fix: fermeture des endpoints HTTP inutilises du plugin admin better-auth"
+```
+
+---
+
+### Task 5: Composant `UserRoleSection` (test d'abord)
+
+**Files:**
+
+- Create: `tests/components/admin/UserRoleSection.test.tsx`
+- Create: `app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx`
+
+- [ ] **Step 1: Écrire le test frontend (rouge)**
+
+Conventions de `tests/users/profile-danger-zone.test.tsx` (mocks hoisted) +
+mock motion via `tests/helpers/motion-mock.tsx`. Les dialogs Radix
+fonctionnent en happy-dom (cf. `tests/components/quiz/FinishDialog.test.tsx`).
+
+```tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { UserRoleSection } from "@/app/(admin)/admin/utilisateurs/[id]/_components/user-role-section"
+import { motionMockFactory } from "../../helpers/motion-mock"
+
+const mocks = vi.hoisted(() => ({
+  updateUserRole: vi.fn(),
+  refresh: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock("@/features/users/actions", () => ({
+  updateUserRole: mocks.updateUserRole,
+}))
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}))
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}))
+vi.mock("motion/react", () => motionMockFactory)
+
+const baseUser = {
+  id: "user-1",
+  name: "Marie Curie",
+  email: "marie@exemple.com",
+  role: "user" as const,
+}
+
+beforeEach(() => {
+  mocks.updateUserRole.mockReset()
+  mocks.refresh.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.toastError.mockReset()
+  mocks.updateUserRole.mockResolvedValue({ success: true })
+})
+
+describe("UserRoleSection", () => {
+  it("affiche « Promouvoir administrateur » pour un utilisateur simple", () => {
+    render(<UserRoleSection user={baseUser} currentUserId="viewer-1" />)
+    expect(screen.getByTestId("role-toggle-open")).toHaveTextContent(
+      "Promouvoir administrateur",
+    )
+  })
+
+  it("affiche « Retirer le rôle administrateur » pour un admin", () => {
+    render(
+      <UserRoleSection
+        user={{ ...baseUser, role: "admin" }}
+        currentUserId="viewer-1"
+      />,
+    )
+    expect(screen.getByTestId("role-toggle-open")).toHaveTextContent(
+      "Retirer le rôle administrateur",
+    )
+  })
+
+  it("masque le bouton sur sa propre fiche et affiche la note", () => {
+    render(<UserRoleSection user={baseUser} currentUserId={baseUser.id} />)
+    expect(screen.queryByTestId("role-toggle-open")).toBeNull()
+    expect(screen.getByTestId("role-self-note")).toHaveTextContent(
+      "Vous ne pouvez pas modifier votre propre rôle",
+    )
+  })
+
+  it("confirme la promotion : dialog avec nom + email, appel action, refresh", async () => {
+    render(<UserRoleSection user={baseUser} currentUserId="viewer-1" />)
+    fireEvent.click(screen.getByTestId("role-toggle-open"))
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("Marie Curie")
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(
+      "marie@exemple.com",
+    )
+    fireEvent.click(screen.getByTestId("role-toggle-confirm"))
+    await waitFor(() =>
+      expect(mocks.updateUserRole).toHaveBeenCalledWith({
+        userId: "user-1",
+        role: "admin",
+      }),
+    )
+    await waitFor(() => expect(mocks.refresh).toHaveBeenCalled())
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Utilisateur promu administrateur.",
+    )
+  })
+
+  it("demande role=user pour rétrograder un admin", async () => {
+    render(
+      <UserRoleSection
+        user={{ ...baseUser, role: "admin" }}
+        currentUserId="viewer-1"
+      />,
+    )
+    fireEvent.click(screen.getByTestId("role-toggle-open"))
+    fireEvent.click(screen.getByTestId("role-toggle-confirm"))
+    await waitFor(() =>
+      expect(mocks.updateUserRole).toHaveBeenCalledWith({
+        userId: "user-1",
+        role: "user",
+      }),
+    )
+  })
+
+  it("affiche le toast d'erreur et n'appelle pas refresh quand l'action échoue", async () => {
+    mocks.updateUserRole.mockResolvedValue({
+      success: false,
+      error: "Utilisateur introuvable.",
+    })
+    render(<UserRoleSection user={baseUser} currentUserId="viewer-1" />)
+    fireEvent.click(screen.getByTestId("role-toggle-open"))
+    fireEvent.click(screen.getByTestId("role-toggle-confirm"))
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith("Utilisateur introuvable."),
+    )
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    // Le dialog reste ouvert en échec (fermeture pilotée par le succès).
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test -- UserRoleSection`
+Expected: FAIL — module `user-role-section` introuvable.
+
+- [ ] **Step 3: Écrire le composant**
+
+```tsx
+"use client"
+
+import { ShieldCheck, ShieldOff } from "lucide-react"
+import { motion } from "motion/react"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { updateUserRole } from "@/features/users/actions"
+import type { AdminUserDetail } from "@/features/users/dal"
+
+interface UserRoleSectionProps {
+  user: Pick<AdminUserDetail, "id" | "name" | "email" | "role">
+  currentUserId: string
+}
+
+export const UserRoleSection = ({
+  user,
+  currentUserId,
+}: UserRoleSectionProps) => {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const isSelf = user.id === currentUserId
+  const isAdmin = user.role === "admin"
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      const result = await updateUserRole({
+        userId: user.id,
+        role: isAdmin ? "user" : "admin",
+      })
+      if (result.success) {
+        toast.success(
+          isAdmin
+            ? "Rôle administrateur retiré."
+            : "Utilisateur promu administrateur.",
+        )
+        setOpen(false)
+        router.refresh()
+      } else {
+        toast.error(result.error ?? "Une erreur est survenue.")
+      }
+    })
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.1 }}
+      className="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-lg dark:border-gray-700/50 dark:bg-gray-900"
+    >
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="h-5 w-5 text-slate-600 dark:text-slate-400" />
+        <h3 className="font-semibold text-gray-900 dark:text-white">
+          Rôle administrateur
+        </h3>
+      </div>
+      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+        {isAdmin
+          ? "Cet utilisateur a un accès complet au back-office : questions, examens, utilisateurs et transactions."
+          : "Promouvoir cet utilisateur lui donne un accès complet au back-office : questions, examens, utilisateurs et transactions."}
+      </p>
+
+      {isSelf ? (
+        <p
+          data-testid="role-self-note"
+          className="mt-4 text-sm italic text-gray-400 dark:text-gray-500"
+        >
+          Vous ne pouvez pas modifier votre propre rôle.
+        </p>
+      ) : (
+        <>
+          <Button
+            data-testid="role-toggle-open"
+            variant={isAdmin ? "outline" : "default"}
+            className={
+              isAdmin
+                ? "mt-4 w-full rounded-xl border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/30"
+                : "mt-4 w-full rounded-xl"
+            }
+            onClick={() => setOpen(true)}
+          >
+            {isAdmin ? (
+              <ShieldOff className="mr-2 h-4 w-4" />
+            ) : (
+              <ShieldCheck className="mr-2 h-4 w-4" />
+            )}
+            {isAdmin
+              ? "Retirer le rôle administrateur"
+              : "Promouvoir administrateur"}
+          </Button>
+
+          <AlertDialog open={open} onOpenChange={setOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {isAdmin
+                    ? "Retirer le rôle administrateur ?"
+                    : "Promouvoir administrateur ?"}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {user.name} ({user.email}){" "}
+                  {isAdmin
+                    ? "perdra immédiatement l'accès au back-office."
+                    : "obtiendra un accès complet au back-office."}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isPending}>
+                  Annuler
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  data-testid="role-toggle-confirm"
+                  disabled={isPending}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    handleConfirm()
+                  }}
+                  className={
+                    isAdmin ? "bg-red-600 text-white hover:bg-red-700" : ""
+                  }
+                >
+                  {isAdmin ? "Retirer le rôle" : "Promouvoir"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
+    </motion.div>
+  )
+}
+```
+
+Note : `e.preventDefault()` sur `AlertDialogAction` empêche Radix de fermer le
+dialog avant la fin de l'action ; la fermeture est pilotée par `setOpen(false)`
+au succès (le dialog reste ouvert en cas d'erreur).
+
+- [ ] **Step 4: Vérifier le vert**
+
+Run: `bun run test -- UserRoleSection`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/components/admin/UserRoleSection.test.tsx "app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx"
+git commit -m "feat: carte de gestion du role admin sur la fiche utilisateur"
+```
+
+---
+
+### Task 6: Câblage page + wrapper client
+
+**Files:**
+
+- Modify: `app/(admin)/admin/utilisateurs/[id]/page.tsx:20` (capturer la session)
+- Modify: `app/(admin)/admin/utilisateurs/[id]/page.tsx:59-68` (prop `currentUserId`)
+- Modify: `app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx` (prop + rendu)
+
+- [ ] **Step 1: Capturer la session dans la page**
+
+Dans `page.tsx`, remplacer :
+
+```ts
+await requireRole(["admin"])
+```
+
+par :
+
+```ts
+const session = await requireRole(["admin"])
+```
+
+et dans le JSX final, ajouter la prop (uniquement l'id — jamais l'objet
+session complet côté client, cf. `data-layer.md` PII) :
+
+```tsx
+<UserDetailClient
+  user={user}
+  currentUserId={session.user.id}
+  initialAccess={access ?? { examAccess: null, trainingAccess: null }}
+  initialTransactions={txPage.items}
+  initialCursor={txPage.nextCursor}
+  products={products}
+  selectableUsers={selectableUsers}
+/>
+```
+
+- [ ] **Step 2: Rendre la carte dans `user-detail-client.tsx`**
+
+Ajouter l'import :
+
+```ts
+import { UserRoleSection } from "./_components/user-role-section"
+```
+
+Étendre l'interface et la signature :
+
+```ts
+interface UserDetailClientProps {
+  user: AdminUserDetail
+  currentUserId: string
+  initialAccess: AccessStatus
+  initialTransactions: AdminTransactionView[]
+  initialCursor: string | null
+  products: ProductView[]
+  selectableUsers: SelectableUser[]
+}
+```
+
+(et ajouter `currentUserId` à la destructuration des props.)
+
+Remplacer la colonne gauche :
+
+```tsx
+<div className="lg:col-span-1">
+  <UserInfoCard user={user} />
+</div>
+```
+
+par :
+
+```tsx
+<div className="space-y-6 lg:col-span-1">
+  <UserInfoCard user={user} />
+  <UserRoleSection user={user} currentUserId={currentUserId} />
+</div>
+```
+
+- [ ] **Step 3: Gates complets**
+
+Run: `bun run check && bun run test`
+Expected: PASS partout.
+
+- [ ] **Step 4: Vérification manuelle (optionnelle mais recommandée)**
+
+`bun dev` → `/admin/utilisateurs` → ouvrir une fiche : carte visible, dialog,
+promotion effective (badge passe à « Admin » après confirmation), note « propre
+rôle » sur sa propre fiche. Arrêter le serveur dev ensuite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/(admin)/admin/utilisateurs/[id]/page.tsx" "app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx"
+git commit -m "feat: cablage de la gestion du role admin dans la fiche utilisateur"
+```
+
+---
+
+### Task 7: Documentation des specs/plans
+
+- [ ] **Step 1: Formater puis committer spec + plan**
+
+`bun run check` inclut `prettier --check .` : les docs doivent être formatés
+pour ne pas casser la CI.
+
+```bash
+bunx prettier --write docs/superpowers/specs/2026-07-05-gestion-role-admin-design.md docs/superpowers/plans/2026-07-05-gestion-role-admin.md
+git add docs/superpowers/specs/2026-07-05-gestion-role-admin-design.md docs/superpowers/plans/2026-07-05-gestion-role-admin.md
+git commit -m "docs: spec + plan gestion du role administrateur"
+```
+
+---
+
+## Hors scope (rappel spec)
+
+Notification email au promu, table d'audit, rôles intermédiaires, action dans
+le side panel de la liste. Ne rien implémenter de tout ça.
+
+Suite recommandée par la revue, à proposer SÉPARÉMENT (pas dans ce plan) :
+durcir le TOCTOU de `deleteMyAccount` (décider la branche « dernier admin »
+sur le rôle lu en base sous verrou, pas sur `authSession.user.role`).

--- a/docs/superpowers/specs/2026-07-05-gestion-role-admin-design.md
+++ b/docs/superpowers/specs/2026-07-05-gestion-role-admin-design.md
@@ -1,0 +1,170 @@
+# Spec — Gestion du rôle administrateur depuis la fiche utilisateur
+
+**Date** : 2026-07-05
+**Statut** : validé (brainstorming) ; revue adversariale design du 2026-07-05
+triée — fermeture des endpoints admin Better Auth ajoutée, tests renforcés
+(toasts, idempotence sans écriture)
+
+## Contexte
+
+Un seul administrateur existe aujourd'hui, promu à la main dans la base (colonne
+`user.role`, enum `user_role = "user" | "admin"`, `db/schema/enums.ts`). Il faut
+permettre à un admin de promouvoir ou rétrograder n'importe quel utilisateur
+depuis l'interface, sans toucher à la base.
+
+**Emplacement retenu** : la fiche utilisateur admin `/admin/utilisateurs/[id]`
+(option validée en brainstorming). Pas de page dédiée : l'enum n'a que deux
+valeurs, la « vue d'ensemble des admins » existe déjà via le filtre rôle de
+`/admin/utilisateurs`.
+
+## Portée
+
+- Une carte « Rôle administrateur » dans la fiche utilisateur admin.
+- Une Server Action `updateUserRole` (promotion **et** rétrogradation).
+- La fermeture des endpoints HTTP inutilisés du plugin admin Better Auth
+  (`disabledPaths`), pour que `updateUserRole` soit l'**unique** chemin de
+  mutation du rôle.
+- Tests d'intégration (action) + tests frontend (carte).
+
+**Hors scope v1** (à proposer séparément si besoin) : notification email au
+promu, table d'audit, rôles intermédiaires (modérateur…), gestion depuis le
+side panel de la liste.
+
+**Suite recommandée** (constat 🟡 de la revue du 2026-07-05) : durcir le
+TOCTOU de `deleteMyAccount` — la branche « dernier admin » est gatée sur le
+rôle porté par la session (`actions.ts:327`), pas re-lu sous verrou ; fenêtre
+très étroite (trois requêtes quasi simultanées) rendue théoriquement
+atteignable par la promotion in-app. Correctif : décider la branche admin sur
+le rôle lu en base sous verrou.
+
+## UX — carte « Rôle administrateur »
+
+Nouveau composant client
+`app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx`, rendu
+dans `user-detail-client.tsx`, colonne gauche sous `UserInfoCard` (le rôle
+relève de l'identité, pas des accès payants). Style : carte `rounded-2xl` +
+`motion` comme les sections existantes.
+
+États :
+
+| Cas                                                    | Affichage                                                               |
+| ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `role === "user"`                                      | Description courte du rôle admin + bouton « Promouvoir administrateur » |
+| `role === "admin"`                                     | Bouton destructif (outline) « Retirer le rôle administrateur »          |
+| Fiche du viewer lui-même (`user.id === currentUserId`) | Pas de bouton — note « Vous ne pouvez pas modifier votre propre rôle »  |
+
+- Clic → `AlertDialog` (shadcn) : nom + email de la cible, phrase expliquant la
+  conséquence (accès complet au back-office / perte de cet accès), bouton
+  d'action explicite. Pas de saisie à retaper : l'action est réversible en un
+  clic, contrairement à la suppression de compte.
+- Pendant l'appel : bouton désactivé (`useTransition`).
+- Succès : toast + `router.refresh()` — le badge rôle de `UserInfoCard` se met
+  à jour via le refetch serveur de la page. Échec : toast d'erreur avec le
+  message renvoyé par l'action.
+- La page serveur (`[id]/page.tsx`) capture la session de `requireRole` et
+  passe `currentUserId` au client (uniquement l'id — jamais l'objet session,
+  cf. `data-layer.md` PII).
+
+## Server Action `updateUserRole`
+
+Dans `features/users/actions.ts`, schéma zod dans `features/users/schemas.ts`.
+
+```
+updateUserRole(input: { userId: string; role: "user" | "admin" })
+  → { success: true } | { success: false; error: string }
+```
+
+Séquence : `requireRole(["admin"])` → `safeParse` → règles → transaction →
+`revalidatePath("/admin/utilisateurs")` + `revalidatePath("/admin/utilisateurs/{userId}")`.
+
+Règles, dans l'ordre :
+
+1. **Auto-modification interdite** : `input.userId === session.user.id` →
+   erreur « Vous ne pouvez pas modifier votre propre rôle. » Couvre
+   l'auto-rétrogradation (lock-out en un clic) et l'auto-promotion (no-op
+   inutile).
+2. **Transaction** avec deux verrous `for update` (ordre déterministe par id
+   pour éviter tout deadlock entre appels croisés) :
+   - Ligne **de l'appelant** : re-check `role = "admin"` et
+     `deletedAt IS NULL`. S'il n'est plus admin actif → erreur. Combiné à la
+     règle 1, cela garantit l'invariant **« jamais zéro admin actif »** sans
+     compter les admins : après l'écriture il reste au moins l'appelant.
+     (Couvre la race « l'appelant vient d'être rétrogradé par un autre
+     admin » — `requireRole` seul est un check hors transaction.)
+     L'invariant suppose que `updateUserRole` est l'unique chemin de mutation
+     du rôle — c'est ce que garantit la fermeture des endpoints du plugin
+     admin ci-dessous.
+   - Ligne **de la cible** : doit exister et `deletedAt IS NULL`, sinon erreur
+     « Utilisateur introuvable. » Si `role` déjà égal à la valeur demandée →
+     succès sans écriture (idempotent).
+   - Écriture : `update user set role = … where id = …`.
+
+### Fermeture des endpoints du plugin admin Better Auth
+
+Le plugin `admin` (`lib/auth.ts:106`) n'est configuré que pour porter le champ
+`role` sur `session.user`. Il expose pourtant **15 endpoints HTTP** via la
+route catch-all `/api/auth/[...all]` — dont `POST /admin/set-role` (aucune
+garde d'auto-modification ni de dernier admin : un admin peut se rétrograder
+lui-même en un fetch) et `POST /admin/remove-user` (suppression **dure**, qui
+contourne la garde « dernier admin » de `deleteMyAccount`). Aucun code de
+l'application ne les appelle (vérifié : zéro usage de `authClient.admin.*` /
+`auth.api.setRole` etc.). Sans fermeture, l'invariant ci-dessus est faux.
+
+Correctif : l'option **`disabledPaths`** de Better Auth (vérifiée sur la
+1.6.20 installée : match exact au niveau du routeur HTTP → 404), listant les
+15 endpoints du plugin. Limites assumées :
+
+- match **exact** — re-vérifier la liste à chaque montée de version de
+  better-auth (un nouvel endpoint du plugin ne serait pas couvert) ;
+- `disabledPaths` ne s'applique qu'à la surface HTTP ; les appels serveur
+  `auth.api.*` la contournent (aucun dans l'app, et ils resteraient sous
+  notre contrôle).
+
+### Fraîcheur du rôle / sessions
+
+Aucune révocation de sessions nécessaire : `lib/auth.ts` n'a pas de
+`cookieCache`, Better Auth relit l'utilisateur en base à chaque
+`getSession`. Le rétrogradé perd la zone admin à sa prochaine requête (les
+layouts/DAL/Actions re-gardent tous côté serveur) ; le promu la gagne pareil.
+
+### Messages d'erreur (FR)
+
+- « Vous ne pouvez pas modifier votre propre rôle. »
+- « Utilisateur introuvable. » (cible inexistante ou supprimée)
+- « Votre compte n'a plus les droits administrateur. » (re-check appelant)
+- « Données invalides » (zod, message de l'issue si disponible)
+
+## Tests
+
+**Intégration** (`tests/integration/users-role.test.ts`, branche Neon éphémère,
+mocks `@/lib/auth-guards` comme `users-account.test.ts` — y ajouter
+`requireRole`) :
+
+- promotion `user → admin` (row mise à jour) ;
+- rétrogradation `admin → user` ;
+- idempotence (même rôle demandé → succès, **aucune écriture** : `updatedAt`
+  — qui a `$onUpdate` — doit rester inchangé) ;
+- refus auto-modification ;
+- refus si l'appelant n'est plus admin actif en base (re-check transactionnel) ;
+- refus cible inexistante / soft-deleted ;
+- zod : `role` hors enum refusé.
+
+**Frontend** (happy-dom, `tests/`) : `user-role-section` — bouton selon le
+rôle, cas « propre fiche » (pas de bouton), ouverture du dialog, appel de
+l'action au confirm (action mockée), toast succès/erreur.
+
+## Fichiers touchés
+
+| Fichier                                                                 | Changement                                                     |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `features/users/schemas.ts`                                             | + `updateUserRoleSchema`                                       |
+| `features/users/actions.ts`                                             | + `updateUserRole`                                             |
+| `lib/auth.ts`                                                           | + `disabledPaths` (fermeture des 15 endpoints du plugin admin) |
+| `app/(admin)/admin/utilisateurs/[id]/page.tsx`                          | capture la session, passe `currentUserId`                      |
+| `app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx`            | rend `UserRoleSection` (colonne gauche)                        |
+| `app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx` | nouveau composant                                              |
+| `tests/integration/users-role.test.ts`                                  | nouveau                                                        |
+| `tests/*` (frontend)                                                    | nouveau test composant                                         |
+
+Aucun changement de schéma DB (la colonne, l'enum et l'index `user_role_idx`
+existent déjà) ; aucune migration.

--- a/features/users/actions.ts
+++ b/features/users/actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, eq, isNull, ne } from "drizzle-orm"
+import { and, eq, inArray, isNull, ne } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { headers } from "next/headers"
 import { db } from "@/db"
@@ -12,7 +12,7 @@ import {
   getUserPanelData,
   getUsersWithFilters,
 } from "@/features/users/dal"
-import { profileSchema } from "@/features/users/schemas"
+import { profileSchema, updateUserRoleSchema } from "@/features/users/schemas"
 import { auth } from "@/lib/auth"
 import { requireRole, requireSession } from "@/lib/auth-guards"
 import { createPresignedUpload } from "@/lib/aws"
@@ -49,6 +49,73 @@ export const loadUserPanelData = async (
 ): Promise<UserPanelData | null> => {
   await requireRole(["admin"])
   return getUserPanelData(userId)
+}
+
+// [Admin] Change le rôle d'un utilisateur. Invariant « jamais zéro admin
+// actif » garanti sans compter les admins : l'auto-modification est interdite
+// ET l'appelant est re-vérifié admin actif sous verrou dans la transaction —
+// après l'écriture il reste donc toujours au moins lui. Le verrou couvre la
+// race « l'appelant vient d'être rétrogradé » (requireRole est hors
+// transaction). Pas de révocation de sessions : sans cookieCache, Better Auth
+// relit le rôle en base à chaque requête.
+export const updateUserRole = async (input: {
+  userId: string
+  role: "user" | "admin"
+}): Promise<AccountActionResult> => {
+  const authSession = await requireRole(["admin"])
+
+  const parsed = updateUserRoleSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Données invalides",
+    }
+  }
+  const { userId: targetId, role } = parsed.data
+
+  if (targetId === authSession.user.id) {
+    return {
+      success: false,
+      error: "Vous ne pouvez pas modifier votre propre rôle.",
+    }
+  }
+
+  const result = await db.transaction(async (tx) => {
+    // Un seul SELECT ... FOR UPDATE trié par id : verrouille appelant + cible
+    // dans un ordre déterministe (pas de deadlock entre deux appels croisés).
+    const rows = await tx
+      .select({ id: user.id, role: user.role, deletedAt: user.deletedAt })
+      .from(user)
+      .where(inArray(user.id, [authSession.user.id, targetId]))
+      .orderBy(user.id)
+      .for("update")
+
+    const caller = rows.find((r) => r.id === authSession.user.id)
+    if (!caller || caller.role !== "admin" || caller.deletedAt !== null) {
+      return {
+        ok: false as const,
+        error: "Votre compte n'a plus les droits administrateur.",
+      }
+    }
+
+    const target = rows.find((r) => r.id === targetId)
+    if (!target || target.deletedAt !== null) {
+      return { ok: false as const, error: "Utilisateur introuvable." }
+    }
+
+    if (target.role !== role) {
+      await tx.update(user).set({ role }).where(eq(user.id, targetId))
+    }
+    return { ok: true as const }
+  })
+
+  if (!result.ok) {
+    return { success: false, error: result.error }
+  }
+
+  revalidatePath("/admin/utilisateurs")
+  revalidatePath(`/admin/utilisateurs/${targetId}`)
+  return { success: true }
 }
 
 // Appelée directement depuis le client (édition inline + onboarding) :

--- a/features/users/schemas.ts
+++ b/features/users/schemas.ts
@@ -30,3 +30,8 @@ export const profileSchema = z.object({
 })
 
 export type ProfileFormValues = z.infer<typeof profileSchema>
+
+export const updateUserRoleSchema = z.object({
+  userId: z.string().min(1, "Utilisateur requis"),
+  role: z.enum(["user", "admin"]),
+})

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -102,6 +102,28 @@ export const auth = betterAuth({
           },
         }
       : {},
+  // Le plugin admin n'est configuré que pour porter `role` sur session.user :
+  // ses endpoints HTTP ne sont pas utilisés par l'app et contournent les
+  // gardes applicatives (auto-modification, dernier admin) de updateUserRole /
+  // deleteMyAccount → fermés au routeur (404). Match EXACT : re-vérifier la
+  // liste à chaque montée de version de better-auth.
+  disabledPaths: [
+    "/admin/set-role",
+    "/admin/get-user",
+    "/admin/create-user",
+    "/admin/update-user",
+    "/admin/list-users",
+    "/admin/list-user-sessions",
+    "/admin/unban-user",
+    "/admin/ban-user",
+    "/admin/impersonate-user",
+    "/admin/stop-impersonating",
+    "/admin/revoke-user-session",
+    "/admin/revoke-user-sessions",
+    "/admin/remove-user",
+    "/admin/set-user-password",
+    "/admin/has-permission",
+  ],
   plugins: [
     admin({ defaultRole: "user", adminRoles: ["admin"] }),
     nextCookies(), // ⚠️ DOIT rester le dernier plugin

--- a/tests/components/admin/UserRoleSection.test.tsx
+++ b/tests/components/admin/UserRoleSection.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { UserRoleSection } from "@/app/(admin)/admin/utilisateurs/[id]/_components/user-role-section"
+
+const mocks = vi.hoisted(() => ({
+  updateUserRole: vi.fn(),
+  refresh: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock("@/features/users/actions", () => ({
+  updateUserRole: mocks.updateUserRole,
+}))
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}))
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}))
+vi.mock("motion/react", async () => {
+  const { motionMockFactory } = await import("../../helpers/motion-mock")
+  return motionMockFactory
+})
+
+const baseUser = {
+  id: "user-1",
+  name: "Marie Curie",
+  email: "marie@exemple.com",
+  role: "user" as const,
+}
+
+beforeEach(() => {
+  mocks.updateUserRole.mockReset()
+  mocks.refresh.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.toastError.mockReset()
+  mocks.updateUserRole.mockResolvedValue({ success: true })
+})
+
+describe("UserRoleSection", () => {
+  it("affiche « Promouvoir administrateur » pour un utilisateur simple", () => {
+    render(<UserRoleSection user={baseUser} currentUserId="viewer-1" />)
+    expect(screen.getByTestId("role-toggle-open")).toHaveTextContent(
+      "Promouvoir administrateur",
+    )
+  })
+
+  it("affiche « Retirer le rôle administrateur » pour un admin", () => {
+    render(
+      <UserRoleSection
+        user={{ ...baseUser, role: "admin" }}
+        currentUserId="viewer-1"
+      />,
+    )
+    expect(screen.getByTestId("role-toggle-open")).toHaveTextContent(
+      "Retirer le rôle administrateur",
+    )
+  })
+
+  it("masque le bouton sur sa propre fiche et affiche la note", () => {
+    render(<UserRoleSection user={baseUser} currentUserId={baseUser.id} />)
+    expect(screen.queryByTestId("role-toggle-open")).toBeNull()
+    expect(screen.getByTestId("role-self-note")).toHaveTextContent(
+      "Vous ne pouvez pas modifier votre propre rôle",
+    )
+  })
+
+  it("confirme la promotion : dialog avec nom + email, appel action, refresh", async () => {
+    render(<UserRoleSection user={baseUser} currentUserId="viewer-1" />)
+    fireEvent.click(screen.getByTestId("role-toggle-open"))
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("Marie Curie")
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(
+      "marie@exemple.com",
+    )
+    fireEvent.click(screen.getByTestId("role-toggle-confirm"))
+    await waitFor(() =>
+      expect(mocks.updateUserRole).toHaveBeenCalledWith({
+        userId: "user-1",
+        role: "admin",
+      }),
+    )
+    await waitFor(() => expect(mocks.refresh).toHaveBeenCalled())
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Utilisateur promu administrateur.",
+    )
+  })
+
+  it("demande role=user pour rétrograder un admin", async () => {
+    render(
+      <UserRoleSection
+        user={{ ...baseUser, role: "admin" }}
+        currentUserId="viewer-1"
+      />,
+    )
+    fireEvent.click(screen.getByTestId("role-toggle-open"))
+    fireEvent.click(screen.getByTestId("role-toggle-confirm"))
+    await waitFor(() =>
+      expect(mocks.updateUserRole).toHaveBeenCalledWith({
+        userId: "user-1",
+        role: "user",
+      }),
+    )
+  })
+
+  it("affiche le toast d'erreur et n'appelle pas refresh quand l'action échoue", async () => {
+    mocks.updateUserRole.mockResolvedValue({
+      success: false,
+      error: "Utilisateur introuvable.",
+    })
+    render(<UserRoleSection user={baseUser} currentUserId="viewer-1" />)
+    fireEvent.click(screen.getByTestId("role-toggle-open"))
+    fireEvent.click(screen.getByTestId("role-toggle-confirm"))
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith("Utilisateur introuvable."),
+    )
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument()
+  })
+})

--- a/tests/integration/users-role.test.ts
+++ b/tests/integration/users-role.test.ts
@@ -162,4 +162,37 @@ describe("updateUserRole", () => {
     expect(result.success).toBe(false)
     expect(await getRole(targetId)).toBe("user")
   })
+
+  it("sérialise deux rétrogradations croisées : il reste toujours un admin", async () => {
+    // Deux admins qui se rétrogradent mutuellement en concurrence réelle : le
+    // verrou (SELECT ... ORDER BY id FOR UPDATE) sérialise ; le perdant voit
+    // son propre rôle déjà retiré au re-check sous verrou et échoue. Exactement
+    // un succès, exactement un admin restant — l'invariant « jamais zéro admin
+    // actif » tient sous concurrence, pas seulement séquentiellement.
+    await db.update(user).set({ role: "admin" }).where(eq(user.id, targetId))
+    vi.mocked(requireRole)
+      .mockResolvedValueOnce({
+        user: { id: adminId, email: adminEmail, role: "admin" },
+        session: { id: createId() },
+      } as never)
+      .mockResolvedValueOnce({
+        user: { id: targetId, email: targetEmail, role: "admin" },
+        session: { id: createId() },
+      } as never)
+
+    const [byAdmin, byTarget] = await Promise.all([
+      updateUserRole({ userId: targetId, role: "user" }),
+      updateUserRole({ userId: adminId, role: "user" }),
+    ])
+
+    const results = [byAdmin, byTarget]
+    expect(results.filter((r) => r.success)).toHaveLength(1)
+    const failed = results.find((r) => !r.success)
+    expect(failed?.error).toBe(
+      "Votre compte n'a plus les droits administrateur.",
+    )
+
+    const roles = [await getRole(adminId), await getRole(targetId)]
+    expect(roles.filter((r) => r === "admin")).toHaveLength(1)
+  })
 })

--- a/tests/integration/users-role.test.ts
+++ b/tests/integration/users-role.test.ts
@@ -1,0 +1,163 @@
+import { eq } from "drizzle-orm"
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+import { db } from "@/db"
+import { user } from "@/db/schema"
+import { updateUserRole } from "@/features/users/actions"
+import { requireRole } from "@/lib/auth-guards"
+import { createId } from "@/lib/ids"
+
+// Mêmes stubs que users-account.test.ts : on ne charge pas la stack Better Auth,
+// et les guards sont pilotés par le test (le re-check transactionnel, lui, lit la
+// vraie base — c'est précisément ce qu'on teste).
+vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/auth", () => ({ auth: { api: {} } }))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+const adminId = createId()
+const targetId = createId()
+const adminEmail = `role-admin-${adminId}@test.invalid`
+const targetEmail = `role-target-${targetId}@test.invalid`
+
+const mockCallerSession = () =>
+  vi.mocked(requireRole).mockResolvedValue({
+    user: { id: adminId, email: adminEmail, role: "admin" },
+    session: { id: createId() },
+  } as never)
+
+const getUserRow = async (id: string) => {
+  const [row] = await db
+    .select({ role: user.role, updatedAt: user.updatedAt })
+    .from(user)
+    .where(eq(user.id, id))
+    .limit(1)
+  return row
+}
+
+const getRole = async (id: string) => (await getUserRow(id))?.role
+
+beforeAll(async () => {
+  await db.insert(user).values([
+    {
+      id: adminId,
+      name: "Admin Test",
+      email: adminEmail,
+      emailVerified: true,
+      role: "admin",
+    },
+    {
+      id: targetId,
+      name: "Cible Test",
+      email: targetEmail,
+      emailVerified: true,
+    },
+  ])
+})
+
+afterAll(async () => {
+  await db.delete(user).where(eq(user.id, adminId))
+  await db.delete(user).where(eq(user.id, targetId))
+})
+
+beforeEach(async () => {
+  // Remet l'état de référence : appelant admin actif, cible user active.
+  await db
+    .update(user)
+    .set({ role: "admin", deletedAt: null })
+    .where(eq(user.id, adminId))
+  await db
+    .update(user)
+    .set({ role: "user", deletedAt: null })
+    .where(eq(user.id, targetId))
+  mockCallerSession()
+})
+
+describe("updateUserRole", () => {
+  it("promeut un utilisateur en admin", async () => {
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result).toEqual({ success: true })
+    expect(await getRole(targetId)).toBe("admin")
+  })
+
+  it("rétrograde un admin en utilisateur", async () => {
+    await db.update(user).set({ role: "admin" }).where(eq(user.id, targetId))
+    const result = await updateUserRole({ userId: targetId, role: "user" })
+    expect(result).toEqual({ success: true })
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("est idempotent si le rôle est déjà celui demandé (aucune écriture)", async () => {
+    const before = await getUserRow(targetId)
+    const result = await updateUserRole({ userId: targetId, role: "user" })
+    expect(result).toEqual({ success: true })
+    const after = await getUserRow(targetId)
+    expect(after?.role).toBe("user")
+    // `updatedAt` a $onUpdate (db/schema/auth.ts) : tout UPDATE le bump —
+    // l'égalité prouve qu'aucune écriture n'a eu lieu.
+    expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime())
+  })
+
+  it("refuse l'auto-modification", async () => {
+    const result = await updateUserRole({ userId: adminId, role: "user" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Vous ne pouvez pas modifier votre propre rôle.")
+    expect(await getRole(adminId)).toBe("admin")
+  })
+
+  it("refuse si l'appelant n'est plus admin actif en base (re-check transactionnel)", async () => {
+    // La session mockée dit encore « admin », mais la base a changé entre-temps.
+    await db.update(user).set({ role: "user" }).where(eq(user.id, adminId))
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Votre compte n'a plus les droits administrateur.")
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("refuse si l'appelant est soft-deleted", async () => {
+    await db
+      .update(user)
+      .set({ deletedAt: new Date() })
+      .where(eq(user.id, adminId))
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result.success).toBe(false)
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("refuse une cible inexistante", async () => {
+    const result = await updateUserRole({ userId: createId(), role: "admin" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Utilisateur introuvable.")
+  })
+
+  it("refuse une cible soft-deleted", async () => {
+    await db
+      .update(user)
+      .set({ deletedAt: new Date() })
+      .where(eq(user.id, targetId))
+    const result = await updateUserRole({ userId: targetId, role: "admin" })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("Utilisateur introuvable.")
+    expect(await getRole(targetId)).toBe("user")
+  })
+
+  it("refuse un rôle hors enum (zod)", async () => {
+    const result = await updateUserRole({
+      userId: targetId,
+      role: "superadmin" as never,
+    })
+    expect(result.success).toBe(false)
+    expect(await getRole(targetId)).toBe("user")
+  })
+})

--- a/tests/integration/users-role.test.ts
+++ b/tests/integration/users-role.test.ts
@@ -14,9 +14,8 @@ import { updateUserRole } from "@/features/users/actions"
 import { requireRole } from "@/lib/auth-guards"
 import { createId } from "@/lib/ids"
 
-// Mêmes stubs que users-account.test.ts : on ne charge pas la stack Better Auth,
-// et les guards sont pilotés par le test (le re-check transactionnel, lui, lit la
-// vraie base — c'est précisément ce qu'on teste).
+// Guards mockés, base réelle : le re-check transactionnel lit la vraie base —
+// c'est lui qu'on teste. Le stub de @/lib/auth évite de charger la stack Better Auth.
 vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
 vi.mock("@/lib/auth-guards", () => ({
   requireSession: vi.fn(),
@@ -72,7 +71,6 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
-  // Remet l'état de référence : appelant admin actif, cible user active.
   await db
     .update(user)
     .set({ role: "admin", deletedAt: null })
@@ -164,11 +162,9 @@ describe("updateUserRole", () => {
   })
 
   it("sérialise deux rétrogradations croisées : il reste toujours un admin", async () => {
-    // Deux admins qui se rétrogradent mutuellement en concurrence réelle : le
-    // verrou (SELECT ... ORDER BY id FOR UPDATE) sérialise ; le perdant voit
-    // son propre rôle déjà retiré au re-check sous verrou et échoue. Exactement
-    // un succès, exactement un admin restant — l'invariant « jamais zéro admin
-    // actif » tient sous concurrence, pas seulement séquentiellement.
+    // Le verrou (SELECT ... ORDER BY id FOR UPDATE) sérialise les deux
+    // rétrogradations croisées ; le perdant voit son rôle déjà retiré au
+    // re-check et échoue — il reste toujours exactement un admin.
     await db.update(user).set({ role: "admin" }).where(eq(user.id, targetId))
     vi.mocked(requireRole)
       .mockResolvedValueOnce({

--- a/tests/integration/users-role.test.ts
+++ b/tests/integration/users-role.test.ts
@@ -121,7 +121,9 @@ describe("updateUserRole", () => {
     await db.update(user).set({ role: "user" }).where(eq(user.id, adminId))
     const result = await updateUserRole({ userId: targetId, role: "admin" })
     expect(result.success).toBe(false)
-    expect(result.error).toBe("Votre compte n'a plus les droits administrateur.")
+    expect(result.error).toBe(
+      "Votre compte n'a plus les droits administrateur.",
+    )
     expect(await getRole(targetId)).toBe("user")
   })
 


### PR DESCRIPTION
## Résumé

Permet à un administrateur de promouvoir ou rétrograder n'importe quel utilisateur depuis sa fiche `/admin/utilisateurs/[id]` — plus besoin de modifier la base à la main.

- **Carte « Rôle administrateur »** sur la fiche : bouton promotion/rétrogradation avec dialog de confirmation, toasts, cas « propre fiche » (auto-modification impossible depuis l'UI).
- **Server Action `updateUserRole`** : guard admin → zod → transaction avec verrous `FOR UPDATE` triés par id. Invariant « jamais zéro admin actif » : auto-modification interdite + re-check de l'appelant sous verrou (couvre la race « l'appelant vient d'être rétrogradé »).
- **Fermeture des 15 endpoints HTTP du plugin admin Better Auth** (`disabledPaths`) : ils étaient exposés via la route catch-all sans garde self/dernier-admin (`/admin/set-role`, `/admin/remove-user`…) et l'app ne les utilise pas — `updateUserRole` devient l'unique chemin de mutation du rôle.
- Aucun changement de schéma DB (enum et colonne `role` existants).

Spec et plan embarqués : `docs/superpowers/{specs,plans}/2026-07-05-gestion-role-admin*`.

## Validation

- Revue adversariale du design (6 constats triés avant implémentation) + revue adversariale d'implémentation (verdict : mergeable, zéro constat bloquant).
- Tests d'intégration 227/227 (branche Neon éphémère), dont 10 cas `updateUserRole` incluant une **race de rétrogradations croisées** prouvant l'invariant sous concurrence réelle.
- Tests frontend 884/884 ; `bun run check` vert.
- Smoke test manuel complet (promotion, persistance après reload, rétrogradation, propre fiche, 404 sur les endpoints fermés).

## Hors scope (documenté au spec)

Durcissement du TOCTOU pré-existant de `deleteMyAccount` (rôle lu depuis la session plutôt que sous verrou) — à traiter séparément.