### PR TITLE
fix: clé de réponse verrouillée pendant un examen ouvert sur tous les canaux de révision

### DIFF
--- a/features/exams/dal.ts
+++ b/features/exams/dal.ts
@@ -644,7 +644,15 @@ export const getParticipantExamResults = async (
     .where(eq(examQuestions.examId, examId))
     .orderBy(asc(examQuestions.position))
 
-  const imgMap = await fetchImages(items.map((i) => i.questionId))
+  const resultQuestionIds = items.map((i) => i.questionId)
+  // Questions figurant AUSSI dans un examen encore ouvert où le lecteur
+  // participe : correction différée jusqu'à la clôture (clé de réponse).
+  const [imgMap, lockedIds] = await Promise.all([
+    fetchImages(resultQuestionIds),
+    isAdmin
+      ? new Set<string>()
+      : getOpenExamLockedQuestionIds(session.user.id, resultQuestionIds),
+  ])
 
   const questionsView: ExamQuestionView[] = items.map((i) => ({
     _id: i.questionId,
@@ -654,7 +662,7 @@ export const getParticipantExamResults = async (
     objectifCMC: i.objectifCMC,
     domain: i.domain,
     images: imgMap.get(i.questionId) ?? [],
-    correctAnswer: i.correctAnswer,
+    ...(lockedIds.has(i.questionId) ? {} : { correctAnswer: i.correctAnswer }),
   }))
 
   const answerRows = await db
@@ -678,7 +686,8 @@ export const getParticipantExamResults = async (
       answers: answerRows.map((a) => ({
         questionId: a.questionId,
         selectedAnswer: a.selectedAnswer ?? null,
-        isCorrect: a.isCorrect ?? null,
+        // isCorrect + selectedAnswer révèle la clé → masqué si verrouillée.
+        isCorrect: lockedIds.has(a.questionId) ? null : (a.isCorrect ?? null),
       })),
     },
     participantUser,
@@ -698,6 +707,37 @@ export type QuestionExplanationView = {
 }
 
 /**
+ * Parmi `questionIds`, celles appartenant à un examen OUVERT (`endDate` future)
+ * où `userId` a une participation (tout statut). La banque de questions étant
+ * partagée training/examens, la clé de réponse de ces questions ne doit fuiter
+ * par AUCUN canal de révision pendant la fenêtre d'examen (explications lazy,
+ * correction d'entraînement). Compromis assumé : la révision training de ces
+ * questions est différée jusqu'à la clôture de l'examen.
+ */
+export const getOpenExamLockedQuestionIds = async (
+  userId: string,
+  questionIds: string[],
+): Promise<Set<string>> => {
+  if (questionIds.length === 0) return new Set()
+  const rows = await db
+    .selectDistinct({ questionId: examQuestions.questionId })
+    .from(examQuestions)
+    .innerJoin(exams, eq(exams.id, examQuestions.examId))
+    .innerJoin(
+      examParticipations,
+      eq(examParticipations.examId, examQuestions.examId),
+    )
+    .where(
+      and(
+        eq(examParticipations.userId, userId),
+        gt(exams.endDate, new Date()),
+        inArray(examQuestions.questionId, questionIds),
+      ),
+    )
+  return new Set(rows.map((r) => r.questionId))
+}
+
+/**
  * Explications à la demande (déplier une question dans les résultats). Sécurité :
  * admin (bypass) OU l'utilisateur a une session de training COMPLÉTÉE contenant
  * la question, OU une participation COMPLÉTÉE à un examen **CLOS** (`endDate`
@@ -708,7 +748,9 @@ export type QuestionExplanationView = {
  * termine tôt de tirer explications + références + images (= les bonnes réponses)
  * AVANT l'ouverture des résultats et de les partager pendant la fenêtre d'examen.
  * Parité avec `getParticipantExamResults` (résultats visibles après `endDate`).
- * La branche training n'a PAS de garde temporelle (révélation à la complétion).
+ * Les DEUX branches sont ensuite filtrées par `getOpenExamLockedQuestionIds`
+ * (banque partagée : ni le training ni un examen clos ne doivent révéler une
+ * question d'un examen encore ouvert).
  */
 export const getExamQuestionExplanations = async (
   questionIds: string[],
@@ -725,7 +767,7 @@ export const getExamQuestionExplanations = async (
   } else {
     const uid = session.user.id
     const nowDate = new Date()
-    const [viaExam, viaTraining] = await Promise.all([
+    const [viaExam, viaTraining, locked] = await Promise.all([
       db
         .selectDistinct({ questionId: examQuestions.questionId })
         .from(examQuestions)
@@ -758,13 +800,16 @@ export const getExamQuestionExplanations = async (
             inArray(trainingSessionItems.questionId, requested),
           ),
         ),
+      getOpenExamLockedQuestionIds(uid, requested),
     ])
+    // Les DEUX branches sont filtrées : un examen clos complété ne doit pas
+    // révéler une question qui figure aussi dans un examen encore ouvert.
     authorized = [
       ...new Set([
         ...viaExam.map((r) => r.questionId),
         ...viaTraining.map((r) => r.questionId),
       ]),
-    ]
+    ].filter((id) => !locked.has(id))
   }
 
   if (authorized.length === 0) return []

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema"
 import { requireSession } from "@/lib/auth-guards"
 import { createId } from "@/lib/ids"
+import { getOpenExamLockedQuestionIds } from "../exams/dal"
 import { hasAccess } from "../payments/dal"
 import {
   type ObjectifsView,
@@ -297,6 +298,15 @@ export const saveTrainingAnswer = async (
 
     // Mode tuteur : révéler la bonne réponse + explication immédiatement.
     if (s.mode === "tutor") {
+      // Question d'un examen OUVERT où l'utilisateur participe : reveal différé
+      // jusqu'à la clôture (même verrou que getTrainingSessionById) — la réponse
+      // est enregistrée, seule la correction est retenue.
+      if (session.user.role !== "admin") {
+        const locked = await getOpenExamLockedQuestionIds(session.user.id, [
+          questionId,
+        ])
+        if (locked.has(questionId)) return { success: true }
+      }
       const [exp] = await db
         .select({
           explanation: questionExplanations.explanation,

--- a/features/training/dal.ts
+++ b/features/training/dal.ts
@@ -23,6 +23,7 @@ import {
 import { requireSession } from "@/lib/auth-guards"
 import { cdnUrl } from "@/lib/cdn"
 import { getCurrentSession } from "@/lib/dal"
+import { getOpenExamLockedQuestionIds } from "../exams/dal"
 
 const clamp = (n: number, lo: number, hi: number) =>
   Math.min(Math.max(lo, Math.floor(n)), hi)
@@ -538,11 +539,21 @@ export const getTrainingSessionById = async (
     .where(eq(trainingSessionItems.sessionId, sessionId))
     .orderBy(asc(trainingSessionItems.position))
 
-  const imgMap = await fetchImages(items.map((i) => i.questionId))
+  const sessionQuestionIds = items.map((i) => i.questionId)
+  // Questions d'un examen OUVERT où l'utilisateur participe : clé de réponse
+  // différée jusqu'à la clôture (voir getOpenExamLockedQuestionIds).
+  const [imgMap, lockedIds] = await Promise.all([
+    fetchImages(sessionQuestionIds),
+    session.user.role === "admin"
+      ? new Set<string>()
+      : getOpenExamLockedQuestionIds(session.user.id, sessionQuestionIds),
+  ])
 
   const questionsView: TrainingSessionQuestion[] = items.map((i) => {
     // In tutor mode, reveal correctAnswer + explanation + references for already-answered questions.
-    const revealAnswer = isCompleted || (isTutor && i.selectedAnswer !== null)
+    const revealAnswer =
+      (isCompleted || (isTutor && i.selectedAnswer !== null)) &&
+      !lockedIds.has(i.questionId)
     return {
       _id: i.questionId,
       _creationTime: i.qCreatedAt.getTime(),
@@ -562,14 +573,19 @@ export const getTrainingSessionById = async (
   })
 
   // Reveal isCorrect in answers only when session is completed or in tutor mode.
-  // In test mode in_progress: no isCorrect leak.
+  // In test mode in_progress: no isCorrect leak. isCorrect + selectedAnswer
+  // révèle la clé → masqué aussi pour les questions verrouillées.
   const revealAnswers = isCompleted || isTutor
   const answers: TrainingAnswerRecord = {}
   for (const i of items) {
     if (i.selectedAnswer !== null) {
-      answers[i.questionId] = revealAnswers
-        ? { selectedAnswer: i.selectedAnswer, isCorrect: i.isCorrect ?? false }
-        : { selectedAnswer: i.selectedAnswer }
+      answers[i.questionId] =
+        revealAnswers && !lockedIds.has(i.questionId)
+          ? {
+              selectedAnswer: i.selectedAnswer,
+              isCorrect: i.isCorrect ?? false,
+            }
+          : { selectedAnswer: i.selectedAnswer }
     }
   }
 
@@ -662,9 +678,14 @@ export const getTrainingSessionResults = async (
   const questionIds = items.map((i) => i.questionId)
   // Session complétée → révélation : images d'énoncé ET d'explication. Le canal
   // explication reste séparé du pont d'énoncé `images` (anti-fuite en passation).
-  const [imgMap, explImgMap] = await Promise.all([
+  // Questions d'un examen OUVERT où l'utilisateur participe : correction différée
+  // jusqu'à la clôture (voir getOpenExamLockedQuestionIds).
+  const [imgMap, explImgMap, lockedIds] = await Promise.all([
     fetchImages(questionIds),
     fetchImages(questionIds, "explanation"),
+    session.user.role === "admin"
+      ? new Set<string>()
+      : getOpenExamLockedQuestionIds(session.user.id, questionIds),
   ])
 
   const questionsView: TrainingSessionQuestion[] = items.map((i) => ({
@@ -675,10 +696,14 @@ export const getTrainingSessionResults = async (
     objectifCMC: i.objectifCMC,
     domain: i.domain,
     images: imgMap.get(i.questionId) ?? [],
-    correctAnswer: i.correctAnswer,
-    explanation: i.explanation ?? "",
-    references: i.references ?? [],
-    explanationImages: explImgMap.get(i.questionId) ?? [],
+    ...(lockedIds.has(i.questionId)
+      ? {}
+      : {
+          correctAnswer: i.correctAnswer,
+          explanation: i.explanation ?? "",
+          references: i.references ?? [],
+          explanationImages: explImgMap.get(i.questionId) ?? [],
+        }),
   }))
 
   const answers: TrainingAnswerRecord = {}
@@ -686,7 +711,10 @@ export const getTrainingSessionResults = async (
     if (i.selectedAnswer !== null) {
       answers[i.questionId] = {
         selectedAnswer: i.selectedAnswer,
-        isCorrect: i.isCorrect ?? undefined,
+        // isCorrect + selectedAnswer révèle la clé → masqué si verrouillée.
+        ...(lockedIds.has(i.questionId)
+          ? {}
+          : { isCorrect: i.isCorrect ?? undefined }),
       }
     }
   }

--- a/tests/integration/exams.test.ts
+++ b/tests/integration/exams.test.ts
@@ -54,8 +54,10 @@ const STUDENT_ID = createId()
 const INTRUDER_ID = createId()
 const NOACCESS_ID = createId()
 const PID = createId()
-// 8 questions : q0..q5 examens, q6 = témoin non autorisé, q7 = training seul.
-const qIds = Array.from({ length: 8 }, () => createId())
+// 11 questions : q0..q5 examens, q6 = témoin non autorisé, q7 = training seul,
+// q8 = chevauchement training + examen clos, q9 = training + examen ouvert,
+// q10 = examen clos SEUL (aucun chevauchement).
+const qIds = Array.from({ length: 11 }, () => createId())
 const examQIds = qIds.slice(0, 6)
 
 const setSession = (id: string, role: "user" | "admin") =>
@@ -112,6 +114,8 @@ const makeExam = async (opts: {
 
 let noPauseId: string
 let pauseId: string
+let pastExamId: string
+let closedOnlyExamId: string
 let pauseOrderedIds: string[] = []
 
 beforeAll(async () => {
@@ -166,10 +170,10 @@ afterAll(async () => {
   // Supprimer les examens cascade participations/réponses/jonctions.
   await db.delete(exams).where(eq(exams.createdBy, ADMIN_ID))
   // Sessions training (cascade items) avant les questions (FK restrict sur items).
+  const uids = [ADMIN_ID, STUDENT_ID, INTRUDER_ID, NOACCESS_ID]
   await db
     .delete(trainingSessions)
-    .where(eq(trainingSessions.userId, STUDENT_ID))
-  const uids = [ADMIN_ID, STUDENT_ID, INTRUDER_ID, NOACCESS_ID]
+    .where(inArray(trainingSessions.userId, uids))
   await db.delete(userAccess).where(inArray(userAccess.userId, uids))
   await db.delete(transactions).where(inArray(transactions.userId, uids))
   await db
@@ -494,10 +498,32 @@ describe("deleteParticipation (admin)", () => {
 })
 
 describe("Gardes d'accès post-endDate + TIME_UP (F3)", () => {
-  let pastExamId: string
-
   beforeAll(async () => {
     const now = Date.now()
+    // Examen clos SEUL (q10, aucun chevauchement avec un examen ouvert) +
+    // participation complétée : le témoin « révélation après endDate ».
+    closedOnlyExamId = await makeExam({
+      questionIds: [qIds[10]],
+      startDate: now - 3 * DAY,
+      endDate: now - DAY,
+    })
+    const closedOnlyPartId = createId()
+    await db.insert(examParticipations).values({
+      id: closedOnlyPartId,
+      examId: closedOnlyExamId,
+      userId: STUDENT_ID,
+      status: "completed",
+      score: 100,
+      startedAt: new Date(now - 3 * DAY + 1000),
+      completedAt: new Date(now - 2 * DAY),
+    })
+    await db.insert(examAnswers).values({
+      id: createId(),
+      participationId: closedOnlyPartId,
+      questionId: qIds[10],
+      selectedAnswer: "A",
+      isCorrect: true,
+    })
     // Examen terminé (endDate dans le passé) + participation complétée seedée
     // directement (startExam refuserait hors fenêtre).
     pastExamId = await makeExam({
@@ -585,10 +611,10 @@ describe("Gardes d'accès post-endDate + TIME_UP (F3)", () => {
   })
 
   it("explications révélées après endDate (examen CLOS complété)", async () => {
-    // L'étudiant a une participation complétée sur pastExamId (endDate passée)
-    // contenant examQIds → les explications sont désormais autorisées.
+    // Participation complétée sur closedOnlyExamId (endDate passée) contenant
+    // q10, qui n'appartient à aucun examen ouvert → explication autorisée.
     asStudent()
-    const r = await getExamQuestionExplanations([examQIds[0]])
+    const r = await getExamQuestionExplanations([qIds[10]])
     expect(r).toHaveLength(1)
     expect(r[0].explanation).toContain("Explication")
   })
@@ -643,5 +669,124 @@ describe("Gardes d'accès post-endDate + TIME_UP (F3)", () => {
     if (!res.success) return
     expect(res.totalQuestions).toBe(0)
     expect(res.score).toBe(0)
+  })
+})
+
+describe("Anti-triche : chevauchement training / examen OUVERT", () => {
+  const seedCompletedTraining = async (userId: string, questionId: string) => {
+    const now = Date.now()
+    const tsId = createId()
+    await db.insert(trainingSessions).values({
+      id: tsId,
+      userId,
+      status: "completed",
+      questionCount: 1,
+      startedAt: new Date(now - 3600_000),
+      completedAt: new Date(now - 3500_000),
+      expiresAt: new Date(now + DAY),
+    })
+    await db.insert(trainingSessionItems).values({
+      id: createId(),
+      sessionId: tsId,
+      questionId,
+      position: 0,
+      selectedAnswer: "A",
+      isCorrect: true,
+    })
+  }
+
+  beforeAll(async () => {
+    const now = Date.now()
+    // q9 : examen OUVERT complété tôt par STUDENT + training complété. q9 ne doit
+    // appartenir à aucun examen CLOS, sinon la branche examen l'autorise (trou
+    // jumeau connu, hors périmètre ici).
+    const openId = await makeExam({ questionIds: [qIds[9]] })
+    await db.insert(examParticipations).values({
+      id: createId(),
+      examId: openId,
+      userId: STUDENT_ID,
+      status: "completed",
+      score: 100,
+      startedAt: new Date(now - 2000),
+      completedAt: new Date(now - 1000),
+    })
+    await seedCompletedTraining(STUDENT_ID, qIds[9])
+    // INTRUDER : participation in_progress + training sur q1.
+    await db.insert(examParticipations).values({
+      id: createId(),
+      examId: noPauseId,
+      userId: INTRUDER_ID,
+      status: "in_progress",
+      score: 0,
+      startedAt: new Date(now - 1000),
+    })
+    await seedCompletedTraining(INTRUDER_ID, qIds[1])
+    // q8 : examen CLOS + training complété → seuls les examens OUVERTS doivent
+    // bloquer la branche training. Participation in_progress : la branche examen
+    // (completed/auto_submitted) ne peut pas accorder q8 — si le test passe,
+    // c'est bien la branche training qui a servi l'explication.
+    const closedId = await makeExam({
+      questionIds: [qIds[8]],
+      startDate: now - 3 * DAY,
+      endDate: now - DAY,
+    })
+    await db.insert(examParticipations).values({
+      id: createId(),
+      examId: closedId,
+      userId: STUDENT_ID,
+      status: "in_progress",
+      score: 0,
+      startedAt: new Date(now - 3 * DAY + 1000),
+    })
+    await seedCompletedTraining(STUDENT_ID, qIds[8])
+  })
+
+  it("participation complétée sur un examen ouvert : le training ne révèle pas la question", async () => {
+    asStudent()
+    expect(await getExamQuestionExplanations([qIds[9]])).toEqual([])
+  })
+
+  it("participation in_progress sur un examen ouvert : le training ne révèle pas la question", async () => {
+    asIntruder()
+    expect(await getExamQuestionExplanations([qIds[1]])).toEqual([])
+  })
+
+  it("examen clos chevauchant : l'explication reste servie via le training", async () => {
+    asStudent()
+    expect(await getExamQuestionExplanations([qIds[8]])).toHaveLength(1)
+  })
+
+  it("branche examen : question d'un examen clos masquée si elle chevauche un examen ouvert", async () => {
+    // q0 : examen clos complété (pastExamId) MAIS aussi examens ouverts où
+    // STUDENT participe → la révélation post-endDate est différée.
+    asStudent()
+    expect(await getExamQuestionExplanations([examQIds[0]])).toEqual([])
+  })
+
+  it("getParticipantExamResults : correctAnswer/isCorrect masqués pour les questions chevauchant un examen ouvert", async () => {
+    asStudent()
+    const r = await getParticipantExamResults(pastExamId, STUDENT_ID)
+    expect(r && "participant" in r).toBe(true)
+    if (!r || "error" in r) return
+
+    const q0 = r.questions.find((q) => q._id === examQIds[0])
+    expect(q0).toBeDefined()
+    expect(q0?.correctAnswer).toBeUndefined()
+
+    const a0 = r.participant.answers.find((a) => a.questionId === examQIds[0])
+    expect(a0?.selectedAnswer).toBe("A")
+    expect(a0?.isCorrect).toBeNull()
+  })
+
+  it("getParticipantExamResults : examen clos sans chevauchement → correction servie", async () => {
+    asStudent()
+    const r = await getParticipantExamResults(closedOnlyExamId, STUDENT_ID)
+    expect(r && "participant" in r).toBe(true)
+    if (!r || "error" in r) return
+
+    expect(r.questions.find((q) => q._id === qIds[10])?.correctAnswer).toBe("A")
+    expect(
+      r.participant.answers.find((a) => a.questionId === qIds[10])?.isCorrect,
+    ).toBe(true)
   })
 })

--- a/tests/integration/training.test.ts
+++ b/tests/integration/training.test.ts
@@ -10,9 +10,13 @@ import {
 } from "vitest"
 import { db } from "@/db"
 import {
+  examParticipations,
+  examQuestions,
+  exams,
   questionExplanations,
   questionImages,
   questions,
+  trainingSessionItems,
   trainingSessions,
   user,
 } from "@/db/schema"
@@ -355,5 +359,153 @@ describe("IDOR / propriété", () => {
       selectedAnswer: "A",
     })
     expect(save.success).toBe(false)
+  })
+})
+
+describe("anti-triche : correction training masquée pendant un examen ouvert", () => {
+  const DAY = 24 * 60 * 60 * 1000
+  const STUDENT2_ID = createId()
+  const completedSid = createId()
+  const tutorSid = createId()
+  // q0 : examen OUVERT (participation) → masqué. q1 : examen CLOS → servi.
+  // q2 : hors examen → servi.
+
+  const asStudent2 = () =>
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: STUDENT2_ID, role: "user" },
+    } as never)
+
+  const seedExam = async (endDate: Date, questionId: string) => {
+    const examId = createId()
+    await db.insert(exams).values({
+      id: examId,
+      title: `Exam lock ${suffix}`,
+      startDate: new Date(Date.now() - DAY),
+      endDate,
+      completionTime: 3600,
+      createdBy: STUDENT2_ID,
+    })
+    await db.insert(examQuestions).values({ examId, questionId, position: 0 })
+    await db.insert(examParticipations).values({
+      id: createId(),
+      examId,
+      userId: STUDENT2_ID,
+      status: "in_progress",
+      startedAt: new Date(),
+    })
+  }
+
+  const seedSession = async (o: {
+    id: string
+    mode: "tutor" | "test"
+    status: "in_progress" | "completed"
+    questionIds: string[]
+  }) => {
+    const now = Date.now()
+    await db.insert(trainingSessions).values({
+      id: o.id,
+      userId: STUDENT2_ID,
+      status: o.status,
+      mode: o.mode,
+      questionCount: o.questionIds.length,
+      startedAt: new Date(now - 3600_000),
+      completedAt: o.status === "completed" ? new Date(now - 1000) : null,
+      expiresAt: new Date(now + DAY),
+      score: o.status === "completed" ? 100 : null,
+    })
+    await db.insert(trainingSessionItems).values(
+      o.questionIds.map((questionId, position) => ({
+        id: createId(),
+        sessionId: o.id,
+        questionId,
+        position,
+        selectedAnswer: "A",
+        isCorrect: true,
+      })),
+    )
+  }
+
+  beforeAll(async () => {
+    await db.insert(user).values({
+      id: STUDENT2_ID,
+      name: "IT training lock",
+      email: `training-lock-${suffix}@test.invalid`,
+    })
+    await seedExam(new Date(Date.now() + DAY), qIds[0])
+    await seedExam(new Date(Date.now() - DAY), qIds[1])
+    await seedSession({
+      id: completedSid,
+      mode: "test",
+      status: "completed",
+      questionIds: [qIds[0], qIds[1], qIds[2]],
+    })
+    await seedSession({
+      id: tutorSid,
+      mode: "tutor",
+      status: "in_progress",
+      questionIds: [qIds[0], qIds[2]],
+    })
+  })
+
+  afterAll(async () => {
+    await db
+      .delete(trainingSessions)
+      .where(eq(trainingSessions.userId, STUDENT2_ID))
+    await db.delete(exams).where(eq(exams.createdBy, STUDENT2_ID))
+    await db.delete(user).where(eq(user.id, STUDENT2_ID))
+  })
+
+  const byId = <T extends { _id: string }>(qs: T[], id: string) =>
+    qs.find((q) => q._id === id)
+
+  it("getTrainingSessionResults : la question d'un examen ouvert est masquée, les autres servies", async () => {
+    asStudent2()
+    const r = await getTrainingSessionResults(completedSid)
+    expect(r && !("error" in r)).toBe(true)
+    if (!r || "error" in r) return
+
+    const locked = byId(r.questions, qIds[0])
+    expect(locked?.correctAnswer).toBeUndefined()
+    expect(locked?.explanation).toBeUndefined()
+    expect(locked?.references).toBeUndefined()
+
+    expect(byId(r.questions, qIds[1])?.correctAnswer).toBe("A")
+    expect(byId(r.questions, qIds[2])?.explanation).toContain("Explication")
+
+    // isCorrect + selectedAnswer révèle la clé : masqué pour la question
+    // verrouillée, servi pour les autres.
+    expect(r.answers[qIds[0]]?.selectedAnswer).toBe("A")
+    expect(r.answers[qIds[0]]?.isCorrect).toBeUndefined()
+    expect(r.answers[qIds[1]]?.isCorrect).toBe(true)
+  })
+
+  it("getTrainingSessionById (complétée) : même masquage", async () => {
+    asStudent2()
+    const v = await getTrainingSessionById(completedSid)
+    expect(v).not.toBeNull()
+    if (!v) return
+
+    expect(byId(v.questions, qIds[0])?.correctAnswer).toBeUndefined()
+    expect(byId(v.questions, qIds[1])?.correctAnswer).toBe("A")
+    expect(byId(v.questions, qIds[2])?.correctAnswer).toBe("A")
+
+    expect(v.answers[qIds[0]]?.selectedAnswer).toBe("A")
+    expect(v.answers[qIds[0]]?.isCorrect).toBeUndefined()
+    expect(v.answers[qIds[1]]?.isCorrect).toBe(true)
+  })
+
+  it("getTrainingSessionById (tuteur, question répondue) : masquage malgré la révélation tuteur", async () => {
+    asStudent2()
+    const v = await getTrainingSessionById(tutorSid)
+    expect(v).not.toBeNull()
+    if (!v) return
+
+    expect(byId(v.questions, qIds[0])?.correctAnswer).toBeUndefined()
+    expect(byId(v.questions, qIds[0])?.explanation).toBeUndefined()
+    expect(byId(v.questions, qIds[2])?.correctAnswer).toBe("A")
+
+    expect(v.answers[qIds[0]]?.selectedAnswer).toBe("A")
+    expect(v.answers[qIds[0]]?.isCorrect).toBeUndefined()
+    expect(v.answers[qIds[2]]?.isCorrect).toBe(true)
   })
 })

--- a/tests/integration/training.test.ts
+++ b/tests/integration/training.test.ts
@@ -13,12 +13,15 @@ import {
   examParticipations,
   examQuestions,
   exams,
+  products,
   questionExplanations,
   questionImages,
   questions,
   trainingSessionItems,
   trainingSessions,
+  transactions,
   user,
+  userAccess,
 } from "@/db/schema"
 import {
   abandonTrainingSession,
@@ -425,11 +428,44 @@ describe("anti-triche : correction training masquée pendant un examen ouvert", 
     )
   }
 
+  const PID2 = createId()
+  const TXID2 = createId()
+
   beforeAll(async () => {
     await db.insert(user).values({
       id: STUDENT2_ID,
       name: "IT training lock",
       email: `training-lock-${suffix}@test.invalid`,
+    })
+    // Accès training réel : saveTrainingAnswer exige hasAccess pour un non-admin.
+    await db.insert(products).values({
+      id: PID2,
+      code: "training_access",
+      name: `Training ${suffix}`,
+      description: "desc",
+      priceCad: 3000,
+      durationDays: 30,
+      accessType: "training",
+      stripeProductId: `prod_t_${suffix}`,
+      stripePriceId: `price_t_${suffix}`,
+    })
+    await db.insert(transactions).values({
+      id: TXID2,
+      userId: STUDENT2_ID,
+      productId: PID2,
+      type: "manual",
+      status: "completed",
+      amountPaid: 3000,
+      currency: "CAD",
+      accessType: "training",
+      durationDays: 30,
+      accessExpiresAt: new Date(Date.now() + 30 * DAY),
+    })
+    await db.insert(userAccess).values({
+      userId: STUDENT2_ID,
+      accessType: "training",
+      expiresAt: new Date(Date.now() + 30 * DAY),
+      lastTransactionId: TXID2,
     })
     await seedExam(new Date(Date.now() + DAY), qIds[0])
     await seedExam(new Date(Date.now() - DAY), qIds[1])
@@ -452,6 +488,9 @@ describe("anti-triche : correction training masquée pendant un examen ouvert", 
       .delete(trainingSessions)
       .where(eq(trainingSessions.userId, STUDENT2_ID))
     await db.delete(exams).where(eq(exams.createdBy, STUDENT2_ID))
+    await db.delete(userAccess).where(eq(userAccess.userId, STUDENT2_ID))
+    await db.delete(transactions).where(eq(transactions.userId, STUDENT2_ID))
+    await db.delete(products).where(eq(products.id, PID2))
     await db.delete(user).where(eq(user.id, STUDENT2_ID))
   })
 
@@ -507,5 +546,26 @@ describe("anti-triche : correction training masquée pendant un examen ouvert", 
     expect(v.answers[qIds[0]]?.selectedAnswer).toBe("A")
     expect(v.answers[qIds[0]]?.isCorrect).toBeUndefined()
     expect(v.answers[qIds[2]]?.isCorrect).toBe(true)
+  })
+
+  it("saveTrainingAnswer (tuteur) : pas de reveal immédiat pour une question d'un examen ouvert", async () => {
+    asStudent2()
+    const locked = await saveTrainingAnswer({
+      sessionId: tutorSid,
+      questionId: qIds[0],
+      selectedAnswer: "A",
+    })
+    expect(locked).toEqual({ success: true })
+
+    const served = await saveTrainingAnswer({
+      sessionId: tutorSid,
+      questionId: qIds[2],
+      selectedAnswer: "A",
+    })
+    expect(served).toMatchObject({
+      success: true,
+      isCorrect: true,
+      reveal: { correctAnswer: "A" },
+    })
   })
 })


### PR DESCRIPTION
## Problème

La banque de questions est partagée entre l'entraînement et les examens blancs. Pendant la fenêtre d'un examen OUVERT, un candidat pouvait récupérer la clé de réponse (`correctAnswer`, `explanation`, `references`, `isCorrect`) de questions de l'examen par plusieurs canaux de révision légitimes, dès lors que la question figurait aussi dans une de ses sessions d'entraînement ou dans un examen clos complété.

## Solution

Garde centralisée `getOpenExamLockedQuestionIds(userId, questionIds)` (`features/exams/dal.ts`) : parmi les questions demandées, celles appartenant à un examen ouvert (`endDate > now`) où l'utilisateur a une participation (tout statut). Appliquée aux **cinq canaux** :

- `getExamQuestionExplanations` — branches training **et** examen clos ;
- `getTrainingSessionById` — passation/correction, révélation tuteur incluse ;
- `getTrainingSessionResults` — page de résultats d'entraînement ;
- `getParticipantExamResults` — résultats d'examen (`correctAnswer` + `isCorrect`) ;
- `saveTrainingAnswer` — reveal immédiat du mode tuteur (2ᵉ commit, constat de revue adversariale).

Compromis assumé (commenté dans le code) : la correction d'entraînement de ces questions est différée jusqu'à la clôture de l'examen. Admin exempté. Masquage par omission de champs — les types optionnels et le rendu passation existants gèrent l'absence.

## Tests

10 tests d'intégration (TDD, chaque comportement vu ROUGE avant implémentation) dans `exams.test.ts` et `training.test.ts` : fuite bloquée par canal, témoins « examen clos seul » (révélation post-`endDate` préservée) et « training hors examen » (mode révision intact).

Gates : `bun run check` ✅ · frontend 884 ✅ · intégration 237 ✅ (branche rebasée sur main).

## Notes

- Deux revues adversariales (sessions séparées) : la première a fait étendre le fix initial (jugé cosmétique) à tous les canaux ; la seconde a validé le delta et fait ajouter le verrou du reveal tuteur.
- Canal public restant : #91 (quiz marketing, hors périmètre de cette PR).

Closes #86