### PR TITLE
chore(ci): Dependabot en écosystème bun + ignores des majeures incompatibles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
-  # Dépendances npm
-  - package-ecosystem: "npm"
+  # Dépendances npm — écosystème "bun" pour que Dependabot régénère bun.lock
+  # (avec "npm" il ne touche que package.json → le CI échoue sur --frozen-lockfile)
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -31,6 +32,17 @@ updates:
           - "*"
         update-types:
           - "major"
+    ignore:
+      # Les types doivent suivre le runtime Node (Vercel/CI = Node 24 LTS)
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # Retirer quand eslint-config-next supportera ESLint 10
+      # (eslint-plugin-react crashe : context.getFilename() supprimé)
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      # Retirer quand Vitest embarquera Vite 8 (v6 importe vite/internal, absent de Vite 7)
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "automated"


### PR DESCRIPTION
## Pourquoi

Les 3 PRs Dependabot (#72, #73, #74) échouaient toutes au CI dès `bun install --frozen-lockfile` : l'écosystème `npm` ne met à jour que `package.json`, jamais `bun.lock`.

## Quoi

- `package-ecosystem: "npm"` → `"bun"` : Dependabot régénère désormais `bun.lock` dans ses PRs (supporté depuis Dependabot ≥ bun 1.1.39, lockfile texte `bun.lock` ✓).
- Ignores des majeures actuellement incompatibles (testées localement sur #74) :
  - `@types/node` : doit suivre le runtime Node 24 LTS (Vercel/CI), pas le dépasser — ignore durable.
  - `eslint` 10 : `eslint-plugin-react` (via eslint-config-next) crashe (`context.getFilename()` supprimé) — retirer quand eslint-config-next supportera ESLint 10.
  - `@vitejs/plugin-react` 6 : importe `vite/internal`, absent du Vite 7 embarqué par Vitest 4.1 — retirer quand Vitest passera à Vite 8.

## Limite connue

L'écosystème `bun` ne supporte que les *version updates* : pas de PRs automatiques de *security updates* (les alertes Dependabot restent actives ; le run hebdomadaire ramassera les correctifs).