### PR TITLE
fix: clôture des sessions d'entraînement gardée sur le statut + refus des sessions expirées

### DIFF
--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -262,10 +262,16 @@ export const saveTrainingAnswer = async (
       return fail("Cette session n'est plus active")
     }
     if (s.expiresAt.getTime() < Date.now()) {
+      // Garde de statut : ne pas écraser une clôture concurrente (cron/autre onglet).
       await db
         .update(trainingSessions)
         .set({ status: "abandoned" })
-        .where(eq(trainingSessions.id, sessionId))
+        .where(
+          and(
+            eq(trainingSessions.id, sessionId),
+            eq(trainingSessions.status, "in_progress"),
+          ),
+        )
       return fail("Cette session a expiré")
     }
     if (session.user.role !== "admin" && !(await hasAccess("training"))) {
@@ -348,6 +354,7 @@ export const completeTrainingSession = async ({
         userId: trainingSessions.userId,
         status: trainingSessions.status,
         questionCount: trainingSessions.questionCount,
+        expiresAt: trainingSessions.expiresAt,
       })
       .from(trainingSessions)
       .where(eq(trainingSessions.id, sessionId))
@@ -358,6 +365,20 @@ export const completeTrainingSession = async ({
     }
     if (s.status !== "in_progress") {
       return fail("Cette session n'est plus active")
+    }
+    if (s.expiresAt.getTime() < Date.now()) {
+      // Parité saveTrainingAnswer : une session expirée ne se score pas, elle
+      // bascule abandonnée (garde de statut contre une clôture concurrente).
+      await db
+        .update(trainingSessions)
+        .set({ status: "abandoned" })
+        .where(
+          and(
+            eq(trainingSessions.id, sessionId),
+            eq(trainingSessions.status, "in_progress"),
+          ),
+        )
+      return fail("Cette session a expiré")
     }
     if (session.user.role !== "admin" && !(await hasAccess("training"))) {
       return fail("Votre accès à l'entraînement a expiré.")
@@ -378,10 +399,21 @@ export const completeTrainingSession = async ({
     const score =
       totalQuestions > 0 ? Math.round((correctCount / totalQuestions) * 100) : 0
 
-    await db
+    // Garde de statut (règle concurrence du repo) : le cron d'expiration ou un
+    // appel concurrent peut avoir clos la session entre la lecture et l'écriture.
+    const updated = await db
       .update(trainingSessions)
       .set({ status: "completed", score, completedAt: new Date() })
-      .where(eq(trainingSessions.id, sessionId))
+      .where(
+        and(
+          eq(trainingSessions.id, sessionId),
+          eq(trainingSessions.status, "in_progress"),
+        ),
+      )
+      .returning({ id: trainingSessions.id })
+    if (updated.length === 0) {
+      return fail("Cette session n'est plus active")
+    }
 
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true, score, correctCount, totalQuestions }
@@ -417,10 +449,21 @@ export const abandonTrainingSession = async ({
       return fail("Cette session n'est pas en cours")
     }
 
-    await db
+    // Garde de statut (pattern du cron) : ne jamais écraser une clôture
+    // concurrente (ex. re-basculer une session completed en abandoned).
+    const updated = await db
       .update(trainingSessions)
       .set({ status: "abandoned" })
-      .where(eq(trainingSessions.id, sessionId))
+      .where(
+        and(
+          eq(trainingSessions.id, sessionId),
+          eq(trainingSessions.status, "in_progress"),
+        ),
+      )
+      .returning({ id: trainingSessions.id })
+    if (updated.length === 0) {
+      return fail("Cette session n'est pas en cours")
+    }
 
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true }

--- a/tests/integration/training-concurrency.test.ts
+++ b/tests/integration/training-concurrency.test.ts
@@ -1,0 +1,157 @@
+import { eq } from "drizzle-orm"
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+import { db } from "@/db"
+import {
+  questions,
+  trainingSessionItems,
+  trainingSessions,
+  user,
+} from "@/db/schema"
+import {
+  abandonTrainingSession,
+  completeTrainingSession,
+} from "@/features/training/actions"
+import { getCurrentSession } from "@/lib/dal"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
+
+const DAY = 24 * 60 * 60 * 1000
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const QID = createId()
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: "IT concurrence",
+    email: `conc-${suffix}@test.invalid`,
+  })
+  await db.insert(questions).values({
+    id: QID,
+    question: `Q ${suffix} ?`,
+    correctAnswer: "A",
+    options: ["A", "B", "C", "D"],
+    objectifCmc: `Obj ${suffix}`,
+    domain: `CONC-${suffix}`,
+  })
+})
+
+beforeEach(() => {
+  vi.mocked(getCurrentSession).mockResolvedValue({
+    user: { id: USER_ID, role: "admin" },
+  } as never)
+})
+
+const seedSession = async (o: {
+  status: "in_progress" | "completed" | "abandoned"
+  expiresAt: Date
+}) => {
+  const id = createId()
+  const now = Date.now()
+  await db.insert(trainingSessions).values({
+    id,
+    userId: USER_ID,
+    status: o.status,
+    questionCount: 1,
+    startedAt: new Date(now - 3600_000),
+    completedAt: o.status === "completed" ? new Date(now - 1000) : null,
+    expiresAt: o.expiresAt,
+    score: o.status === "completed" ? 100 : null,
+  })
+  await db.insert(trainingSessionItems).values({
+    id: createId(),
+    sessionId: id,
+    questionId: QID,
+    position: 0,
+    selectedAnswer: "A",
+    isCorrect: true,
+  })
+  return id
+}
+
+const statusOf = (id: string) =>
+  db
+    .select({
+      status: trainingSessions.status,
+      score: trainingSessions.score,
+    })
+    .from(trainingSessions)
+    .where(eq(trainingSessions.id, id))
+    .limit(1)
+    .then((r) => r[0])
+
+describe("clôture de session : gardes de statut + expiration", () => {
+  it("session expirée : complétion refusée et session basculée abandonnée", async () => {
+    const sid = await seedSession({
+      status: "in_progress",
+      expiresAt: new Date(Date.now() - DAY),
+    })
+    const res = await completeTrainingSession({ sessionId: sid })
+    expect(res.success).toBe(false)
+    expect((await statusOf(sid))?.status).toBe("abandoned")
+  })
+
+  it("session abandonnée par le cron : complétion refusée, statut intact", async () => {
+    const sid = await seedSession({
+      status: "abandoned",
+      expiresAt: new Date(Date.now() + DAY),
+    })
+    const res = await completeTrainingSession({ sessionId: sid })
+    expect(res.success).toBe(false)
+    expect((await statusOf(sid))?.status).toBe("abandoned")
+  })
+
+  it("session complétée : abandon refusé, statut et score intacts", async () => {
+    const sid = await seedSession({
+      status: "completed",
+      expiresAt: new Date(Date.now() + DAY),
+    })
+    const res = await abandonTrainingSession({ sessionId: sid })
+    expect(res.success).toBe(false)
+    const s = await statusOf(sid)
+    expect(s?.status).toBe("completed")
+    expect(s?.score).toBe(100)
+  })
+
+  it("race complete/abandon concurrents : exactement une clôture gagne", async () => {
+    const sid = await seedSession({
+      status: "in_progress",
+      expiresAt: new Date(Date.now() + DAY),
+    })
+
+    const [complete, abandon] = await Promise.all([
+      completeTrainingSession({ sessionId: sid }),
+      abandonTrainingSession({ sessionId: sid }),
+    ])
+
+    expect([complete, abandon].filter((r) => r.success)).toHaveLength(1)
+
+    const s = await statusOf(sid)
+    if (complete.success) {
+      expect(s?.status).toBe("completed")
+      expect(s?.score).toBe(100)
+    } else {
+      expect(s?.status).toBe("abandoned")
+    }
+  })
+})
+
+afterAll(async () => {
+  await db.delete(trainingSessions).where(eq(trainingSessions.userId, USER_ID))
+  await db.delete(questions).where(eq(questions.id, QID))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})


### PR DESCRIPTION
## Problème

`completeTrainingSession` et `abandonTrainingSession` (`features/training/actions.ts`) lisaient le statut puis écrivaient sans garde, en violation de la règle de concurrence du repo : une clôture concurrente (cron d'expiration, double onglet) pouvait être écrasée — p. ex. une session `abandoned` par le cron silencieusement re-basculée `completed`. Et `completeTrainingSession` ne vérifiait jamais `expiresAt` : une session expirée pouvait encore être scorée.

## Solution

- UPDATE gardés `status = 'in_progress'` + `.returning()` (pattern du cron) dans les deux actions ; zéro ligne touchée → même erreur métier que le pré-check, pas d'écrasement.
- Session expirée : complétion refusée (« Cette session a expiré ») avec bascule `abandoned` gardée, en parité avec `saveTrainingAnswer`.
- Chemin « expiré » de `saveTrainingAnswer` gardé aussi (critère de l'epic #77 : aucune écriture de statut sans garde).

## Tests

`tests/integration/training-concurrency.test.ts` (fichier dédié) : expiration refusée + bascule (vu ROUGE avant le fix), complétion sur session close par le cron, abandon sur session complétée, et race `Promise.all(complete, abandon)` → exactement une clôture gagne (déterministe : Postgres ré-évalue le `WHERE` sous verrou de ligne).

Gates : `bun run check` ✅ · frontend 884 ✅ · intégration 231 ✅. Revue adversariale : verdict OUI, aucun bloquant.

Closes #82
Closes #83