### PR TITLE
fix: campagne issues — #91 quiz public (P0) + #84/#85 taux marketing + #87/#88

### DIFF
--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -55,7 +55,9 @@ here` + `No tests found` (faux « tout est cassé »). Passer par le **script**
   participation du user dessus (+ cascade réponses) + **TOUTES** ses sessions
   d'entraînement (pas seulement `in_progress`) → remet aussi à zéro la fenêtre du
   rate-limit `MAX_SESSIONS_PER_HOUR` (sinon les sessions accumulées au fil des runs
-  saturent la limite). Appelée en setup ET teardown.
+  saturent la limite) + purge `quiz_rate_limits` (rate-limit IP du quiz public
+  #91 : bucket local partagé, sinon la suite `evaluation-quiz` flake au fil des
+  runs). Appelée en setup ET teardown.
 - `cleanup` (`prefix`, défaut `"[E2E]"`) : supprime examens préfixés (cascade) +
   questions orphelines préfixées.
 - `set-access` (`userEmail`, `accessType:"exam"|"training"`, `grant?:boolean`) :

--- a/app/(marketing)/evaluation/quiz/page.tsx
+++ b/app/(marketing)/evaluation/quiz/page.tsx
@@ -50,17 +50,21 @@ export default function QuizPage() {
     if (questionsLoadedRef.current) return
     questionsLoadedRef.current = true
 
-    loadRandomQuizQuestions({ count: 10 }).then((bundle) => {
-      setQuizBundle(bundle)
-      if (bundle.questions.length > 0 && bundle.questions.length < 10) {
-        setQuizState((prev) => ({
-          ...prev,
-          userAnswers: new Array(bundle.questions.length).fill(null),
-          timeRemaining: bundle.questions.length * 20,
-          totalTime: bundle.questions.length * 20,
-        }))
-      }
-    })
+    loadRandomQuizQuestions({ count: 10 })
+      .then((bundle) => {
+        setQuizBundle(bundle)
+        if (bundle.questions.length > 0 && bundle.questions.length < 10) {
+          setQuizState((prev) => ({
+            ...prev,
+            userAnswers: new Array(bundle.questions.length).fill(null),
+            timeRemaining: bundle.questions.length * 20,
+            totalTime: bundle.questions.length * 20,
+          }))
+        }
+      })
+      // Rejet de l'action (réseau coupé, throw serveur) → bundle vide plutôt
+      // que le loader infini : le rendu bascule sur « momentanément indisponible ».
+      .catch(() => setQuizBundle({ questions: [], token: null }))
   }, [])
 
   // Timer - utiliser setInterval pour décrémenter le temps
@@ -100,30 +104,36 @@ export default function QuizPage() {
       selectedAnswer: quizState.userAnswers[i],
     }))
 
-    scoreQuizAnswers({ answers, token }).then((result) => {
-      // Refus silencieux serveur (jeton expiré, rate-limit, verrou examen
-      // total) → écran « session expirée », pas de résultats à trous.
-      if (result.totalQuestions === 0) {
-        setScoreFailed(true)
-        return
-      }
-      const resultMap = new Map(
-        result.questionResults.map((r) => [r.questionId, r]),
-      )
-      const merged = served.map((q) => {
-        const scored = resultMap.get(q._id)
-        return {
-          ...q,
-          correctAnswer: scored?.correctAnswer ?? "",
-          explanation: scored?.explanation ?? "",
-          references: scored?.references ?? [],
-          // Images d'explication révélées avec la clé de correction — rendues
-          // par `QuestionCard variant="review"` uniquement (jamais en passation).
-          explanationImages: scored?.explanationImages ?? [],
-        } satisfies QuestionDoc
+    scoreQuizAnswers({ answers, token })
+      .then((result) => {
+        // Refus TOTAL du serveur (jeton expiré, rate-limit, ou toutes les
+        // questions verrouillées par un examen ouvert) → écran « session
+        // expirée ». Un verrou PARTIEL (rare : examen ouvert pendant la vie du
+        // jeton couvrant une partie du lot) laisse ces questions avec
+        // `correctAnswer: ""` — compromis assumé (spec § menace résiduelle).
+        if (result.totalQuestions === 0) {
+          setScoreFailed(true)
+          return
+        }
+        const resultMap = new Map(
+          result.questionResults.map((r) => [r.questionId, r]),
+        )
+        const merged = served.map((q) => {
+          const scored = resultMap.get(q._id)
+          return {
+            ...q,
+            correctAnswer: scored?.correctAnswer ?? "",
+            explanation: scored?.explanation ?? "",
+            references: scored?.references ?? [],
+            // Images d'explication révélées avec la clé de correction — rendues
+            // par `QuestionCard variant="review"` uniquement (jamais en passation).
+            explanationImages: scored?.explanationImages ?? [],
+          } satisfies QuestionDoc
+        })
+        setScoredResults({ score: result.score, mergedQuestions: merged })
       })
-      setScoredResults({ score: result.score, mergedQuestions: merged })
-    })
+      // Rejet de l'action → même écran que le refus total (pas de loader figé).
+      .catch(() => setScoreFailed(true))
   }, [quizState.isCompleted, quizBundle, quizState.userAnswers])
 
   // Scroll vers le haut quand la question change

--- a/app/(marketing)/evaluation/quiz/page.tsx
+++ b/app/(marketing)/evaluation/quiz/page.tsx
@@ -11,14 +11,10 @@ import QuizProgress from "@/components/quiz/quiz-progress"
 import QuizResults from "@/components/quiz/quiz-results"
 import { Button } from "@/components/ui/button"
 import {
+  type QuizBundle,
   loadRandomQuizQuestions,
   scoreQuizAnswers,
 } from "@/features/questions/actions"
-import type { QuizQuestionView } from "@/features/questions/dal"
-
-// Forme renvoyée par le DAL public (sans correctAnswer/explanation), assignable
-// au contrat `QuestionDoc` des composants quiz partagés via cast.
-type QuizQuestion = QuizQuestionView
 
 interface QuizState {
   currentQuestion: number
@@ -33,9 +29,9 @@ export default function QuizPage() {
   const questionsLoadedRef = useRef(false)
   const scoringTriggeredRef = useRef(false)
 
-  const [quizQuestions, setQuizQuestions] = useState<QuizQuestion[] | null>(
-    null,
-  )
+  const [quizBundle, setQuizBundle] = useState<QuizBundle | null>(null)
+  const [scoreFailed, setScoreFailed] = useState(false)
+  const quizQuestions = quizBundle ? quizBundle.questions : null
   const [scoredResults, setScoredResults] = useState<{
     score: number
     mergedQuestions: QuestionDoc[]
@@ -54,14 +50,14 @@ export default function QuizPage() {
     if (questionsLoadedRef.current) return
     questionsLoadedRef.current = true
 
-    loadRandomQuizQuestions({ count: 10 }).then((questions) => {
-      setQuizQuestions(questions)
-      if (questions.length > 0 && questions.length < 10) {
+    loadRandomQuizQuestions({ count: 10 }).then((bundle) => {
+      setQuizBundle(bundle)
+      if (bundle.questions.length > 0 && bundle.questions.length < 10) {
         setQuizState((prev) => ({
           ...prev,
-          userAnswers: new Array(questions.length).fill(null),
-          timeRemaining: questions.length * 20,
-          totalTime: questions.length * 20,
+          userAnswers: new Array(bundle.questions.length).fill(null),
+          timeRemaining: bundle.questions.length * 20,
+          totalTime: bundle.questions.length * 20,
         }))
       }
     })
@@ -86,21 +82,35 @@ export default function QuizPage() {
 
   // Scorer côté serveur quand le quiz est terminé
   useEffect(() => {
-    if (!quizState.isCompleted || !quizQuestions || scoringTriggeredRef.current)
+    if (!quizState.isCompleted || !quizBundle || scoringTriggeredRef.current)
       return
+    if (quizBundle.questions.length === 0) return
     scoringTriggeredRef.current = true
 
-    const answers = quizQuestions.map((q, i) => ({
+    // Pas de setState SYNCHRONE dans le corps de l'effet (ESLint
+    // react-hooks/set-state-in-effect casse `check`) : le cas token null est
+    // dérivé au RENDU (écran « Session expirée »), jamais stocké ici.
+    // setScoreFailed ne vit que dans le .then (asynchrone, OK).
+    const token = quizBundle.token
+    if (!token) return
+
+    const served = quizBundle.questions
+    const answers = served.map((q, i) => ({
       questionId: q._id,
       selectedAnswer: quizState.userAnswers[i],
     }))
 
-    scoreQuizAnswers({ answers }).then((result) => {
-      // Merge quizQuestions (text, options) with scored results (correctAnswer, explanation)
+    scoreQuizAnswers({ answers, token }).then((result) => {
+      // Refus silencieux serveur (jeton expiré, rate-limit, verrou examen
+      // total) → écran « session expirée », pas de résultats à trous.
+      if (result.totalQuestions === 0) {
+        setScoreFailed(true)
+        return
+      }
       const resultMap = new Map(
         result.questionResults.map((r) => [r.questionId, r]),
       )
-      const merged = quizQuestions!.map((q) => {
+      const merged = served.map((q) => {
         const scored = resultMap.get(q._id)
         return {
           ...q,
@@ -114,7 +124,7 @@ export default function QuizPage() {
       })
       setScoredResults({ score: result.score, mergedQuestions: merged })
     })
-  }, [quizState.isCompleted, quizQuestions, quizState.userAnswers])
+  }, [quizState.isCompleted, quizBundle, quizState.userAnswers])
 
   // Scroll vers le haut quand la question change
   useEffect(() => {
@@ -156,7 +166,7 @@ export default function QuizPage() {
     window.location.reload()
   }
 
-  if (!quizQuestions || quizQuestions.length === 0) {
+  if (!quizBundle) {
     return (
       <div className="flex items-center justify-center bg-linear-to-br from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">
         <div className="text-center">
@@ -169,8 +179,36 @@ export default function QuizPage() {
     )
   }
 
+  // Refus serveur (rate-limit, banque vide) : message générique volontairement
+  // identique quelle que soit la cause — pas d'oracle côté client.
+  if (!quizQuestions || quizQuestions.length === 0) {
+    return (
+      <div className="flex items-center justify-center bg-linear-to-br from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">
+        <div className="text-center">
+          <p className="mb-4 text-gray-600 dark:text-gray-300">
+            Le quiz est momentanément indisponible. Réessayez plus tard.
+          </p>
+          <Button onClick={restartQuiz}>Réessayer</Button>
+        </div>
+      </div>
+    )
+  }
+
   // Écran de résultats
   if (quizState.isCompleted) {
+    if (scoreFailed || !quizBundle.token) {
+      return (
+        <div className="flex items-center justify-center bg-linear-to-br from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">
+          <div className="text-center">
+            <p className="mb-4 text-gray-600 dark:text-gray-300">
+              Session expirée — recommencez le quiz.
+            </p>
+            <Button onClick={restartQuiz}>Recommencer</Button>
+          </div>
+        </div>
+      )
+    }
+
     if (!scoredResults) {
       return (
         <div className="flex items-center justify-center bg-linear-to-br from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">

--- a/app/api/cron/close-expired/route.ts
+++ b/app/api/cron/close-expired/route.ts
@@ -3,6 +3,7 @@ import { sendPendingNotifications } from "@/features/notifications/cron"
 import { closeExpiredTrainingSessions } from "@/features/training/cron"
 import { anonymizeExpiredDeletedAccounts } from "@/features/users/cron"
 import { env } from "@/lib/env/server"
+import { cleanupQuizRateLimits } from "@/lib/quiz-rate-limit"
 
 // Accès DB → runtime Node.
 export const runtime = "nodejs"
@@ -38,12 +39,17 @@ export async function GET(request: Request) {
   }
 
   try {
-    const [examParticipations, trainingSessions, anonymizedAccounts] =
-      await Promise.all([
-        closeExpiredExamParticipations(),
-        closeExpiredTrainingSessions(),
-        anonymizeExpiredDeletedAccounts(),
-      ])
+    const [
+      examParticipations,
+      trainingSessions,
+      anonymizedAccounts,
+      quizRateLimitCleanup,
+    ] = await Promise.all([
+      closeExpiredExamParticipations(),
+      closeExpiredTrainingSessions(),
+      anonymizeExpiredDeletedAccounts(),
+      cleanupQuizRateLimits(),
+    ])
 
     // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
     const notifications = await sendPendingNotifications()
@@ -69,6 +75,7 @@ export async function GET(request: Request) {
       trainingSessions,
       anonymizedAccounts,
       notifications,
+      quizRateLimitCleanup,
     })
   } catch (error) {
     // Erreur inattendue (DB…) → 500 ; Vercel logue + réessaie à la prochaine heure.

--- a/app/api/e2e/route.ts
+++ b/app/api/e2e/route.ts
@@ -9,6 +9,7 @@ import {
   products,
   questionImages,
   questions,
+  quizRateLimits,
   trainingSessionItems,
   trainingSessions,
   transactions,
@@ -116,10 +117,18 @@ async function resetExam(userEmail: string) {
     .where(eq(trainingSessions.userId, u.id))
     .returning({ id: trainingSessions.id })
 
+  // Purge les compteurs du rate-limit quiz public (#91) : en local toutes les
+  // requêtes partagent un bucket IP → sans purge, les runs e2e successifs de
+  // evaluation-quiz.spec.ts saturent la limite (30/h) et la suite flake.
+  const quizRateLimitRows = await db
+    .delete(quizRateLimits)
+    .returning({ id: quizRateLimits.id })
+
   return {
     userFound: true as const,
     deletedParticipations,
     deletedTrainingSessions: trainingRows.length,
+    deletedQuizRateLimits: quizRateLimitRows.length,
     activeExamId,
   }
 }

--- a/db/schema/ops.ts
+++ b/db/schema/ops.ts
@@ -29,3 +29,20 @@ export const uploadRateLimits = pgTable(
     index("upload_rate_limits_user_id_idx").on(t.userId),
   ],
 )
+
+// Rate-limit ANONYME du quiz marketing (#91) : `key` = HMAC de l'IP (jamais
+// l'IP en clair), pas de FK user (l'appelant n'a pas de compte). Purgée par le
+// cron close-expired (fenêtres > 24 h).
+export const quizRateLimits = pgTable(
+  "quiz_rate_limits",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    key: text("key").notNull(),
+    action: text("action").$type<"load" | "score">().notNull(),
+    count: integer("count").notNull(),
+    windowStart: timestamp("window_start", { withTimezone: true }).notNull(),
+  },
+  (t) => [unique("quiz_rate_limits_key_action_unique").on(t.key, t.action)],
+)

--- a/docs/superpowers/handoffs/2026-07-08-campagne-fix-issues-handoff.md
+++ b/docs/superpowers/handoffs/2026-07-08-campagne-fix-issues-handoff.md
@@ -1,0 +1,75 @@
+# Handoff — Campagne fix des issues GitHub (2026-07-08)
+
+Reprise dans une session fraîche. Contexte : audit du 2026-07-07 des 13 issues
+ouvertes (toutes issues de revues adversariales), fixées par incréments — chaque
+incrément suit le même cycle : **TDD (RED observé avant le code) → gates →
+revue adversariale dans une session séparée → triage → commit → PR**.
+
+## Fait et mergé dans main (ne pas re-traiter)
+
+| PR (mergée) | Contenu                                                                                                                                                                                                                                                                | Issues closes                         |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| #93         | Anti-triche : verrou `getOpenExamLockedQuestionIds` sur les 5 canaux de révision (explications lazy branches training+examen, `getTrainingSessionById` tuteur inclus, `getTrainingSessionResults`, `getParticipantExamResults`, reveal tuteur de `saveTrainingAnswer`) | #86                                   |
+| #94         | Concurrence training : UPDATE gardés `status='in_progress'` + `.returning()` (complete/abandon + chemin expiré de `saveTrainingAnswer`), refus des sessions expirées                                                                                                   | #82, #83 (+ epic #77 fermé à la main) |
+| #95         | Stripe : `amount_total`/`currency` réels persistés au fulfillment, **XAF converti zéro-décimal → centièmes**, valeurs inexploitables → provisoire conservé + log                                                                                                       | #79, #80                              |
+
+## Restant, par priorité
+
+1. **#91 — P0 sécurité** : `scoreQuizAnswers` (`features/questions/actions.ts`,
+   quiz marketing public SANS auth) sert la clé de N'IMPORTE QUELLE question de
+   la banque via `getQuizAnswerKey` (`features/questions/dal.ts:522`). Deux
+   angles : fuite pendant un examen ouvert + scraping de la banque (50/lot,
+   pas de rate-limit). **C'est la tâche de cette session** — passer par
+   /brainstorming → spec + plan → revue de design AVANT d'implémenter.
+2. **#84** : sortir `successRate`/`rating` du DAL marketing → constante
+   éditoriale centralisée (`constants/index.tsx`). Petit.
+3. **#85** (après #84) : vrai taux de réussite — ⚠️ valider les seuils (60 %
+   réussite, 50 participations) avec le responsable produit AVANT de coder.
+4. **#87 + #88** : doc Stripe obsolète + code mort « Bientôt ». Rapides,
+   groupables en une PR.
+5. **#92** : webhook — accepter `no_payment_required` (promo 100 %).
+6. **#81** : audit historique Stripe — ⚠️ lecture PROD (Stripe live + base),
+   demander les accès avant de commencer. Sa décision de backfill conditionne
+   la fermeture de l'epic #76.
+
+Epics encore ouverts : #76 (attend #81), #78 (attend #84+#85).
+
+## Acquis techniques pour #91 (vérifiés dans le code)
+
+- Le quiz marketing tire ses questions **dans toute la banque**
+  (`getRandomQuizQuestions`, aléatoire) — pas de pool démo. Le fix ne peut donc
+  pas borner à un pool : exclure les questions d'examens **ouverts**
+  (`endDate > now`) et rate-limiter.
+- `getOpenExamLockedQuestionIds(userId, questionIds)`
+  (`features/exams/dal.ts`) : helper mergé par PR #93, corrélé à un utilisateur
+  (participation). Pour #91 l'appelant est **anonyme** → écrire une variante
+  sans dimension utilisateur (toute question d'un examen ouvert), au même
+  endroit.
+- Pattern rate-limit existant : `lib/upload-rate-limit.ts` (consommé à l'étape
+  presign). À adapter aux Server Actions publiques du quiz.
+- Piste de la revue : borner aussi le scoring aux questions réellement servies
+  par `loadRandomQuizQuestions` (le client ne score que ce qu'on lui a donné) —
+  décision de design à trancher au spec.
+
+## Conventions et pièges de la campagne
+
+- `bun run test` (JAMAIS `bun test`) ; `bun run test:integration` = branche
+  Neon éphémère (~90 s) ; `test:integration:keep` la conserve pour itérer.
+- Tests d'intégration : `fileParallelism: false` → agrégats testables en
+  delta-vs-baseline. Cleanup `afterAll` dans l'ordre des FK.
+- Scénarios anti-triche : isoler les branches d'autorisation (une question dans
+  examen clos + ouvert est accordée par l'AUTRE branche → témoins dédiés,
+  cf. q10 « clos seul » et participation `in_progress` dans
+  `tests/integration/exams.test.ts`).
+- SonarLint (`typescript:Sxxxx`) = IDE-only, ne casse pas `bun run check` — ne
+  pas refactorer pour lui (règle `.claude/rules/data-layer.md`).
+- Revue adversariale : générer le prompt avec le skill `adversarial-review-prompt`,
+  l'exécuter dans une session séparée, trier ici, supprimer le rapport après
+  triage (artefact jetable, jamais committé).
+- Si un worktree git vit sous `.claude/worktrees/`, le `prettier --check .` du
+  checkout principal le scanne aussi → échecs fantômes si le worktree est sur
+  une vieille base. (Envisager `.prettierignore`.)
+
+## Gates avant tout commit
+
+`bun run check` (prettier + tsc + eslint) · `bun run test` · `bun run test:integration`.

--- a/docs/superpowers/plans/2026-07-09-quiz-public-answer-key.md
+++ b/docs/superpowers/plans/2026-07-09-quiz-public-answer-key.md
@@ -1,0 +1,1418 @@
+# Verrouillage du quiz marketing public (#91) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fermer l'oracle public de clé de réponse (`scoreQuizAnswers`) : liaison HMAC au tirage, exclusion des questions d'examens ouverts (tirage + scoring), rate-limit IP des deux actions publiques.
+
+**Architecture:** Un jeton HMAC stateless (`features/questions/quiz-token.ts`, secret = `BETTER_AUTH_SECRET`) lie le scoring aux questions servies. Une variante anonyme du verrou d'examen (`getOpenExamQuestionIds`, `features/exams/dal.ts`) exclut les questions d'examens ouverts au tirage (SQL `NOT EXISTS`) et au scoring (re-check). Une table `quiz_rate_limits` (clé = HMAC d'IP, pas de FK) + helper `lib/quiz-rate-limit.ts` calqué sur `consumeUploadRateLimit` limite à 30/h/IP/action, purgée par le cron existant. Le client stocke le jeton et remplace le loader infini par des écrans d'erreur.
+
+**Tech Stack:** Next.js 16 Server Actions, Drizzle/Neon, `node:crypto` (HMAC-SHA256), zod, Vitest (unit happy-dom + intégration branche Neon éphémère).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-quiz-public-answer-key-design.md`
+
+**Rappels projet :** commits conventionnels SANS attribution Claude ; `bun run test` (JAMAIS `bun test`) ; ne jamais lancer `bun dev` soi-même (c'est l'utilisateur qui lance). La branche `fix/91-quiz-public-answer-key` est **déjà créée** depuis `main`.
+
+**Coût des runs d'intégration :** `bun run test:integration` crée/migre/détruit une branche Neon (~90-120 s). Pour itérer, `bun run test:integration:keep` conserve la branche ; les runs RED/GREEN « officiels » de ce plan peuvent tous se faire avec la commande standard (1 RED + 1 GREEN par task suffisent).
+
+---
+
+### Task 0: Formater et committer les docs (sinon tous les gates sont rouges)
+
+`bun run check` inclut `prettier --check .` : les 3 docs non formatées du
+working tree (spec, plan, **et le handoff du 2026-07-08**) le font échouer
+AUJOURD'HUI — aucun « Expected: PASS » des tasks suivantes n'est atteignable
+avant ce commit (revue design 2026-07-09, constat #4).
+
+- [ ] **Step 1: Formater et committer les 3 docs**
+
+```bash
+bunx prettier --write docs/superpowers/specs/2026-07-09-quiz-public-answer-key-design.md docs/superpowers/plans/2026-07-09-quiz-public-answer-key.md docs/superpowers/handoffs/2026-07-08-campagne-fix-issues-handoff.md
+git add docs/superpowers/specs/2026-07-09-quiz-public-answer-key-design.md docs/superpowers/plans/2026-07-09-quiz-public-answer-key.md docs/superpowers/handoffs/2026-07-08-campagne-fix-issues-handoff.md
+git commit -m "docs: spec + plan verrouillage du quiz marketing public (#91) + handoff campagne"
+```
+
+- [ ] **Step 2: Vérifier que la base est verte**
+
+Run: `bun run check && bun run test`
+Expected: PASS (baseline verte avant la première ligne de code).
+
+---
+
+### Task 1: Jeton HMAC `quiz-token` (unit, RED → GREEN)
+
+**Files:**
+
+- Create: `tests/questions/quiz-token.test.ts`
+- Create: `features/questions/quiz-token.ts`
+
+- [ ] **Step 1: Écrire le test unitaire (rouge)**
+
+Le projet vitest `frontend` stub `server-only` (alias `vitest.config.ts:144`) mais ne pose PAS les env serveur (`vitest.setup.ts` est vide) → on mocke `@/lib/env/server`.
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { signQuizToken, verifyQuizToken } from "@/features/questions/quiz-token"
+
+vi.mock("@/lib/env/server", () => ({
+  env: { BETTER_AUTH_SECRET: "test-secret-please-change-000000000000" },
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("signQuizToken / verifyQuizToken", () => {
+  it("aller-retour : les ids signés sont vérifiables, insensibles à l'ordre", () => {
+    const token = signQuizToken(["q-b", "q-a"])
+    expect(verifyQuizToken(token)).toEqual(new Set(["q-a", "q-b"]))
+  })
+
+  it("accepte un lot vide", () => {
+    expect(verifyQuizToken(signQuizToken([]))).toEqual(new Set())
+  })
+
+  it("refuse un jeton expiré (> 1 h)", () => {
+    vi.useFakeTimers()
+    const token = signQuizToken(["q-a"])
+    vi.advanceTimersByTime(61 * 60 * 1000)
+    expect(verifyQuizToken(token)).toBeNull()
+  })
+
+  it("accepte un jeton encore frais (59 min)", () => {
+    vi.useFakeTimers()
+    const token = signQuizToken(["q-a"])
+    vi.advanceTimersByTime(59 * 60 * 1000)
+    expect(verifyQuizToken(token)).toEqual(new Set(["q-a"]))
+  })
+
+  it("refuse un payload altéré (ids substitués)", () => {
+    const token = signQuizToken(["q-a"])
+    const [, sig] = token.split(".")
+    const forged = Buffer.from(
+      JSON.stringify({ v: 1, ids: ["q-volee"], exp: Date.now() + 60_000 }),
+    ).toString("base64url")
+    expect(verifyQuizToken(`${forged}.${sig}`)).toBeNull()
+  })
+
+  it("refuse une signature altérée", () => {
+    const token = signQuizToken(["q-a"])
+    const flipped = token.endsWith("A")
+      ? `${token.slice(0, -1)}B`
+      : `${token.slice(0, -1)}A`
+    expect(verifyQuizToken(flipped)).toBeNull()
+  })
+
+  it("refuse les chaînes malformées", () => {
+    for (const bad of ["", "abc", "a.b.c", "%%%.###", "e30."]) {
+      expect(verifyQuizToken(bad)).toBeNull()
+    }
+  })
+
+  it("refuse plus de 10 ids (borne du produit)", () => {
+    const token = signQuizToken(Array.from({ length: 11 }, (_, i) => `q-${i}`))
+    expect(verifyQuizToken(token)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test -- quiz-token`
+Expected: FAIL — module `@/features/questions/quiz-token` introuvable.
+
+- [ ] **Step 3: Écrire le module**
+
+```ts
+import { createHmac, timingSafeEqual } from "node:crypto"
+import "server-only"
+import { env } from "@/lib/env/server"
+
+/**
+ * Jeton stateless liant le scoring du quiz marketing aux questions réellement
+ * servies (#91) : la clé de réponse n'est délivrable que pour un lot signé par
+ * NOUS et encore frais. Séparation de domaine dans le message signé : un HMAC
+ * produit avec le même secret pour un autre usage n'est pas rejouable ici.
+ */
+
+const DOMAIN_PREFIX = "quiz-answer-key:"
+const TTL_MS = 60 * 60 * 1000 // 1 h — le quiz légitime dure ~200 s
+const MAX_IDS = 10 // aligné sur le clamp du tirage public
+
+type QuizTokenPayload = { v: 1; ids: string[]; exp: number }
+
+const hmac = (payloadB64: string) =>
+  createHmac("sha256", env.BETTER_AUTH_SECRET)
+    .update(DOMAIN_PREFIX + payloadB64)
+    .digest()
+
+export const signQuizToken = (questionIds: string[]): string => {
+  const payload: QuizTokenPayload = {
+    v: 1,
+    ids: [...questionIds].sort(),
+    exp: Date.now() + TTL_MS,
+  }
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url")
+  return `${payloadB64}.${hmac(payloadB64).toString("base64url")}`
+}
+
+/** `null` sur TOUT échec, sans distinction de cause (pas d'oracle). */
+export const verifyQuizToken = (token: string): Set<string> | null => {
+  const parts = token.split(".")
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null
+  const [payloadB64, sigB64] = parts
+
+  const expected = hmac(payloadB64)
+  const provided = Buffer.from(sigB64, "base64url")
+  if (
+    provided.length !== expected.length ||
+    !timingSafeEqual(provided, expected)
+  ) {
+    return null
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"))
+  } catch {
+    return null
+  }
+  if (typeof payload !== "object" || payload === null) return null
+  const p = payload as Partial<QuizTokenPayload>
+  if (p.v !== 1) return null
+  if (typeof p.exp !== "number" || p.exp <= Date.now()) return null
+  if (
+    !Array.isArray(p.ids) ||
+    p.ids.length > MAX_IDS ||
+    !p.ids.every((id) => typeof id === "string")
+  ) {
+    return null
+  }
+  return new Set(p.ids)
+}
+```
+
+- [ ] **Step 4: Vérifier le vert + gates**
+
+Run: `bun run test -- quiz-token` puis `bun run check`
+Expected: PASS (8 tests) ; check PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/questions/quiz-token.test.ts features/questions/quiz-token.ts
+git commit -m "feat: jeton HMAC liant le scoring du quiz public aux questions servies"
+```
+
+---
+
+### Task 2: Table `quiz_rate_limits` + migration
+
+**Files:**
+
+- Modify: `db/schema/ops.ts` (append)
+- Create: `db/migrations/*` (généré)
+
+- [ ] **Step 1: Ajouter la table au schéma**
+
+À la fin de `db/schema/ops.ts` (les imports `integer`, `pgTable`, `text`, `timestamp`, `unique` et `createId` existent déjà) :
+
+```ts
+// Rate-limit ANONYME du quiz marketing (#91) : `key` = HMAC de l'IP (jamais
+// l'IP en clair), pas de FK user (l'appelant n'a pas de compte). Purgée par le
+// cron close-expired (fenêtres > 24 h).
+export const quizRateLimits = pgTable(
+  "quiz_rate_limits",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    key: text("key").notNull(),
+    action: text("action").$type<"load" | "score">().notNull(),
+    count: integer("count").notNull(),
+    windowStart: timestamp("window_start", { withTimezone: true }).notNull(),
+  },
+  (t) => [unique("quiz_rate_limits_key_action_unique").on(t.key, t.action)],
+)
+```
+
+(Vérifier que `db/schema/index.ts` ré-exporte `./ops` — c'est déjà le cas pour `uploadRateLimits` ; sinon ajouter l'export.)
+
+- [ ] **Step 2: Générer la migration**
+
+Run: `bun run db:generate`
+Expected: un nouveau fichier `db/migrations/XXXX_*.sql` contenant `CREATE TABLE "quiz_rate_limits"` + la contrainte unique. Ne PAS lancer `db:migrate` (les branches d'intégration migrent seules ; la dev/prod migrera au déploiement — `reference_vercel_migrate_on_deploy`).
+
+- [ ] **Step 3: Gates + commit**
+
+Run: `bun run check`
+Expected: PASS
+
+```bash
+git add db/schema/ops.ts db/migrations
+git commit -m "feat: table quiz_rate_limits (rate-limit anonyme du quiz public)"
+```
+
+---
+
+### Task 3: Helper `lib/quiz-rate-limit.ts` + purge cron (intégration, RED → GREEN)
+
+**Files:**
+
+- Create: `tests/integration/quiz-rate-limit.test.ts`
+- Create: `lib/quiz-rate-limit.ts`
+- Modify: `app/api/cron/close-expired/route.ts`
+- Modify: `vitest.config.ts` (coverage.exclude — revue #1)
+- Modify: `app/api/e2e/route.ts` (purge e2e — revue #5)
+- Modify: `.claude/rules/e2e-testing.md` (doc de la purge)
+
+- [ ] **Step 1: Écrire le test d'intégration (rouge)**
+
+```ts
+import { eq } from "drizzle-orm"
+import { afterAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { quizRateLimits } from "@/db/schema"
+import { createId } from "@/lib/ids"
+import {
+  cleanupQuizRateLimits,
+  consumeQuizRateLimit,
+} from "@/lib/quiz-rate-limit"
+
+// getClientIpKey (next/headers) n'est pas exercé ici — on teste le compteur
+// avec des clés synthétiques ; le mock évite juste l'import RSC.
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+const keyA = `test-key-${createId()}`
+const keyB = `test-key-${createId()}`
+
+afterAll(async () => {
+  for (const key of [keyA, keyB]) {
+    await db.delete(quizRateLimits).where(eq(quizRateLimits.key, key))
+  }
+})
+
+describe("consumeQuizRateLimit", () => {
+  it("autorise 30 appels/h puis refuse le 31e ; une autre clé n'est pas affectée", async () => {
+    for (let i = 0; i < 30; i++) {
+      expect(await consumeQuizRateLimit(keyA, "load")).toBe(true)
+    }
+    expect(await consumeQuizRateLimit(keyA, "load")).toBe(false)
+    expect(await consumeQuizRateLimit(keyB, "load")).toBe(true)
+  })
+
+  it("compte load et score indépendamment", async () => {
+    // keyA est épuisée en "load" (test précédent) mais vierge en "score".
+    expect(await consumeQuizRateLimit(keyA, "score")).toBe(true)
+  })
+
+  it("réinitialise le compteur quand la fenêtre expire", async () => {
+    await db
+      .update(quizRateLimits)
+      .set({ windowStart: new Date(Date.now() - 61 * 60 * 1000) })
+      .where(eq(quizRateLimits.key, keyA))
+    expect(await consumeQuizRateLimit(keyA, "load")).toBe(true)
+  })
+})
+
+describe("cleanupQuizRateLimits", () => {
+  it("purge les fenêtres de plus de 24 h, conserve les récentes", async () => {
+    await db
+      .update(quizRateLimits)
+      .set({ windowStart: new Date(Date.now() - 25 * 60 * 60 * 1000) })
+      .where(eq(quizRateLimits.key, keyB))
+    await cleanupQuizRateLimits()
+
+    const gone = await db
+      .select({ id: quizRateLimits.id })
+      .from(quizRateLimits)
+      .where(eq(quizRateLimits.key, keyB))
+    expect(gone).toHaveLength(0)
+
+    const kept = await db
+      .select({ id: quizRateLimits.id })
+      .from(quizRateLimits)
+      .where(eq(quizRateLimits.key, keyA))
+    expect(kept.length).toBeGreaterThan(0)
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test:integration`
+Expected: FAIL — `quiz-rate-limit.test.ts` échoue à l'import (`@/lib/quiz-rate-limit` n'existe pas). Le reste de la suite reste vert.
+
+- [ ] **Step 3: Écrire le helper**
+
+Pattern copié de `lib/upload-rate-limit.ts` (fenêtre glissante + `FOR UPDATE`, consommation atomique AVANT le travail — TOCTOU fermé, appels abusifs comptés même si le travail échoue ensuite).
+
+```ts
+import { and, eq, lt } from "drizzle-orm"
+import { headers } from "next/headers"
+import { createHmac } from "node:crypto"
+import "server-only"
+import { db } from "@/db"
+import { quizRateLimits } from "@/db/schema"
+import { env } from "@/lib/env/server"
+
+const WINDOW_MS = 60 * 60 * 1000 // 1 h
+const MAX_PER_WINDOW = 30 // légitime = 1 appel/action/tentative ; marge NAT
+const RETENTION_MS = 24 * 60 * 60 * 1000
+
+export type QuizRateLimitAction = "load" | "score"
+
+/**
+ * Clé pseudonyme de l'appelant anonyme : HMAC de l'IP (`x-forwarded-for` posé
+ * par Vercel, premier élément = client). Le HMAC (et non un simple hash) déjoue
+ * le brute-force de l'espace IPv4 — aucune IP en clair en base. Sans header
+ * (hors proxy) : bucket partagé "unknown", fail-closed assumé.
+ */
+export const getClientIpKey = async (): Promise<string> => {
+  const h = await headers()
+  const ip =
+    h.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    h.get("x-real-ip")?.trim() ||
+    "unknown"
+  return createHmac("sha256", env.BETTER_AUTH_SECRET)
+    .update(`quiz-ip:${ip}`)
+    .digest("hex")
+    .slice(0, 32)
+}
+
+/** Consomme un slot pour `(key, action)`. `false` = limite atteinte (refus silencieux côté action). */
+export const consumeQuizRateLimit = async (
+  key: string,
+  action: QuizRateLimitAction,
+): Promise<boolean> => {
+  const now = Date.now()
+
+  return db.transaction(async (tx) => {
+    // Garantit la ligne sans toucher aux compteurs existants (course à la
+    // première insertion), puis verrou de ligne : les requêtes concurrentes de
+    // la même clé sont sérialisées.
+    await tx
+      .insert(quizRateLimits)
+      .values({ key, action, count: 0, windowStart: new Date(now) })
+      .onConflictDoNothing({
+        target: [quizRateLimits.key, quizRateLimits.action],
+      })
+
+    const [row] = await tx
+      .select({
+        id: quizRateLimits.id,
+        count: quizRateLimits.count,
+        windowStart: quizRateLimits.windowStart,
+      })
+      .from(quizRateLimits)
+      .where(
+        and(eq(quizRateLimits.key, key), eq(quizRateLimits.action, action)),
+      )
+      .for("update")
+      .limit(1)
+    if (!row) return true // garde défensive : la ligne existe forcément
+
+    const windowAge = now - row.windowStart.getTime()
+    if (windowAge >= WINDOW_MS) {
+      await tx
+        .update(quizRateLimits)
+        .set({ count: 1, windowStart: new Date(now) })
+        .where(eq(quizRateLimits.id, row.id))
+      return true
+    }
+    if (row.count < MAX_PER_WINDOW) {
+      await tx
+        .update(quizRateLimits)
+        .set({ count: row.count + 1 })
+        .where(eq(quizRateLimits.id, row.id))
+      return true
+    }
+    return false
+  })
+}
+
+/** Purge des fenêtres mortes (> 24 h) — la table ne croît pas sans borne. */
+export const cleanupQuizRateLimits = async (): Promise<{
+  deletedCount: number
+}> => {
+  const res = await db
+    .delete(quizRateLimits)
+    .where(lt(quizRateLimits.windowStart, new Date(Date.now() - RETENTION_MS)))
+    .returning({ id: quizRateLimits.id })
+  return { deletedCount: res.length }
+}
+```
+
+- [ ] **Step 4: Câbler la purge dans le cron**
+
+Dans `app/api/cron/close-expired/route.ts` :
+
+Import (avec les autres imports) :
+
+```ts
+import { cleanupQuizRateLimits } from "@/lib/quiz-rate-limit"
+```
+
+Étendre le `Promise.all` :
+
+```ts
+const [
+  examParticipations,
+  trainingSessions,
+  anonymizedAccounts,
+  quizRateLimitCleanup,
+] = await Promise.all([
+  closeExpiredExamParticipations(),
+  closeExpiredTrainingSessions(),
+  anonymizeExpiredDeletedAccounts(),
+  cleanupQuizRateLimits(),
+])
+```
+
+Et l'ajouter à la réponse JSON :
+
+```ts
+return Response.json({
+  examParticipations,
+  trainingSessions,
+  anonymizedAccounts,
+  notifications,
+  quizRateLimitCleanup,
+})
+```
+
+(Pas besoin de l'ajouter à la condition de log — purge silencieuse.)
+
+- [ ] **Step 5: Exclure le helper de la coverage CI (revue #1)**
+
+`lib/quiz-rate-limit.ts` matche `coverage.include: "lib/**/*.ts"` mais n'est
+couvert QUE par les tests d'intégration (hors coverage CI) → sans exclusion,
+~50 statements à 0 % font tomber le seuil 80 % (marge mesurée : Functions
+81,13 %). Dans `vitest.config.ts`, bloc `coverage.exclude` (l.52-57), après
+`"lib/upload-rate-limit.ts"` :
+
+```ts
+        "lib/upload-rate-limit.ts",
+        "lib/quiz-rate-limit.ts",
+```
+
+(même justification que le commentaire existant « Infra server-only (I/O) :
+couverte par les tests d'integration ».)
+
+- [ ] **Step 6: Purger `quiz_rate_limits` au reset e2e (revue #5)**
+
+En local, pas de `x-forwarded-for` → la suite Playwright
+`e2e/tests/evaluation-quiz.spec.ts` (5 loads + 1 score par run) partage UN
+bucket 30/h et flakerait dès ~6 runs/h. `reset-exam` est appelée par
+`global.setup.ts` en setup ET teardown → y purger la table (compteurs
+éphémères, base de dev — la route répond 404 en prod).
+
+Dans `app/api/e2e/route.ts` : ajouter `quizRateLimits` à l'import
+`@/db/schema` (l.3-17), puis dans `resetExam`, juste avant le `return` final :
+
+```ts
+// Purge les compteurs du rate-limit quiz public (#91) : en local toutes les
+// requêtes partagent un bucket IP → sans purge, les runs e2e successifs de
+// evaluation-quiz.spec.ts saturent la limite (30/h) et la suite flake.
+const quizRateLimitRows = await db
+  .delete(quizRateLimits)
+  .returning({ id: quizRateLimits.id })
+
+return {
+  userFound: true as const,
+  deletedParticipations,
+  deletedTrainingSessions: trainingRows.length,
+  deletedQuizRateLimits: quizRateLimitRows.length,
+  activeExamId,
+}
+```
+
+Dans `.claude/rules/e2e-testing.md`, § « Route support `/api/e2e` », compléter
+la puce `reset-exam` : « … + purge `quiz_rate_limits` (rate-limit IP du quiz
+public #91 : bucket local partagé, sinon la suite `evaluation-quiz` flake au
+fil des runs). »
+
+- [ ] **Step 7: Vérifier le vert + gates**
+
+Run: `bun run test:integration` puis `bun run check`
+Expected: PASS (4 tests du nouveau fichier verts, reste inchangé) ; check PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/integration/quiz-rate-limit.test.ts lib/quiz-rate-limit.ts app/api/cron/close-expired/route.ts vitest.config.ts app/api/e2e/route.ts .claude/rules/e2e-testing.md
+git commit -m "feat: rate-limit IP des actions publiques du quiz + purges cron et e2e"
+```
+
+---
+
+### Task 4: Verrou anonyme `getOpenExamQuestionIds` (intégration, RED → GREEN)
+
+**Files:**
+
+- Modify: `tests/integration/questions-quiz-dal.test.ts` (fixtures examens + nouveau describe)
+- Modify: `features/exams/dal.ts` (nouveau helper, sous `getOpenExamLockedQuestionIds` ~l.738)
+
+- [ ] **Step 1: Ajouter les fixtures examens au test quiz (et le describe rouge)**
+
+Dans `tests/integration/questions-quiz-dal.test.ts` :
+
+Imports à étendre :
+
+```ts
+import {
+  examQuestions,
+  exams,
+  questionExplanations,
+  questionImages,
+  questions,
+  user,
+} from "@/db/schema"
+import { getOpenExamQuestionIds } from "@/features/exams/dal"
+```
+
+Fixtures (après les déclarations existantes `qImg`/`q2`/`ids`) :
+
+```ts
+// qOpen appartient à un examen OUVERT (endDate future) → verrouillée pour le
+// canal public ; qClosed appartient à un examen CLOS uniquement → témoin
+// (l'examen clos ne verrouille pas, pattern q10 de exams.test.ts).
+const qOpen = ids[2]
+const qClosed = ids[3]
+const examCreatorId = createId()
+const examOpenId = createId()
+const examClosedId = createId()
+```
+
+Dans le `beforeAll` existant, après les inserts de questions :
+
+```ts
+await db.insert(user).values({
+  id: examCreatorId,
+  name: "Créateur Examen Quiz",
+  email: `quiz91-${suffix}@test.invalid`,
+  emailVerified: true,
+})
+await db.insert(exams).values([
+  {
+    id: examOpenId,
+    title: `Examen ouvert ${suffix}`,
+    startDate: new Date(Date.now() - 60 * 60 * 1000),
+    endDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    completionTime: 3600,
+    createdBy: examCreatorId,
+  },
+  {
+    id: examClosedId,
+    title: `Examen clos ${suffix}`,
+    startDate: new Date(Date.now() - 48 * 60 * 60 * 1000),
+    endDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    completionTime: 3600,
+    createdBy: examCreatorId,
+  },
+])
+await db.insert(examQuestions).values([
+  { examId: examOpenId, questionId: qOpen, position: 0 },
+  { examId: examClosedId, questionId: qClosed, position: 0 },
+])
+```
+
+Dans le `afterAll` existant, AVANT les deletes de questions (FK `restrict`
+`exam_questions.question_id` ; le delete des `exams` cascade ses
+`exam_questions`) et APRÈS pour le user (FK `restrict` `exams.created_by`) :
+
+```ts
+afterAll(async () => {
+  await db.delete(exams).where(inArray(exams.id, [examOpenId, examClosedId]))
+  await db.delete(questionImages).where(inArray(questionImages.questionId, ids))
+  await db
+    .delete(questionExplanations)
+    .where(inArray(questionExplanations.questionId, ids))
+  await db.delete(questions).where(inArray(questions.id, ids))
+  await db.delete(user).where(eq(user.id, examCreatorId))
+})
+```
+
+(ajouter `eq` à l'import drizzle du fichier : `import { eq, inArray } from "drizzle-orm"`)
+
+Nouveau describe :
+
+```ts
+describe("getOpenExamQuestionIds (verrou anonyme)", () => {
+  it("verrouille les questions d'un examen ouvert, pas celles d'un examen clos", async () => {
+    const locked = await getOpenExamQuestionIds([
+      qOpen,
+      qClosed,
+      q2,
+      createId(),
+    ])
+    expect(locked).toEqual(new Set([qOpen]))
+  })
+
+  it("Set vide pour une liste vide", async () => {
+    expect((await getOpenExamQuestionIds([])).size).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test:integration`
+Expected: FAIL — `questions-quiz-dal.test.ts` échoue à l'import (`getOpenExamQuestionIds` n'est pas exporté par `@/features/exams/dal`).
+
+- [ ] **Step 3: Écrire le helper**
+
+Dans `features/exams/dal.ts`, juste après `getOpenExamLockedQuestionIds`
+(≈ l.738 — les imports `and`, `gt`, `inArray`, `eq`, `exams`, `examQuestions`
+existent déjà dans ce fichier) :
+
+```ts
+/**
+ * Variante ANONYME de `getOpenExamLockedQuestionIds` : parmi `questionIds`,
+ * celles figurant dans AU MOINS un examen ouvert (`endDate` future), sans
+ * dimension utilisateur. Canal public du quiz marketing (#91) : l'appelant
+ * étant anonyme, la clé d'une question d'examen ouvert ne doit fuiter pour
+ * PERSONNE — une question aussi présente dans un examen clos reste verrouillée
+ * (l'examen ouvert prime).
+ */
+export const getOpenExamQuestionIds = async (
+  questionIds: string[],
+): Promise<Set<string>> => {
+  if (questionIds.length === 0) return new Set()
+  const rows = await db
+    .selectDistinct({ questionId: examQuestions.questionId })
+    .from(examQuestions)
+    .innerJoin(exams, eq(exams.id, examQuestions.examId))
+    .where(
+      and(
+        gt(exams.endDate, new Date()),
+        inArray(examQuestions.questionId, questionIds),
+      ),
+    )
+  return new Set(rows.map((r) => r.questionId))
+}
+```
+
+- [ ] **Step 4: Vérifier le vert + gates**
+
+Run: `bun run test:integration` puis `bun run check`
+Expected: PASS partout (les tests existants du fichier restent verts : le tirage n'exclut encore rien).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/questions-quiz-dal.test.ts features/exams/dal.ts
+git commit -m "feat: verrou anonyme des questions d'examens ouverts (canal public)"
+```
+
+---
+
+### Task 5: Tirage — exclusion SQL des examens ouverts + clamp 10 (RED → GREEN)
+
+**Files:**
+
+- Modify: `tests/integration/questions-quiz-dal.test.ts` (describe `getRandomQuizQuestions`)
+- Modify: `features/questions/dal.ts:405-431` (`getRandomQuizQuestions`)
+
+- [ ] **Step 1: Mettre à jour les attentes du tirage (rouge)**
+
+Dans le describe `getRandomQuizQuestions` existant, remplacer le test
+« borne le nombre et filtre par domaine » par :
+
+```ts
+it("borne le nombre, filtre par domaine et exclut les examens ouverts", async () => {
+  const three = await getRandomQuizQuestions({ domain: DOMAIN, count: 3 })
+  expect(three).toHaveLength(3)
+  expect(three.every((q) => q.domain === DOMAIN)).toBe(true)
+
+  // qOpen (examen ouvert) n'est jamais servie ; qClosed (examen clos) l'est.
+  const servable = ids.filter((id) => id !== qOpen)
+  const all = await getRandomQuizQuestions({ domain: DOMAIN, count: 10 })
+  expect(new Set(all.map((q) => q._id))).toEqual(new Set(servable))
+})
+```
+
+Ajouter deux tests :
+
+```ts
+it("ne sert jamais une question d'un examen ouvert (tirages répétés)", async () => {
+  for (let i = 0; i < 5; i++) {
+    const items = await getRandomQuizQuestions({ domain: DOMAIN, count: 10 })
+    expect(items.map((q) => q._id)).not.toContain(qOpen)
+  }
+})
+
+it("clampe count à 10", async () => {
+  const items = await getRandomQuizQuestions({ count: 50 })
+  expect(items.length).toBeLessThanOrEqual(10)
+})
+```
+
+Et dans les deux tests existants qui appellent `getRandomQuizQuestions({ domain: DOMAIN, count: 50 })` (« ne fuite jamais… » et « joint les images… »), remplacer `count: 50` par `count: 10` (le clamp rend `50` équivalent, mais les tests doivent lire la nouvelle borne).
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test:integration`
+Expected: FAIL — « borne le nombre… » attend 4 questions sans `qOpen` mais en reçoit 5 (l'exclusion n'existe pas encore) ; « ne sert jamais… » échoue dès qu'un tirage inclut `qOpen`.
+
+- [ ] **Step 3: Implémenter l'exclusion + le clamp**
+
+Dans `features/questions/dal.ts`, `getRandomQuizQuestions` :
+
+Imports à étendre (l.1-23) : ajouter `gt` à l'import drizzle et `exams` à
+l'import `@/db/schema` (`notExists`, `examQuestions` y sont déjà).
+
+Remplacer :
+
+```ts
+const safeCount = clamp(count, 1, 50)
+const where = and(
+  isNull(questions.deletedAt),
+  domain && domain !== "all" ? eq(questions.domain, domain) : undefined,
+)
+```
+
+par :
+
+```ts
+const safeCount = clamp(count, 1, 10)
+const where = and(
+  isNull(questions.deletedAt),
+  // Anti-triche #91 : jamais de question d'un examen OUVERT dans le quiz
+  // public. L'exclusion vit dans le WHERE (pas en post-filtrage) pour que
+  // `ORDER BY random() LIMIT n` rende quand même n questions corrigeables.
+  notExists(
+    db
+      .select({ x: sql`1` })
+      .from(examQuestions)
+      .innerJoin(exams, eq(exams.id, examQuestions.examId))
+      .where(
+        and(
+          eq(examQuestions.questionId, questions.id),
+          gt(exams.endDate, sql`now()`),
+        ),
+      ),
+  ),
+  domain && domain !== "all" ? eq(questions.domain, domain) : undefined,
+)
+```
+
+Mettre à jour la doc du helper (l.398-404) : mentionner l'exclusion des
+examens ouverts et le clamp `1..10`.
+
+- [ ] **Step 4: Vérifier le vert + gates**
+
+Run: `bun run test:integration` puis `bun run check`
+Expected: PASS partout.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/questions-quiz-dal.test.ts features/questions/dal.ts
+git commit -m "fix: le tirage du quiz public exclut les examens ouverts et clampe a 10"
+```
+
+---
+
+### Task 6: Actions publiques — jeton + re-check + rate-limit (RED → GREEN)
+
+**Files:**
+
+- Modify: `features/questions/schemas.ts` (append)
+- Modify: `tests/integration/questions-quiz-dal.test.ts` (describes actions)
+- Modify: `features/questions/actions.ts:82-137` (les deux actions publiques)
+
+- [ ] **Step 1: Ajouter le schéma zod**
+
+À la fin de `features/questions/schemas.ts` :
+
+```ts
+// Entrées PUBLIQUES (quiz marketing, appelant anonyme) : bornes strictes,
+// refus silencieux côté action (pas de message d'erreur → pas d'oracle).
+// Sans zod sur le tirage, `count: "abc"` → clamp = NaN → `LIMIT NaN` → 500.
+export const loadRandomQuizQuestionsSchema = z.object({
+  count: z.number().int(),
+  domain: z.string().max(100).optional(),
+})
+
+export const scoreQuizAnswersSchema = z.object({
+  answers: z
+    .array(
+      z.object({
+        questionId: z.string().min(1).max(64),
+        selectedAnswer: z.string().max(500).nullable(),
+      }),
+    )
+    .max(10),
+  token: z.string().min(1).max(2048),
+})
+```
+
+- [ ] **Step 2: Étendre le test d'intégration (rouge)**
+
+Dans `tests/integration/questions-quiz-dal.test.ts` :
+
+Imports à étendre :
+
+```ts
+import { headers } from "next/headers"
+import { quizRateLimits } from "@/db/schema"
+import {
+  loadRandomQuizQuestions,
+  scoreQuizAnswers,
+} from "@/features/questions/actions"
+import { signQuizToken, verifyQuizToken } from "@/features/questions/quiz-token"
+import { getClientIpKey } from "@/lib/quiz-rate-limit"
+```
+
+Mock supplémentaire (avec les `vi.mock` existants) + helper IP :
+
+```ts
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+// Chaque test prend une "IP" unique (chaîne arbitraire : elle est HMAC-ée) →
+// compteurs indépendants entre tests. Les IPs utilisées sont tracées pour le
+// cleanup (les clés stockées sont des HMAC, non corrélables sans re-calcul).
+// `setIpHeader` (mock seul, ne mute PAS usedIps) est ce que le cleanup
+// utilise — itérer usedIps avec une fonction qui y push serait une boucle
+// infinie (revue design 2026-07-09, constat #3).
+const usedIps: string[] = []
+const setIpHeader = (ip: string) =>
+  vi
+    .mocked(headers)
+    .mockResolvedValue(new Headers({ "x-forwarded-for": ip }) as never)
+const withIp = (ip: string) => {
+  usedIps.push(ip)
+  setIpHeader(ip)
+}
+```
+
+Dans le `afterAll`, ajouter en tête :
+
+```ts
+for (const ip of usedIps) {
+  setIpHeader(ip)
+  await db
+    .delete(quizRateLimits)
+    .where(eq(quizRateLimits.key, await getClientIpKey()))
+}
+```
+
+Remplacer le describe `scoreQuizAnswers (action publique)` existant par :
+
+```ts
+describe("scoreQuizAnswers (action publique)", () => {
+  const EMPTY = { score: 0, totalQuestions: 0, questionResults: [] }
+
+  it("score avec un jeton valide ; les ids hors jeton sont omis (anti-moisson)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([qImg, q2])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: [
+        { questionId: qImg, selectedAnswer: "A" }, // correct
+        { questionId: q2, selectedAnswer: "mauvaise" }, // incorrect
+        { questionId: ids[4], selectedAnswer: "C" }, // HORS jeton → omis
+      ],
+    })
+
+    expect(result.score).toBe(1)
+    expect(result.totalQuestions).toBe(2)
+    expect(result.questionResults.map((r) => r.questionId)).not.toContain(
+      ids[4],
+    )
+    const imgResult = result.questionResults.find((r) => r.questionId === qImg)
+    expect(imgResult).toMatchObject({
+      isCorrect: true,
+      correctAnswer: "A",
+      explanation: "Exp img",
+      references: ["R1", "R2"],
+    })
+  })
+
+  it("refuse de servir la clé d'ids arbitraires sans jeton les couvrant", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([q2])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: [{ questionId: qImg, selectedAnswer: "A" }],
+    })
+    expect(result).toEqual(EMPTY)
+  })
+
+  it("refuse un jeton falsifié ou malformé", async () => {
+    withIp(`ip-${createId()}`)
+    const valid = signQuizToken([qImg])
+    const tampered = valid.endsWith("A")
+      ? `${valid.slice(0, -1)}B`
+      : `${valid.slice(0, -1)}A`
+    for (const bad of [tampered, "abc"]) {
+      const result = await scoreQuizAnswers({
+        token: bad,
+        answers: [{ questionId: qImg, selectedAnswer: "A" }],
+      })
+      expect(result).toEqual(EMPTY)
+    }
+  })
+
+  it("refuse un jeton expiré", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() - 2 * 60 * 60 * 1000)
+    const stale = signQuizToken([qImg])
+    vi.useRealTimers()
+
+    withIp(`ip-${createId()}`)
+    const result = await scoreQuizAnswers({
+      token: stale,
+      answers: [{ questionId: qImg, selectedAnswer: "A" }],
+    })
+    expect(result).toEqual(EMPTY)
+  })
+
+  it("n'expose jamais la clé d'une question d'examen ouvert, même sous jeton valide (examen ouvert après émission)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([qOpen, q2])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: [
+        { questionId: qOpen, selectedAnswer: "C" },
+        { questionId: q2, selectedAnswer: "B" },
+      ],
+    })
+    expect(result.questionResults.map((r) => r.questionId)).toEqual([q2])
+    expect(result.totalQuestions).toBe(1)
+  })
+
+  it("refuse une entrée hors bornes zod (> 10 réponses)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([qImg])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: Array.from({ length: 11 }, () => ({
+        questionId: qImg,
+        selectedAnswer: "A",
+      })),
+    })
+    expect(result).toEqual(EMPTY)
+  })
+
+  it("refuse au-delà de 30 scorings/h pour la même IP", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([q2])
+    for (let i = 0; i < 30; i++) {
+      const r = await scoreQuizAnswers({
+        token,
+        answers: [{ questionId: q2, selectedAnswer: "B" }],
+      })
+      expect(r.totalQuestions).toBe(1)
+    }
+    const refused = await scoreQuizAnswers({
+      token,
+      answers: [{ questionId: q2, selectedAnswer: "B" }],
+    })
+    expect(refused).toEqual(EMPTY)
+  })
+})
+
+describe("loadRandomQuizQuestions (action publique)", () => {
+  it("renvoie les questions et un jeton couvrant exactement les ids servis", async () => {
+    withIp(`ip-${createId()}`)
+    const bundle = await loadRandomQuizQuestions({
+      count: 3,
+      domain: DOMAIN,
+    })
+    expect(bundle.questions).toHaveLength(3)
+    expect(bundle.token).not.toBeNull()
+    expect(verifyQuizToken(bundle.token!)).toEqual(
+      new Set(bundle.questions.map((q) => q._id)),
+    )
+  })
+
+  it("refuse au-delà de 30 tirages/h pour la même IP", async () => {
+    withIp(`ip-${createId()}`)
+    for (let i = 0; i < 30; i++) {
+      const bundle = await loadRandomQuizQuestions({
+        count: 1,
+        domain: DOMAIN,
+      })
+      expect(bundle.token).not.toBeNull()
+    }
+    const refused = await loadRandomQuizQuestions({
+      count: 1,
+      domain: DOMAIN,
+    })
+    expect(refused).toEqual({ questions: [], token: null })
+  })
+
+  it("refuse un count non numérique (zod) sans throw", async () => {
+    withIp(`ip-${createId()}`)
+    const bundle = await loadRandomQuizQuestions({ count: "abc" as never })
+    expect(bundle).toEqual({ questions: [], token: null })
+  })
+})
+```
+
+- [ ] **Step 3: Vérifier le rouge**
+
+Run: `bun run test:integration`
+Expected: FAIL — l'ancienne `scoreQuizAnswers` ignore `token` et sert `qImg`
+sans couverture (« refuse de servir la clé d'ids arbitraires… » échoue :
+c'est la moisson #91 démontrée) ; `loadRandomQuizQuestions` renvoie un tableau,
+pas un bundle.
+
+- [ ] **Step 4: Réécrire les deux actions**
+
+Dans `features/questions/actions.ts` :
+
+Imports à ajouter :
+
+```ts
+import { getOpenExamQuestionIds } from "@/features/exams/dal"
+import { consumeQuizRateLimit, getClientIpKey } from "@/lib/quiz-rate-limit"
+import { signQuizToken, verifyQuizToken } from "./quiz-token"
+```
+
+et étendre l'import de `./schemas` avec `loadRandomQuizQuestionsSchema` et
+`scoreQuizAnswersSchema`.
+
+Remplacer le bloc `[Public] Quiz marketing` (l.82-137) par :
+
+```ts
+/**
+ * [Public] Questions aléatoires pour le quiz d'évaluation marketing. Sans
+ * session (page publique) mais : rate-limit IP + jeton HMAC couvrant les ids
+ * servis — `scoreQuizAnswers` ne corrige que ce que CE bundle a servi (#91).
+ * La DAL masque `correctAnswer`/`explanation` et exclut les examens ouverts.
+ */
+export type QuizBundle = {
+  questions: QuizQuestionView[]
+  token: string | null
+}
+
+export const loadRandomQuizQuestions = async (args: {
+  count: number
+  domain?: string
+}): Promise<QuizBundle> => {
+  // zod AVANT le rate-limit : une entrée malformée ne consomme pas de slot
+  // (et ne throw plus — l'ancien clamp propageait NaN jusqu'à LIMIT).
+  const parsed = loadRandomQuizQuestionsSchema.safeParse(args)
+  if (!parsed.success) return { questions: [], token: null }
+
+  const ipKey = await getClientIpKey()
+  if (!(await consumeQuizRateLimit(ipKey, "load"))) {
+    return { questions: [], token: null }
+  }
+  const quizQuestions = await getRandomQuizQuestions(parsed.data)
+  if (quizQuestions.length === 0) return { questions: [], token: null }
+  return {
+    questions: quizQuestions,
+    token: signQuizToken(quizQuestions.map((q) => q._id)),
+  }
+}
+
+export type QuizQuestionResult = {
+  questionId: string
+  isCorrect: boolean
+  correctAnswer: string
+  explanation: string
+  references: string[]
+  explanationImages: { url: string; storagePath: string; order: number }[]
+}
+
+export type QuizScore = {
+  score: number
+  totalQuestions: number
+  questionResults: QuizQuestionResult[]
+}
+
+const EMPTY_SCORE: QuizScore = {
+  score: 0,
+  totalQuestions: 0,
+  questionResults: [],
+}
+
+/**
+ * [Public] Score le quiz marketing côté serveur. Refus TOUJOURS silencieux
+ * (`QuizScore` vide, même shape) : pas d'oracle sur la raison — zod hors
+ * bornes, rate-limit, jeton invalide/expiré. Séquence : zod → rate-limit IP
+ * (consommé AVANT le travail) → jeton (intersection ids servis) → re-check
+ * examens ouverts (un examen a pu OUVRIR pendant la vie du jeton — la clé
+ * reste verrouillée sur TOUS les canaux pendant la fenêtre, cf. #86/#93).
+ */
+export const scoreQuizAnswers = async (args: {
+  answers: { questionId: string; selectedAnswer: string | null }[]
+  token: string
+}): Promise<QuizScore> => {
+  const parsed = scoreQuizAnswersSchema.safeParse(args)
+  if (!parsed.success) return EMPTY_SCORE
+
+  const ipKey = await getClientIpKey()
+  if (!(await consumeQuizRateLimit(ipKey, "score"))) return EMPTY_SCORE
+
+  const servedIds = verifyQuizToken(parsed.data.token)
+  if (!servedIds) return EMPTY_SCORE
+
+  const seen = new Set<string>()
+  const answers = parsed.data.answers.filter((a) => {
+    if (!servedIds.has(a.questionId) || seen.has(a.questionId)) return false
+    seen.add(a.questionId)
+    return true
+  })
+  if (answers.length === 0) return EMPTY_SCORE
+
+  const answeredIds = answers.map((a) => a.questionId)
+  const lockedIds = await getOpenExamQuestionIds(answeredIds)
+  const keyMap = await getQuizAnswerKey(
+    answeredIds.filter((id) => !lockedIds.has(id)),
+  )
+
+  let score = 0
+  const questionResults: QuizQuestionResult[] = []
+  for (const a of answers) {
+    const key = keyMap.get(a.questionId)
+    if (!key) continue
+    const isCorrect = a.selectedAnswer === key.correctAnswer
+    if (isCorrect) score++
+    questionResults.push({
+      questionId: a.questionId,
+      isCorrect,
+      correctAnswer: key.correctAnswer,
+      explanation: key.explanation,
+      references: key.references,
+      explanationImages: key.explanationImages,
+    })
+  }
+
+  return { score, totalQuestions: questionResults.length, questionResults }
+}
+```
+
+(`EMPTY_SCORE` est un const module partagé jamais muté — sérialisé à chaque
+réponse par le runtime Server Actions.)
+
+- [ ] **Step 5: Vérifier le vert**
+
+Run: `bun run test:integration`
+Expected: PASS — les 9 nouveaux tests verts, le reste de la suite inchangé.
+
+`bun run check` échouera encore sur `app/(marketing)/evaluation/quiz/page.tsx`
+(l'appelant n'est pas encore adapté au bundle) — c'est la Task 7 ; ne PAS
+committer `check` rouge : Task 6 et 7 peuvent être committées ensemble si
+`check` bloque un pre-commit hook, sinon committer ici et enchaîner.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/questions/schemas.ts features/questions/actions.ts tests/integration/questions-quiz-dal.test.ts
+git commit -m "fix: scoreQuizAnswers verrouille sur jeton signe + examens ouverts + rate-limit (#91)"
+```
+
+---
+
+### Task 7: Client — jeton + écrans d'erreur (fin du loader infini)
+
+**Files:**
+
+- Modify: `app/(marketing)/evaluation/quiz/page.tsx`
+
+- [ ] **Step 1: Adapter l'état et le chargement**
+
+Remplacer (l.13-17) l'import des actions pour récupérer aussi le type :
+
+```ts
+import {
+  type QuizBundle,
+  loadRandomQuizQuestions,
+  scoreQuizAnswers,
+} from "@/features/questions/actions"
+```
+
+Supprimer le type local devenu mort et son import (sinon ESLint `unused` casse
+`check`) — l.17-21 :
+
+```ts
+import type { QuizQuestionView } from "@/features/questions/dal"
+
+// Forme renvoyée par le DAL public (sans correctAnswer/explanation), assignable
+// au contrat `QuestionDoc` des composants quiz partagés via cast.
+type QuizQuestion = QuizQuestionView
+```
+
+Remplacer l'état `quizQuestions` (l.36-38) par :
+
+```ts
+const [quizBundle, setQuizBundle] = useState<QuizBundle | null>(null)
+const [scoreFailed, setScoreFailed] = useState(false)
+const quizQuestions = quizBundle ? quizBundle.questions : null
+```
+
+Adapter l'effet de chargement (l.53-68) :
+
+```ts
+useEffect(() => {
+  if (questionsLoadedRef.current) return
+  questionsLoadedRef.current = true
+
+  loadRandomQuizQuestions({ count: 10 }).then((bundle) => {
+    setQuizBundle(bundle)
+    if (bundle.questions.length > 0 && bundle.questions.length < 10) {
+      setQuizState((prev) => ({
+        ...prev,
+        userAnswers: new Array(bundle.questions.length).fill(null),
+        timeRemaining: bundle.questions.length * 20,
+        totalTime: bundle.questions.length * 20,
+      }))
+    }
+  })
+}, [])
+```
+
+- [ ] **Step 2: Adapter le scoring**
+
+Remplacer l'effet de scoring (l.87-117) :
+
+```ts
+useEffect(() => {
+  if (!quizState.isCompleted || !quizBundle || scoringTriggeredRef.current)
+    return
+  if (quizBundle.questions.length === 0) return
+  scoringTriggeredRef.current = true
+
+  // Pas de setState SYNCHRONE dans le corps de l'effet (ESLint
+  // react-hooks/set-state-in-effect casse `check` — revue #2) : le cas
+  // token null est dérivé au RENDU (écran « Session expirée »), jamais
+  // stocké ici. setScoreFailed ne vit que dans le .then (asynchrone, OK).
+  const token = quizBundle.token
+  if (!token) return
+
+  const served = quizBundle.questions
+  const answers = served.map((q, i) => ({
+    questionId: q._id,
+    selectedAnswer: quizState.userAnswers[i],
+  }))
+
+  scoreQuizAnswers({ answers, token }).then((result) => {
+    // Refus silencieux serveur (jeton expiré, rate-limit, verrou examen
+    // total) → écran « session expirée », pas de résultats à trous.
+    if (result.totalQuestions === 0) {
+      setScoreFailed(true)
+      return
+    }
+    const resultMap = new Map(
+      result.questionResults.map((r) => [r.questionId, r]),
+    )
+    const merged = served.map((q) => {
+      const scored = resultMap.get(q._id)
+      return {
+        ...q,
+        correctAnswer: scored?.correctAnswer ?? "",
+        explanation: scored?.explanation ?? "",
+        references: scored?.references ?? [],
+        // Images d'explication révélées avec la clé de correction — rendues
+        // par `QuestionCard variant="review"` uniquement (jamais en passation).
+        explanationImages: scored?.explanationImages ?? [],
+      } satisfies QuestionDoc
+    })
+    setScoredResults({ score: result.score, mergedQuestions: merged })
+  })
+}, [quizState.isCompleted, quizBundle, quizState.userAnswers])
+```
+
+- [ ] **Step 3: Écrans d'erreur (remplacer les gardes de rendu)**
+
+Remplacer la garde `if (!quizQuestions || quizQuestions.length === 0)`
+(l.159-170) par :
+
+```tsx
+if (!quizBundle) {
+  return (
+    <div className="bg-linear-to-br flex items-center justify-center from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">
+      <div className="text-center">
+        <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <p className="text-gray-600 dark:text-gray-300">
+          Chargement des questions...
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// Refus serveur (rate-limit, banque vide) : message générique volontairement
+// identique quelle que soit la cause — pas d'oracle côté client.
+if (!quizQuestions || quizQuestions.length === 0) {
+  return (
+    <div className="bg-linear-to-br flex items-center justify-center from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">
+      <div className="text-center">
+        <p className="mb-4 text-gray-600 dark:text-gray-300">
+          Le quiz est momentanément indisponible. Réessayez plus tard.
+        </p>
+        <Button onClick={restartQuiz}>Réessayer</Button>
+      </div>
+    </div>
+  )
+}
+```
+
+Dans le bloc `if (quizState.isCompleted)` (l.173-196), AVANT la garde
+`if (!scoredResults)`, ajouter (le `!quizBundle.token` dérive le cas « jeton
+absent » au rendu — l'effet ci-dessus n'a pas le droit de le stocker) :
+
+```tsx
+if (scoreFailed || !quizBundle.token) {
+  return (
+    <div className="bg-linear-to-br flex items-center justify-center from-blue-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900/30">
+      <div className="text-center">
+        <p className="mb-4 text-gray-600 dark:text-gray-300">
+          Session expirée — recommencez le quiz.
+        </p>
+        <Button onClick={restartQuiz}>Recommencer</Button>
+      </div>
+    </div>
+  )
+}
+```
+
+(`restartQuiz` existe déjà : `window.location.reload()` — il sert aussi de
+« Réessayer ». `handleNextQuestion`/`handleAnswerSelect` continuent d'utiliser
+`quizQuestions`, désormais dérivé du bundle — aucun autre changement.)
+
+- [ ] **Step 4: Gates complets**
+
+Run: `bun run check && bun run test`
+Expected: PASS partout (le type `QuizQuestion`/imports du fichier compilent, la suite frontend est inchangée — aucun test existant ne mocke ces deux actions, vérifié).
+
+- [ ] **Step 5: Vérification manuelle (par l'utilisateur)**
+
+Demander à l'utilisateur de lancer `bun dev` et vérifier `/evaluation/quiz` :
+quiz complet (10 questions), soumission → résultats avec corrections ; recharger
+~31 fois pour observer l'écran « momentanément indisponible » (optionnel).
+NE PAS lancer le serveur soi-même.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/(marketing)/evaluation/quiz/page.tsx"
+git commit -m "fix: page quiz marketing - jeton de scoring + ecrans d'erreur"
+```
+
+---
+
+### Task 8: Gates finaux
+
+(Les docs sont formatées et commitées depuis la Task 0 ; si spec/plan ont été
+retouchés en cours d'exécution, re-passer `bunx prettier --write` dessus et
+committer avant les gates.)
+
+- [ ] **Step 1: Gates finaux (avant revue/PR)**
+
+Run: `bun run check && bun run test && bun run test:coverage && bun run test:integration`
+Expected: PASS partout. `test:coverage` est OBLIGATOIRE ici (revue #1) : c'est
+lui qui vérifie que l'exclusion de `lib/quiz-rate-limit.ts` suffit à tenir le
+seuil CI de 80 % — `bun run test` seul ne le verrait pas.
+
+---
+
+## Hors scope (rappel spec)
+
+CAPTCHA/BotID, pool démo dédié, généralisation de `upload_rate_limits`,
+protection contre le scraping distribué « au rythme du produit » (résiduel
+assumé). Ne rien implémenter de tout ça.

--- a/docs/superpowers/specs/2026-07-09-quiz-public-answer-key-design.md
+++ b/docs/superpowers/specs/2026-07-09-quiz-public-answer-key-design.md
@@ -1,0 +1,300 @@
+# Spec — Verrouiller la clé de réponse du quiz marketing public (#91)
+
+**Date** : 2026-07-09
+**Statut** : validé (brainstorming) ; revue adversariale design du 2026-07-09
+triée — architecture confirmée, 5 correctifs d'exécution intégrés (exclusion
+coverage, écran d'échec dérivé au rendu, cleanup de test, formatage des docs en
+Task 0, purge e2e de `quiz_rate_limits`), oracle d'appartenance documenté en
+menace résiduelle
+**Issue** : #91 (P0 sécurité)
+
+## Contexte
+
+Le quiz d'évaluation marketing (`app/(marketing)/evaluation/quiz/page.tsx`,
+page publique, aucun compte) est servi par deux Server Actions volontairement
+sans garde (`features/questions/actions.ts`) :
+
+- `loadRandomQuizQuestions` → `getRandomQuizQuestions`
+  (`features/questions/dal.ts`) : tire des questions aléatoires **dans toute
+  la banque** (~3000 QCM, pas de pool démo), clamp `1..50` ;
+- `scoreQuizAnswers` → `getQuizAnswerKey` (`features/questions/dal.ts:522`) :
+  renvoie `correctAnswer` + `explanation` + `references` + images
+  d'explication pour un lot de `questionId` **arbitraires** (seul filtre :
+  `deletedAt IS NULL`), borné à 50 par appel, **appels illimités**.
+
+Deux attaques (issue #91) :
+
+1. **Anti-triche** : pendant la fenêtre d'un examen ouvert (`endDate > now`),
+   POSTer les IDs des questions de l'examen à `scoreQuizAnswers` renvoie la
+   clé complète — contournement direct de l'invariant #86/#93
+   (`getOpenExamLockedQuestionIds` verrouille tous les canaux authentifiés,
+   mais pas ce canal public).
+2. **Scraping** : par lots de 50 sans rate-limit, la banque entière (l'actif
+   principal) se siphonne clé comprise en ~60 requêtes (+ énumération des ids
+   par coupon-collector sur `loadRandomQuizQuestions`).
+
+**Usage légitime observé** (page.tsx) : 1 appel `loadRandomQuizQuestions({
+count: 10 })` au montage + 1 appel `scoreQuizAnswers` à la soumission ;
+« Recommencer » recharge la page. Le quiz dure ~200 s.
+
+## Portée
+
+Trois mesures complémentaires, plus deux durcissements annexes :
+
+1. **Jeton signé** : `scoreQuizAnswers` ne score que les questions réellement
+   servies par `loadRandomQuizQuestions` (liaison HMAC stateless).
+2. **Exclusion examens ouverts** : au tirage (SQL) **et** au scoring
+   (re-vérification) — variante anonyme du verrou de `features/exams/dal.ts`.
+3. **Rate-limit IP** des deux actions publiques (nouvelle table
+   `quiz_rate_limits` + helper calqué sur `lib/upload-rate-limit.ts`).
+4. Annexes : clamp du tirage réduit à `1..10` ; le client remplace le loader
+   infini par un message d'erreur générique quand le serveur refuse.
+
+**Hors scope** : CAPTCHA/BotID, pool de questions démo dédié, généralisation
+de `upload_rate_limits`, protection contre un scraping distribué « au rythme
+du produit » (résiduel assumé, voir « Menace résiduelle »).
+
+## 1. Jeton de quiz signé
+
+Nouveau module serveur `features/questions/quiz-token.ts`
+(`import "server-only"`, `node:crypto`, zéro dépendance) :
+
+```
+signQuizToken(questionIds: string[]): string
+verifyQuizToken(token: string): Set<string> | null
+```
+
+- **Payload** : `{ v: 1, ids: [ids triés], exp }` (`exp` = epoch ms,
+  TTL **1 h** — le quiz légitime dure ~200 s, marge ×18).
+- **Format** : `base64url(JSON payload) + "." + base64url(signature)`.
+- **Signature** : HMAC-SHA256, clé = `env.BETTER_AUTH_SECRET`
+  (`lib/env/server.ts`, déjà obligatoire, min 32 caractères — pas de nouvelle
+  variable d'env), message = `"quiz-answer-key:" + payloadB64` (séparation de
+  domaine : un HMAC forgé pour un autre usage du même secret ne peut pas être
+  rejoué ici, et inversement).
+- **Vérification** : format 2 segments → recalcul HMAC → `timingSafeEqual`
+  (après garde de longueur) → parse JSON → `v === 1`, `exp > Date.now()`,
+  `ids` = tableau de strings de longueur ≤ 10. Tout échec → `null`, sans
+  distinction de cause.
+
+### Changement d'API des deux actions
+
+```
+loadRandomQuizQuestions({ count, domain? })
+  → { questions: QuizQuestionView[]; token: string | null }
+
+scoreQuizAnswers({ answers, token })  // token requis
+  → QuizScore  (shape inchangée)
+```
+
+- `token` est `null` quand `questions` est vide (rate-limit ou banque vide).
+- `scoreQuizAnswers` ne score que l'**intersection** `answers ∩ ids du
+jeton`. Jeton absent / invalide / expiré → `QuizScore` vide
+  (`{ score: 0, totalQuestions: 0, questionResults: [] }`), **sans erreur
+  levée ni message différencié** : pas d'oracle sur la raison du refus.
+- Validation zod des **deux** entrées publiques (nouveau, dans
+  `features/questions/schemas.ts`) : pour le scoring, `answers` borné à 10
+  éléments (`questionId` string 1..64, `selectedAnswer` string ≤ 500 ou
+  null), `token` string 1..2048 ; pour le tirage, `count` entier et `domain`
+  string ≤ 100 optionnel (sans zod, `count: "abc"` → `LIMIT NaN` → 500 après
+  consommation du slot). Entrée invalide → `QuizScore` vide / bundle vide.
+
+## 2. Exclusion des questions d'examens ouverts
+
+### Variante anonyme du verrou
+
+Dans `features/exams/dal.ts`, à côté de `getOpenExamLockedQuestionIds`
+(qui joint la participation d'un utilisateur — inutilisable ici, l'appelant
+est anonyme) :
+
+```
+getOpenExamQuestionIds(questionIds: string[]): Promise<Set<string>>
+```
+
+Même requête sans la jointure participation : parmi `questionIds`, celles
+figurant dans **au moins un examen ouvert** (`exams.endDate > now`), tous
+utilisateurs confondus. Une question à la fois dans un examen clos et un
+examen ouvert est **verrouillée** (l'examen ouvert prime — pattern témoin
+« clos seul » de `tests/integration/exams.test.ts`).
+
+### Au tirage (SQL)
+
+`getRandomQuizQuestions` ajoute au `WHERE` un `NOT EXISTS` (sous-requête
+`exam_questions ⋈ exams` avec `endDate > now`). L'exclusion doit être dans le
+SQL — pas en post-filtrage — pour que `ORDER BY random() LIMIT n` rende
+quand même `n` questions corrigeables. Le quiz marketing reste donc complet
+(10 questions avec correction) même pendant un examen.
+
+### Au scoring (re-vérification)
+
+`scoreQuizAnswers` appelle `getOpenExamQuestionIds` sur les ids retenus et
+**omet** les questions verrouillées des `questionResults` (même comportement
+qu'une clé absente aujourd'hui). Nécessaire malgré l'exclusion au tirage : le
+jeton vit 1 h, un examen peut **ouvrir** entre l'émission et la soumission.
+Défense en profondeur alignée sur #86/#93 : aucun canal ne sert la clé
+pendant la fenêtre.
+
+Conséquence UX assumée (cas rare : examen ouvert pendant les ~200 s du
+quiz) : ces questions disparaissent de la correction ; si toutes le sont,
+l'écran résultats affiche le message générique d'expiration (voir § Client).
+
+## 3. Rate-limit IP des actions publiques
+
+### Table `quiz_rate_limits`
+
+Dans `db/schema/ops.ts` (+ migration Drizzle via `bun run db:generate`) :
+
+| Colonne       | Type                                         |
+| ------------- | -------------------------------------------- |
+| `id`          | text PK (`createId()`)                       |
+| `key`         | text — hash HMAC de l'IP (jamais l'IP brute) |
+| `action`      | text `$type<"load" \| "score">()`            |
+| `count`       | integer                                      |
+| `windowStart` | timestamptz                                  |
+
+Contrainte `UNIQUE(key, action)`. Pas de FK (appelant anonyme) —
+`upload_rate_limits` (FK `user_id`) reste intact.
+
+### Helper `lib/quiz-rate-limit.ts`
+
+- `consumeQuizRateLimit(key, action)` : copie du pattern
+  `consumeUploadRateLimit` (fenêtre glissante **1 h**, `INSERT …
+onConflictDoNothing` puis `SELECT … FOR UPDATE`, consommation atomique
+  AVANT le travail — résistant au TOCTOU et aux appels qui échouent ensuite).
+  Limite : **30/h par IP et par action** (légitime = 1 load + 1 score par
+  tentative ; marge pour NAT partagés — classes, campus).
+- `getClientIpKey()` : `await headers()` → premier élément de
+  `x-forwarded-for` (posé par Vercel), sinon `x-real-ip`, sinon `"unknown"`
+  (bucket partagé fail-closed, assumé). La clé stockée est
+  `HMAC-SHA256(BETTER_AUTH_SECRET, "quiz-ip:" + ip)` tronqué — pas d'adresse
+  IP en clair en base (pseudonymisation ; le brute-force IPv4 est déjoué par
+  le secret, contrairement à un simple SHA-256).
+- `cleanupQuizRateLimits()` : `DELETE … WHERE window_start < now - 24 h`,
+  appelé dans le cron existant `app/api/cron/close-expired/route.ts`
+  (`Promise.all`) — la table ne croît pas sans borne.
+
+### Application
+
+- `loadRandomQuizQuestions` : consomme `load` en entrée ; refus →
+  `{ questions: [], token: null }`.
+- `scoreQuizAnswers` : consomme `score` en entrée (avant vérification du
+  jeton) ; refus → `QuizScore` vide.
+
+### E2E et dev local (revue 2026-07-09, constat #5)
+
+En local (pas de proxy), toutes les requêtes tombent dans le MÊME bucket IP →
+la suite Playwright existante `e2e/tests/evaluation-quiz.spec.ts` (5 loads +
+1 score par run) épuiserait 30/h en ~6 runs. Correctif : l'action `reset-exam`
+de `app/api/e2e/route.ts` (appelée par `global.setup.ts` en setup ET teardown)
+purge intégralement `quiz_rate_limits` (table de compteurs éphémères, base de
+dev uniquement — la route répond 404 en prod). Documenté dans
+`.claude/rules/e2e-testing.md`.
+
+### Coverage CI
+
+`lib/quiz-rate-limit.ts` est couvert par les tests d'intégration uniquement
+(I/O DB, non testable en happy-dom) → l'ajouter au `coverage.exclude` de
+`vitest.config.ts`, comme `lib/upload-rate-limit.ts` (même justification). La
+marge CI est fine (Functions 81,13 % pour un seuil de 80 %) : sans exclusion,
+la CI de la PR tomberait.
+
+## 4. Client (`app/(marketing)/evaluation/quiz/page.tsx`)
+
+- Stocke `{ questions, token }` du load ; renvoie `token` au scoring.
+- **Correctif du loader infini** : aujourd'hui `questions.length === 0`
+  affiche le spinner pour toujours. Distinguer « chargement » (`null`) de
+  « chargé vide » → écran « Le quiz est momentanément indisponible.
+  Réessayez plus tard. » + bouton Réessayer (reload). Message identique quel
+  que soit le refus (rate-limit, banque vide) — pas d'oracle.
+- **Résultats vides** : si `scoreQuizAnswers` rend `totalQuestions === 0`
+  alors que le quiz avait des questions → écran « Session expirée —
+  recommencez le quiz. » + bouton Recommencer (reload). Couvre jeton expiré,
+  rate-limit score, verrouillage total par un examen ouvert entre-temps.
+- Correction partielle (certaines questions verrouillées, pas toutes) : les
+  manquantes gardent le fallback actuel (`correctAnswer: ""`) — assumé, cas
+  rare et borné à la fenêtre d'examen.
+
+## Séquence de `scoreQuizAnswers` (récapitulatif)
+
+1. `safeParse` zod → invalide : `QuizScore` vide.
+2. `consumeQuizRateLimit(ipKey, "score")` → refus : vide.
+3. `verifyQuizToken(token)` → `null` : vide.
+4. `answers` ∩ ids du jeton (et dédup par `questionId`).
+5. `getOpenExamQuestionIds(ids)` → retirer les verrouillées.
+6. `getQuizAnswerKey(ids restants)` → scorer (logique actuelle).
+
+## Menace résiduelle (assumée)
+
+- Un attaquant patient peut toujours jouer le produit honnêtement : 30
+  tirages/h × 10 questions, scorer ce qu'on lui sert → ~300 clés/h/IP au
+  mieux, coupon-collector ⇒ plusieurs dizaines d'heures par IP pour la
+  banque entière ; multipliable par botnet. Accepté : le but de #91 est de
+  fermer l'oracle arbitraire et la fuite d'examen, pas d'atteindre du
+  DRM parfait.
+- `"unknown"` (aucun header IP) est un bucket partagé de 30/h — en pratique
+  Vercel pose toujours `x-forwarded-for`.
+- **Oracle d'appartenance** (revue 2026-07-09, constat #6) : un porteur de
+  jeton valide peut re-scorer son lot pendant 1 h et déduire, d'une question
+  qui **disparaît** de la correction, qu'elle vient d'entrer dans un examen
+  ouvert — il apprend un fragment de **composition** d'examen (jamais la
+  clé). Portée : uniquement les examens qui OUVRENT pendant la vie d'un
+  jeton, sur les ~10 ids du lot (≈ 10/3000 par question). Assumé :
+  l'alternative (`QuizScore` vide dès qu'UN id est verrouillé) dégraderait
+  le cas légitime pour un gain marginal.
+
+## Tests
+
+### Unitaires (`tests/`, happy-dom — `server-only` déjà stubé par vitest)
+
+`tests/questions/quiz-token.test.ts` (mock `@/lib/env/server` avec un secret
+de test) : aller-retour sign/verify ; insensibilité à l'ordre des ids ;
+expiration ; payload altéré ; signature altérée ; chaînes malformées
+(segments manquants, base64 invalide, JSON invalide) ; `v` inconnu ; > 10
+ids refusés.
+
+### Intégration (`tests/integration/`, branche Neon éphémère)
+
+Étendre `questions-quiz-dal.test.ts` (+ fixtures examens ouvert/clos, pattern
+de `exams.test.ts` ; mock `next/headers` pour piloter l'IP par test ;
+cleanup `quiz_rate_limits` et tables examens dans l'ordre des FK) :
+
+- **Tirage** : question d'un examen ouvert jamais servie ; témoin « examen
+  clos seul » servie ; clamp `count: 50` → ≤ 10.
+- **Scoring** : jeton valide → clé servie pour une question hors examen
+  (quiz marketing fonctionnel — critère d'acceptation) ; ids hors jeton
+  omis ; jeton absent/falsifié/expiré → `QuizScore` vide ; question passée
+  dans un examen **ouvert après émission** du jeton → omise ; le test
+  existant qui démontrait la moisson (ids arbitraires acceptés) passe RED
+  puis est inversé en garde.
+- **Rate-limit** : 31ᵉ appel refusé (même IP) ; IP différente non affectée ;
+  fenêtre expirée → reset (`windowStart` vieilli en DB) ;
+  `cleanupQuizRateLimits` purge les lignes > 24 h.
+
+## Fichiers touchés
+
+| Fichier                                        | Changement                                                                               |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `features/questions/quiz-token.ts`             | nouveau — sign/verify HMAC                                                               |
+| `features/questions/schemas.ts`                | + `scoreQuizAnswersSchema`                                                               |
+| `features/questions/actions.ts`                | `loadRandomQuizQuestions` (bundle + rate-limit), `scoreQuizAnswers` (séquence ci-dessus) |
+| `features/questions/dal.ts`                    | `getRandomQuizQuestions` : `NOT EXISTS` examens ouverts + clamp `1..10`                  |
+| `features/exams/dal.ts`                        | + `getOpenExamQuestionIds` (variante anonyme)                                            |
+| `db/schema/ops.ts`                             | + table `quizRateLimits`                                                                 |
+| `db/migrations/*` (généré)                     | migration `quiz_rate_limits`                                                             |
+| `lib/quiz-rate-limit.ts`                       | nouveau — consume + ipKey + cleanup                                                      |
+| `app/api/cron/close-expired/route.ts`          | + `cleanupQuizRateLimits()`                                                              |
+| `app/api/e2e/route.ts`                         | `reset-exam` purge `quiz_rate_limits` (suite e2e non flakée)                             |
+| `.claude/rules/e2e-testing.md`                 | note purge rate-limit quiz dans `reset-exam`                                             |
+| `vitest.config.ts`                             | + `lib/quiz-rate-limit.ts` au `coverage.exclude`                                         |
+| `app/(marketing)/evaluation/quiz/page.tsx`     | jeton + écrans d'erreur (loader infini corrigé)                                          |
+| `tests/questions/quiz-token.test.ts`           | nouveau                                                                                  |
+| `tests/integration/questions-quiz-dal.test.ts` | étendu (fixtures examens, jeton, rate-limit)                                             |
+
+## Critères d'acceptation (issue #91)
+
+- [ ] Pendant la fenêtre d'un examen ouvert, `scoreQuizAnswers` ne renvoie ni
+      clé ni explication pour les questions de cet examen (tirage + scoring).
+- [ ] Les deux actions publiques sont rate-limitées (30/h/IP/action).
+- [ ] Tests d'intégration : question d'examen ouvert exclue du scoring ;
+      question hors examen toujours servie.
+- [ ] `bun run check` et `bun run test` passent (jamais `bun test`).

--- a/drizzle/0011_demonic_iron_monger.sql
+++ b/drizzle/0011_demonic_iron_monger.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "quiz_rate_limits" (
+	"id" text PRIMARY KEY NOT NULL,
+	"key" text NOT NULL,
+	"action" text NOT NULL,
+	"count" integer NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	CONSTRAINT "quiz_rate_limits_key_action_unique" UNIQUE("key","action")
+);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2597 @@
+{
+  "id": "4bad79ee-0fd3-402e-af38-b2b9fcb19c00",
+  "prevId": "57f004e6-f9d4-4fe7-8fbc-25a4b9dec740",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_key_idx": {
+          "name": "rate_limit_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_exam_results": {
+          "name": "notify_exam_results",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_access_expiry": {
+          "name": "notify_access_expiry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymized_at": {
+          "name": "anonymized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_role_idx": {
+          "name": "user_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_answers": {
+      "name": "exam_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer": {
+          "name": "selected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_flagged": {
+          "name": "is_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_answers_participation_id_idx": {
+          "name": "exam_answers_participation_id_idx",
+          "columns": [
+            {
+              "expression": "participation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_answers_question_id_idx": {
+          "name": "exam_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_answers_participation_id_exam_participations_id_fk": {
+          "name": "exam_answers_participation_id_exam_participations_id_fk",
+          "tableFrom": "exam_answers",
+          "tableTo": "exam_participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_answers_question_id_questions_id_fk": {
+          "name": "exam_answers_question_id_questions_id_fk",
+          "tableFrom": "exam_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exam_answers_participation_question_unique": {
+          "name": "exam_answers_participation_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participation_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_audience": {
+      "name": "exam_audience",
+      "schema": "",
+      "columns": {
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_audience_user_id_idx": {
+          "name": "exam_audience_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_audience_exam_id_exams_id_fk": {
+          "name": "exam_audience_exam_id_exams_id_fk",
+          "tableFrom": "exam_audience",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_audience_user_id_user_id_fk": {
+          "name": "exam_audience_user_id_user_id_fk",
+          "tableFrom": "exam_audience",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exam_audience_exam_id_user_id_pk": {
+          "name": "exam_audience_exam_id_user_id_pk",
+          "columns": [
+            "exam_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_participations": {
+      "name": "exam_participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "exam_participation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results_notified_at": {
+          "name": "results_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_started_at": {
+          "name": "pause_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pause_duration_ms": {
+          "name": "total_pause_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_participations_exam_id_idx": {
+          "name": "exam_participations_exam_id_idx",
+          "columns": [
+            {
+              "expression": "exam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_user_id_idx": {
+          "name": "exam_participations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_status_idx": {
+          "name": "exam_participations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_results_pending_idx": {
+          "name": "exam_participations_results_pending_idx",
+          "columns": [
+            {
+              "expression": "exam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"exam_participations\".\"status\" in ('completed', 'auto_submitted') and \"exam_participations\".\"results_notified_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_participations_exam_id_exams_id_fk": {
+          "name": "exam_participations_exam_id_exams_id_fk",
+          "tableFrom": "exam_participations",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_participations_user_id_user_id_fk": {
+          "name": "exam_participations_user_id_user_id_fk",
+          "tableFrom": "exam_participations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exam_participations_exam_user_unique": {
+          "name": "exam_participations_exam_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "exam_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_questions": {
+      "name": "exam_questions",
+      "schema": "",
+      "columns": {
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "exam_questions_question_id_idx": {
+          "name": "exam_questions_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_questions_exam_id_exams_id_fk": {
+          "name": "exam_questions_exam_id_exams_id_fk",
+          "tableFrom": "exam_questions",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_questions_question_id_questions_id_fk": {
+          "name": "exam_questions_question_id_questions_id_fk",
+          "tableFrom": "exam_questions",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exam_questions_exam_id_question_id_pk": {
+          "name": "exam_questions_exam_id_question_id_pk",
+          "columns": [
+            "exam_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "exam_questions_exam_position_unique": {
+          "name": "exam_questions_exam_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "exam_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exams": {
+      "name": "exams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_time": {
+          "name": "completion_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_pause": {
+          "name": "enable_pause",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pause_duration_minutes": {
+          "name": "pause_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "exam_audience_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribers'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exams_is_active_idx": {
+          "name": "exams_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_start_date_idx": {
+          "name": "exams_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_end_date_idx": {
+          "name": "exams_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_is_active_start_date_idx": {
+          "name": "exams_is_active_start_date_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_created_by_idx": {
+          "name": "exams_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exams_created_by_user_id_fk": {
+          "name": "exams_created_by_user_id_fk",
+          "tableFrom": "exams",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_explanations": {
+      "name": "question_explanations",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_explanations_question_id_questions_id_fk": {
+          "name": "question_explanations_question_id_questions_id_fk",
+          "tableFrom": "question_explanations",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_images": {
+      "name": "question_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_image_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'statement'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_images_question_id_idx": {
+          "name": "question_images_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_images_question_kind_idx": {
+          "name": "question_images_question_kind_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_images_question_id_questions_id_fk": {
+          "name": "question_images_question_id_questions_id_fk",
+          "tableFrom": "question_images",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objectif_cmc": {
+          "name": "objectif_cmc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_domain_idx": {
+          "name": "questions_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_objectif_cmc_idx": {
+          "name": "questions_objectif_cmc_idx",
+          "columns": [
+            {
+              "expression": "objectif_cmc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_session_items": {
+      "name": "training_session_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer": {
+          "name": "selected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "training_session_items_session_id_idx": {
+          "name": "training_session_items_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_session_items_question_id_idx": {
+          "name": "training_session_items_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_session_items_session_id_training_sessions_id_fk": {
+          "name": "training_session_items_session_id_training_sessions_id_fk",
+          "tableFrom": "training_session_items",
+          "tableTo": "training_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_session_items_question_id_questions_id_fk": {
+          "name": "training_session_items_question_id_questions_id_fk",
+          "tableFrom": "training_session_items",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "training_session_items_session_question_unique": {
+          "name": "training_session_items_session_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "question_id"
+          ]
+        },
+        "training_session_items_session_position_unique": {
+          "name": "training_session_items_session_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_sessions": {
+      "name": "training_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "training_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "training_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'test'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectif_cmc": {
+          "name": "objectif_cmc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_sessions_user_status_idx": {
+          "name": "training_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_user_started_at_idx": {
+          "name": "training_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_status_idx": {
+          "name": "training_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_status_expires_at_idx": {
+          "name": "training_sessions_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_sessions_user_id_user_id_fk": {
+          "name": "training_sessions_user_id_user_id_fk",
+          "tableFrom": "training_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "product_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cad": {
+          "name": "price_cad",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_days": {
+          "name": "duration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_combo": {
+          "name": "is_combo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "products_code_idx": {
+          "name": "products_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stripe_product_id_idx": {
+          "name": "products_stripe_product_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_is_active_idx": {
+          "name": "products_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_days": {
+          "name": "duration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_stripe_event_id_unique": {
+          "name": "transactions_stripe_event_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_id_idx": {
+          "name": "transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_session_id_idx": {
+          "name": "transactions_stripe_session_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_type_idx": {
+          "name": "transactions_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_access_type_idx": {
+          "name": "transactions_user_access_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_created_at_idx": {
+          "name": "transactions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_product_id_products_id_fk": {
+          "name": "transactions_product_id_products_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_recorded_by_user_id_fk": {
+          "name": "transactions_recorded_by_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_access": {
+      "name": "user_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_reminder_sent_at": {
+          "name": "expiry_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transaction_id": {
+          "name": "last_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_access_user_id_idx": {
+          "name": "user_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_access_expires_at_idx": {
+          "name": "user_access_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_access_expiry_reminder_pending_idx": {
+          "name": "user_access_expiry_reminder_pending_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_access\".\"expiry_reminder_sent_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_access_user_id_user_id_fk": {
+          "name": "user_access_user_id_user_id_fk",
+          "tableFrom": "user_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_access_last_transaction_id_transactions_id_fk": {
+          "name": "user_access_last_transaction_id_transactions_id_fk",
+          "tableFrom": "user_access",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "last_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_access_user_access_type_unique": {
+          "name": "user_access_user_access_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "access_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rate_limits": {
+      "name": "quiz_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quiz_rate_limits_key_action_unique": {
+          "name": "quiz_rate_limits_key_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_rate_limits": {
+      "name": "upload_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_type": {
+          "name": "upload_type",
+          "type": "upload_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upload_rate_limits_user_id_idx": {
+          "name": "upload_rate_limits_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_rate_limits_user_id_user_id_fk": {
+          "name": "upload_rate_limits_user_id_user_id_fk",
+          "tableFrom": "upload_rate_limits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "upload_rate_limits_user_type_unique": {
+          "name": "upload_rate_limits_user_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "upload_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_type": {
+      "name": "access_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "training"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "CAD",
+        "XAF"
+      ]
+    },
+    "public.exam_audience_type": {
+      "name": "exam_audience_type",
+      "schema": "public",
+      "values": [
+        "subscribers",
+        "restricted"
+      ]
+    },
+    "public.exam_participation_status": {
+      "name": "exam_participation_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "auto_submitted"
+      ]
+    },
+    "public.exam_pause_phase": {
+      "name": "exam_pause_phase",
+      "schema": "public",
+      "values": [
+        "before_pause",
+        "during_pause",
+        "after_pause"
+      ]
+    },
+    "public.product_code": {
+      "name": "product_code",
+      "schema": "public",
+      "values": [
+        "exam_access",
+        "training_access",
+        "exam_access_promo",
+        "training_access_promo",
+        "premium_access"
+      ]
+    },
+    "public.question_image_kind": {
+      "name": "question_image_kind",
+      "schema": "public",
+      "values": [
+        "statement",
+        "explanation"
+      ]
+    },
+    "public.training_mode": {
+      "name": "training_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "test"
+      ]
+    },
+    "public.training_status": {
+      "name": "training_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "abandoned"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed",
+        "refunded"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "manual"
+      ]
+    },
+    "public.upload_type": {
+      "name": "upload_type",
+      "schema": "public",
+      "values": [
+        "avatar",
+        "question-image"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782927494569,
       "tag": "0010_backfill_results_notified",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1783638004589,
+      "tag": "0011_demonic_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/features/exams/dal.ts
+++ b/features/exams/dal.ts
@@ -738,6 +738,31 @@ export const getOpenExamLockedQuestionIds = async (
 }
 
 /**
+ * Variante ANONYME de `getOpenExamLockedQuestionIds` : parmi `questionIds`,
+ * celles figurant dans AU MOINS un examen ouvert (`endDate` future), sans
+ * dimension utilisateur. Canal public du quiz marketing (#91) : l'appelant
+ * étant anonyme, la clé d'une question d'examen ouvert ne doit fuiter pour
+ * PERSONNE — une question aussi présente dans un examen clos reste verrouillée
+ * (l'examen ouvert prime).
+ */
+export const getOpenExamQuestionIds = async (
+  questionIds: string[],
+): Promise<Set<string>> => {
+  if (questionIds.length === 0) return new Set()
+  const rows = await db
+    .selectDistinct({ questionId: examQuestions.questionId })
+    .from(examQuestions)
+    .innerJoin(exams, eq(exams.id, examQuestions.examId))
+    .where(
+      and(
+        gt(exams.endDate, new Date()),
+        inArray(examQuestions.questionId, questionIds),
+      ),
+    )
+  return new Set(rows.map((r) => r.questionId))
+}
+
+/**
  * Explications à la demande (déplier une question dans les résultats). Sécurité :
  * admin (bypass) OU l'utilisateur a une session de training COMPLÉTÉE contenant
  * la question, OU une participation COMPLÉTÉE à un examen **CLOS** (`endDate`

--- a/features/questions/actions.ts
+++ b/features/questions/actions.ts
@@ -4,9 +4,11 @@ import { and, eq, isNull } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { db } from "@/db"
 import { questionExplanations, questionImages, questions } from "@/db/schema"
+import { getOpenExamQuestionIds } from "@/features/exams/dal"
 import { requireRole } from "@/lib/auth-guards"
 import { copyInS3, createPresignedUpload } from "@/lib/aws"
 import { createId } from "@/lib/ids"
+import { consumeQuizRateLimit, getClientIpKey } from "@/lib/quiz-rate-limit"
 import {
   assertSafeStoragePath,
   finalPathFromTmp,
@@ -32,11 +34,14 @@ import {
   getUniqueObjectifsCMC,
 } from "./dal"
 import { normalizeObjectifCMC } from "./lib"
+import { signQuizToken, verifyQuizToken } from "./quiz-token"
 import {
   type CreateQuestionInput,
   type SetQuestionImagesInput,
   type UpdateQuestionInput,
   createQuestionSchema,
+  loadRandomQuizQuestionsSchema,
+  scoreQuizAnswersSchema,
   setQuestionImagesSchema,
   updateQuestionSchema,
 } from "./schemas"
@@ -80,14 +85,35 @@ export const loadUniqueObjectifsCMC = async (): Promise<string[]> => {
 // ============================================
 
 /**
- * [Public] Questions aléatoires pour le quiz d'évaluation marketing. Sans garde
- * (page publique). La DAL masque `correctAnswer`/`explanation`.
+ * [Public] Questions aléatoires pour le quiz d'évaluation marketing. Sans
+ * session (page publique) mais : rate-limit IP + jeton HMAC couvrant les ids
+ * servis — `scoreQuizAnswers` ne corrige que ce que CE bundle a servi (#91).
+ * La DAL masque `correctAnswer`/`explanation` et exclut les examens ouverts.
  */
+export type QuizBundle = {
+  questions: QuizQuestionView[]
+  token: string | null
+}
+
 export const loadRandomQuizQuestions = async (args: {
   count: number
   domain?: string
-}): Promise<QuizQuestionView[]> => {
-  return getRandomQuizQuestions(args)
+}): Promise<QuizBundle> => {
+  // zod AVANT le rate-limit : une entrée malformée ne consomme pas de slot
+  // (et ne throw plus — l'ancien clamp propageait NaN jusqu'à LIMIT).
+  const parsed = loadRandomQuizQuestionsSchema.safeParse(args)
+  if (!parsed.success) return { questions: [], token: null }
+
+  const ipKey = await getClientIpKey()
+  if (!(await consumeQuizRateLimit(ipKey, "load"))) {
+    return { questions: [], token: null }
+  }
+  const quizQuestions = await getRandomQuizQuestions(parsed.data)
+  if (quizQuestions.length === 0) return { questions: [], token: null }
+  return {
+    questions: quizQuestions,
+    token: signQuizToken(quizQuestions.map((q) => q._id)),
+  }
 }
 
 export type QuizQuestionResult = {
@@ -105,16 +131,46 @@ export type QuizScore = {
   questionResults: QuizQuestionResult[]
 }
 
+const EMPTY_SCORE: QuizScore = {
+  score: 0,
+  totalQuestions: 0,
+  questionResults: [],
+}
+
 /**
- * [Public] Score le quiz marketing côté serveur. Sans garde (page publique).
- * La clé de correction n'est révélée qu'au moment de la soumission (parité avec
- * l'ancienne mutation Convex publique). Borne anti-abus sur la taille du lot.
+ * [Public] Score le quiz marketing côté serveur. Refus TOUJOURS silencieux
+ * (`QuizScore` vide, même shape) : pas d'oracle sur la raison — zod hors
+ * bornes, rate-limit, jeton invalide/expiré. Séquence : zod → rate-limit IP
+ * (consommé AVANT le travail) → jeton (intersection ids servis) → re-check
+ * examens ouverts (un examen a pu OUVRIR pendant la vie du jeton — la clé
+ * reste verrouillée sur TOUS les canaux pendant la fenêtre, cf. #86/#93).
  */
 export const scoreQuizAnswers = async (args: {
   answers: { questionId: string; selectedAnswer: string | null }[]
+  token: string
 }): Promise<QuizScore> => {
-  const answers = args.answers.slice(0, 50)
-  const keyMap = await getQuizAnswerKey(answers.map((a) => a.questionId))
+  const parsed = scoreQuizAnswersSchema.safeParse(args)
+  if (!parsed.success) return EMPTY_SCORE
+
+  const ipKey = await getClientIpKey()
+  if (!(await consumeQuizRateLimit(ipKey, "score"))) return EMPTY_SCORE
+
+  const servedIds = verifyQuizToken(parsed.data.token)
+  if (!servedIds) return EMPTY_SCORE
+
+  const seen = new Set<string>()
+  const answers = parsed.data.answers.filter((a) => {
+    if (!servedIds.has(a.questionId) || seen.has(a.questionId)) return false
+    seen.add(a.questionId)
+    return true
+  })
+  if (answers.length === 0) return EMPTY_SCORE
+
+  const answeredIds = answers.map((a) => a.questionId)
+  const lockedIds = await getOpenExamQuestionIds(answeredIds)
+  const keyMap = await getQuizAnswerKey(
+    answeredIds.filter((id) => !lockedIds.has(id)),
+  )
 
   let score = 0
   const questionResults: QuizQuestionResult[] = []

--- a/features/questions/dal.ts
+++ b/features/questions/dal.ts
@@ -4,6 +4,7 @@ import {
   desc,
   eq,
   exists,
+  gt,
   ilike,
   inArray,
   isNull,
@@ -15,6 +16,7 @@ import "server-only"
 import { db } from "@/db"
 import {
   examQuestions,
+  exams,
   questionExplanations,
   questionImages,
   questions,
@@ -398,7 +400,10 @@ export type QuizQuestionView = {
 /**
  * [Public] Questions aléatoires pour le quiz d'évaluation marketing. Aucune
  * garde (page publique). Masque `correctAnswer` et `explanation` (renvoyés
- * seulement après soumission via la clé de correction). `ORDER BY random()`
+ * seulement après soumission via la clé de correction). Exclut les questions
+ * d'un examen OUVERT (`endDate` future) — anti-triche #91, l'exclusion vit dans
+ * le WHERE pour que `ORDER BY random() LIMIT n` rende quand même n questions
+ * corrigeables. Clamp `1..10` (le produit ne sert que 10). `ORDER BY random()`
  * suffit pour la banque (~3000 questions, hors chemin chaud). Images jointes
  * (URL CDN) pour l'affichage.
  */
@@ -409,9 +414,24 @@ export const getRandomQuizQuestions = async ({
   count: number
   domain?: string
 }): Promise<QuizQuestionView[]> => {
-  const safeCount = clamp(count, 1, 50)
+  const safeCount = clamp(count, 1, 10)
   const where = and(
     isNull(questions.deletedAt),
+    // Anti-triche #91 : jamais de question d'un examen OUVERT dans le quiz
+    // public. L'exclusion vit dans le WHERE (pas en post-filtrage) pour que
+    // `ORDER BY random() LIMIT n` rende quand même n questions corrigeables.
+    notExists(
+      db
+        .select({ x: sql`1` })
+        .from(examQuestions)
+        .innerJoin(exams, eq(exams.id, examQuestions.examId))
+        .where(
+          and(
+            eq(examQuestions.questionId, questions.id),
+            gt(exams.endDate, sql`now()`),
+          ),
+        ),
+    ),
     domain && domain !== "all" ? eq(questions.domain, domain) : undefined,
   )
 

--- a/features/questions/quiz-token.ts
+++ b/features/questions/quiz-token.ts
@@ -1,0 +1,66 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+import "server-only"
+import { env } from "@/lib/env/server"
+
+/**
+ * Jeton stateless liant le scoring du quiz marketing aux questions réellement
+ * servies (#91) : la clé de réponse n'est délivrable que pour un lot signé par
+ * NOUS et encore frais. Séparation de domaine dans le message signé : un HMAC
+ * produit avec le même secret pour un autre usage n'est pas rejouable ici.
+ */
+
+const DOMAIN_PREFIX = "quiz-answer-key:"
+const TTL_MS = 60 * 60 * 1000 // 1 h — le quiz légitime dure ~200 s
+const MAX_IDS = 10 // aligné sur le clamp du tirage public
+
+type QuizTokenPayload = { v: 1; ids: string[]; exp: number }
+
+const hmac = (payloadB64: string) =>
+  createHmac("sha256", env.BETTER_AUTH_SECRET)
+    .update(DOMAIN_PREFIX + payloadB64)
+    .digest()
+
+export const signQuizToken = (questionIds: string[]): string => {
+  const payload: QuizTokenPayload = {
+    v: 1,
+    ids: [...questionIds].sort(),
+    exp: Date.now() + TTL_MS,
+  }
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url")
+  return `${payloadB64}.${hmac(payloadB64).toString("base64url")}`
+}
+
+/** `null` sur TOUT échec, sans distinction de cause (pas d'oracle). */
+export const verifyQuizToken = (token: string): Set<string> | null => {
+  const parts = token.split(".")
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null
+  const [payloadB64, sigB64] = parts
+
+  const expected = hmac(payloadB64)
+  const provided = Buffer.from(sigB64, "base64url")
+  if (
+    provided.length !== expected.length ||
+    !timingSafeEqual(provided, expected)
+  ) {
+    return null
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"))
+  } catch {
+    return null
+  }
+  if (typeof payload !== "object" || payload === null) return null
+  const p = payload as Partial<QuizTokenPayload>
+  if (p.v !== 1) return null
+  if (typeof p.exp !== "number" || p.exp <= Date.now()) return null
+  if (
+    !Array.isArray(p.ids) ||
+    p.ids.length > MAX_IDS ||
+    !p.ids.every((id) => typeof id === "string")
+  ) {
+    return null
+  }
+  return new Set(p.ids)
+}

--- a/features/questions/schemas.ts
+++ b/features/questions/schemas.ts
@@ -55,3 +55,23 @@ export const setQuestionImagesSchema = z.object({
 // optionnel à l'appel (callers existants `{ questionId, images }`) mais toujours
 // défini après `safeParse`.
 export type SetQuestionImagesInput = z.input<typeof setQuestionImagesSchema>
+
+// Entrées PUBLIQUES (quiz marketing, appelant anonyme) : bornes strictes,
+// refus silencieux côté action (pas de message d'erreur → pas d'oracle).
+// Sans zod sur le tirage, `count: "abc"` → clamp = NaN → `LIMIT NaN` → 500.
+export const loadRandomQuizQuestionsSchema = z.object({
+  count: z.number().int(),
+  domain: z.string().max(100).optional(),
+})
+
+export const scoreQuizAnswersSchema = z.object({
+  answers: z
+    .array(
+      z.object({
+        questionId: z.string().min(1).max(64),
+        selectedAnswer: z.string().max(500).nullable(),
+      }),
+    )
+    .max(10),
+  token: z.string().min(1).max(2048),
+})

--- a/lib/quiz-rate-limit.ts
+++ b/lib/quiz-rate-limit.ts
@@ -1,0 +1,93 @@
+import { and, eq, lt } from "drizzle-orm"
+import { headers } from "next/headers"
+import { createHmac } from "node:crypto"
+import "server-only"
+import { db } from "@/db"
+import { quizRateLimits } from "@/db/schema"
+import { env } from "@/lib/env/server"
+
+const WINDOW_MS = 60 * 60 * 1000 // 1 h
+const MAX_PER_WINDOW = 30 // légitime = 1 appel/action/tentative ; marge NAT
+const RETENTION_MS = 24 * 60 * 60 * 1000
+
+export type QuizRateLimitAction = "load" | "score"
+
+/**
+ * Clé pseudonyme de l'appelant anonyme : HMAC de l'IP (`x-forwarded-for` posé
+ * par Vercel, premier élément = client). Le HMAC (et non un simple hash) déjoue
+ * le brute-force de l'espace IPv4 — aucune IP en clair en base. Sans header
+ * (hors proxy) : bucket partagé "unknown", fail-closed assumé.
+ */
+export const getClientIpKey = async (): Promise<string> => {
+  const h = await headers()
+  const ip =
+    h.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    h.get("x-real-ip")?.trim() ||
+    "unknown"
+  return createHmac("sha256", env.BETTER_AUTH_SECRET)
+    .update(`quiz-ip:${ip}`)
+    .digest("hex")
+    .slice(0, 32)
+}
+
+/** Consomme un slot pour `(key, action)`. `false` = limite atteinte (refus silencieux côté action). */
+export const consumeQuizRateLimit = async (
+  key: string,
+  action: QuizRateLimitAction,
+): Promise<boolean> => {
+  const now = Date.now()
+
+  return db.transaction(async (tx) => {
+    // Garantit la ligne sans toucher aux compteurs existants (course à la
+    // première insertion), puis verrou de ligne : les requêtes concurrentes de
+    // la même clé sont sérialisées.
+    await tx
+      .insert(quizRateLimits)
+      .values({ key, action, count: 0, windowStart: new Date(now) })
+      .onConflictDoNothing({
+        target: [quizRateLimits.key, quizRateLimits.action],
+      })
+
+    const [row] = await tx
+      .select({
+        id: quizRateLimits.id,
+        count: quizRateLimits.count,
+        windowStart: quizRateLimits.windowStart,
+      })
+      .from(quizRateLimits)
+      .where(
+        and(eq(quizRateLimits.key, key), eq(quizRateLimits.action, action)),
+      )
+      .for("update")
+      .limit(1)
+    if (!row) return true // garde défensive : la ligne existe forcément
+
+    const windowAge = now - row.windowStart.getTime()
+    if (windowAge >= WINDOW_MS) {
+      await tx
+        .update(quizRateLimits)
+        .set({ count: 1, windowStart: new Date(now) })
+        .where(eq(quizRateLimits.id, row.id))
+      return true
+    }
+    if (row.count < MAX_PER_WINDOW) {
+      await tx
+        .update(quizRateLimits)
+        .set({ count: row.count + 1 })
+        .where(eq(quizRateLimits.id, row.id))
+      return true
+    }
+    return false
+  })
+}
+
+/** Purge des fenêtres mortes (> 24 h) — la table ne croît pas sans borne. */
+export const cleanupQuizRateLimits = async (): Promise<{
+  deletedCount: number
+}> => {
+  const res = await db
+    .delete(quizRateLimits)
+    .where(lt(quizRateLimits.windowStart, new Date(Date.now() - RETENTION_MS)))
+    .returning({ id: quizRateLimits.id })
+  return { deletedCount: res.length }
+}

--- a/tests/integration/questions-quiz-dal.test.ts
+++ b/tests/integration/questions-quiz-dal.test.ts
@@ -1,7 +1,15 @@
-import { inArray } from "drizzle-orm"
+import { eq, inArray } from "drizzle-orm"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { db } from "@/db"
-import { questionExplanations, questionImages, questions } from "@/db/schema"
+import {
+  examQuestions,
+  exams,
+  questionExplanations,
+  questionImages,
+  questions,
+  user,
+} from "@/db/schema"
+import { getOpenExamQuestionIds } from "@/features/exams/dal"
 import { scoreQuizAnswers } from "@/features/questions/actions"
 import {
   getQuizAnswerKey,
@@ -27,6 +35,15 @@ const qImg = createId()
 const q2 = createId()
 const ids = [qImg, q2, createId(), createId(), createId()] // 5 au total
 
+// qOpen appartient à un examen OUVERT (endDate future) → verrouillée pour le
+// canal public ; qClosed appartient à un examen CLOS uniquement → témoin
+// (l'examen clos ne verrouille pas, pattern q10 de exams.test.ts).
+const qOpen = ids[2]
+const qClosed = ids[3]
+const examCreatorId = createId()
+const examOpenId = createId()
+const examClosedId = createId()
+
 const mkQuestion = (id: string, correct: string) =>
   db.insert(questions).values({
     id,
@@ -51,14 +68,61 @@ beforeAll(async () => {
     { questionId: qImg, storagePath: `quiz/${suffix}/1.jpg`, position: 1 },
     { questionId: qImg, storagePath: `quiz/${suffix}/0.jpg`, position: 0 },
   ])
+
+  await db.insert(user).values({
+    id: examCreatorId,
+    name: "Créateur Examen Quiz",
+    email: `quiz91-${suffix}@test.invalid`,
+    emailVerified: true,
+  })
+  await db.insert(exams).values([
+    {
+      id: examOpenId,
+      title: `Examen ouvert ${suffix}`,
+      startDate: new Date(Date.now() - 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      completionTime: 3600,
+      createdBy: examCreatorId,
+    },
+    {
+      id: examClosedId,
+      title: `Examen clos ${suffix}`,
+      startDate: new Date(Date.now() - 48 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      completionTime: 3600,
+      createdBy: examCreatorId,
+    },
+  ])
+  await db.insert(examQuestions).values([
+    { examId: examOpenId, questionId: qOpen, position: 0 },
+    { examId: examClosedId, questionId: qClosed, position: 0 },
+  ])
 })
 
 afterAll(async () => {
+  await db.delete(exams).where(inArray(exams.id, [examOpenId, examClosedId]))
   await db.delete(questionImages).where(inArray(questionImages.questionId, ids))
   await db
     .delete(questionExplanations)
     .where(inArray(questionExplanations.questionId, ids))
   await db.delete(questions).where(inArray(questions.id, ids))
+  await db.delete(user).where(eq(user.id, examCreatorId))
+})
+
+describe("getOpenExamQuestionIds (verrou anonyme)", () => {
+  it("verrouille les questions d'un examen ouvert, pas celles d'un examen clos", async () => {
+    const locked = await getOpenExamQuestionIds([
+      qOpen,
+      qClosed,
+      q2,
+      createId(),
+    ])
+    expect(locked).toEqual(new Set([qOpen]))
+  })
+
+  it("Set vide pour une liste vide", async () => {
+    expect((await getOpenExamQuestionIds([])).size).toBe(0)
+  })
 })
 
 describe("getRandomQuizQuestions", () => {

--- a/tests/integration/questions-quiz-dal.test.ts
+++ b/tests/integration/questions-quiz-dal.test.ts
@@ -126,18 +126,31 @@ describe("getOpenExamQuestionIds (verrou anonyme)", () => {
 })
 
 describe("getRandomQuizQuestions", () => {
-  it("borne le nombre et filtre par domaine", async () => {
+  it("borne le nombre, filtre par domaine et exclut les examens ouverts", async () => {
     const three = await getRandomQuizQuestions({ domain: DOMAIN, count: 3 })
     expect(three).toHaveLength(3)
     expect(three.every((q) => q.domain === DOMAIN)).toBe(true)
 
-    const all = await getRandomQuizQuestions({ domain: DOMAIN, count: 50 })
-    expect(all).toHaveLength(5)
-    expect(new Set(all.map((q) => q._id))).toEqual(new Set(ids))
+    // qOpen (examen ouvert) n'est jamais servie ; qClosed (examen clos) l'est.
+    const servable = ids.filter((id) => id !== qOpen)
+    const all = await getRandomQuizQuestions({ domain: DOMAIN, count: 10 })
+    expect(new Set(all.map((q) => q._id))).toEqual(new Set(servable))
+  })
+
+  it("ne sert jamais une question d'un examen ouvert (tirages répétés)", async () => {
+    for (let i = 0; i < 5; i++) {
+      const items = await getRandomQuizQuestions({ domain: DOMAIN, count: 10 })
+      expect(items.map((q) => q._id)).not.toContain(qOpen)
+    }
+  })
+
+  it("clampe count à 10", async () => {
+    const items = await getRandomQuizQuestions({ count: 50 })
+    expect(items.length).toBeLessThanOrEqual(10)
   })
 
   it("ne fuite jamais correctAnswer ni explanation", async () => {
-    const items = await getRandomQuizQuestions({ domain: DOMAIN, count: 50 })
+    const items = await getRandomQuizQuestions({ domain: DOMAIN, count: 10 })
     for (const item of items) {
       expect(item).not.toHaveProperty("correctAnswer")
       expect(item).not.toHaveProperty("explanation")
@@ -145,7 +158,7 @@ describe("getRandomQuizQuestions", () => {
   })
 
   it("joint les images (URL CDN, triées par position)", async () => {
-    const items = await getRandomQuizQuestions({ domain: DOMAIN, count: 50 })
+    const items = await getRandomQuizQuestions({ domain: DOMAIN, count: 10 })
     const withImg = items.find((q) => q._id === qImg)
     expect(withImg?.images.map((i) => i.order)).toEqual([0, 1])
     expect(withImg?.images[0].url).toContain(`quiz/${suffix}/0.jpg`)

--- a/tests/integration/questions-quiz-dal.test.ts
+++ b/tests/integration/questions-quiz-dal.test.ts
@@ -1,4 +1,5 @@
 import { eq, inArray } from "drizzle-orm"
+import { headers } from "next/headers"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { db } from "@/db"
 import {
@@ -7,15 +8,21 @@ import {
   questionExplanations,
   questionImages,
   questions,
+  quizRateLimits,
   user,
 } from "@/db/schema"
 import { getOpenExamQuestionIds } from "@/features/exams/dal"
-import { scoreQuizAnswers } from "@/features/questions/actions"
+import {
+  loadRandomQuizQuestions,
+  scoreQuizAnswers,
+} from "@/features/questions/actions"
 import {
   getQuizAnswerKey,
   getRandomQuizQuestions,
 } from "@/features/questions/dal"
+import { signQuizToken, verifyQuizToken } from "@/features/questions/quiz-token"
 import { createId } from "@/lib/ids"
+import { getClientIpKey } from "@/lib/quiz-rate-limit"
 
 vi.mock("react", async (orig) => {
   const actual = await orig<typeof import("react")>()
@@ -26,6 +33,23 @@ vi.mock("@/lib/auth-guards", () => ({
   requireSession: vi.fn(),
 }))
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+// Chaque test prend une "IP" unique (chaîne arbitraire : elle est HMAC-ée) →
+// compteurs indépendants entre tests. Les IPs utilisées sont tracées pour le
+// cleanup (les clés stockées sont des HMAC, non corrélables sans re-calcul).
+// `setIpHeader` (mock seul, ne mute PAS usedIps) est ce que le cleanup
+// utilise — itérer usedIps avec une fonction qui y push serait une boucle
+// infinie (revue design 2026-07-09, constat #3).
+const usedIps: string[] = []
+const setIpHeader = (ip: string) =>
+  vi
+    .mocked(headers)
+    .mockResolvedValue(new Headers({ "x-forwarded-for": ip }) as never)
+const withIp = (ip: string) => {
+  usedIps.push(ip)
+  setIpHeader(ip)
+}
 
 const suffix = createId().slice(0, 8)
 const DOMAIN = `QUIZ-${suffix}`
@@ -100,6 +124,12 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  for (const ip of usedIps) {
+    setIpHeader(ip)
+    await db
+      .delete(quizRateLimits)
+      .where(eq(quizRateLimits.key, await getClientIpKey()))
+  }
   await db.delete(exams).where(inArray(exams.id, [examOpenId, examClosedId]))
   await db.delete(questionImages).where(inArray(questionImages.questionId, ids))
   await db
@@ -187,17 +217,25 @@ describe("getQuizAnswerKey", () => {
 })
 
 describe("scoreQuizAnswers (action publique)", () => {
-  it("score côté serveur + renvoie l'explication ; ignore les ids inconnus", async () => {
+  const EMPTY = { score: 0, totalQuestions: 0, questionResults: [] }
+
+  it("score avec un jeton valide ; les ids hors jeton sont omis (anti-moisson)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([qImg, q2])
     const result = await scoreQuizAnswers({
+      token,
       answers: [
         { questionId: qImg, selectedAnswer: "A" }, // correct
         { questionId: q2, selectedAnswer: "mauvaise" }, // incorrect
-        { questionId: createId(), selectedAnswer: null }, // inconnu → ignoré
+        { questionId: ids[4], selectedAnswer: "C" }, // HORS jeton → omis
       ],
     })
 
     expect(result.score).toBe(1)
     expect(result.totalQuestions).toBe(2)
+    expect(result.questionResults.map((r) => r.questionId)).not.toContain(
+      ids[4],
+    )
     const imgResult = result.questionResults.find((r) => r.questionId === qImg)
     expect(imgResult).toMatchObject({
       isCorrect: true,
@@ -205,5 +243,125 @@ describe("scoreQuizAnswers (action publique)", () => {
       explanation: "Exp img",
       references: ["R1", "R2"],
     })
+  })
+
+  it("refuse de servir la clé d'ids arbitraires sans jeton les couvrant", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([q2])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: [{ questionId: qImg, selectedAnswer: "A" }],
+    })
+    expect(result).toEqual(EMPTY)
+  })
+
+  it("refuse un jeton falsifié ou malformé", async () => {
+    withIp(`ip-${createId()}`)
+    const valid = signQuizToken([qImg])
+    const tampered = valid.endsWith("A")
+      ? `${valid.slice(0, -1)}B`
+      : `${valid.slice(0, -1)}A`
+    for (const bad of [tampered, "abc"]) {
+      const result = await scoreQuizAnswers({
+        token: bad,
+        answers: [{ questionId: qImg, selectedAnswer: "A" }],
+      })
+      expect(result).toEqual(EMPTY)
+    }
+  })
+
+  it("refuse un jeton expiré", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() - 2 * 60 * 60 * 1000)
+    const stale = signQuizToken([qImg])
+    vi.useRealTimers()
+
+    withIp(`ip-${createId()}`)
+    const result = await scoreQuizAnswers({
+      token: stale,
+      answers: [{ questionId: qImg, selectedAnswer: "A" }],
+    })
+    expect(result).toEqual(EMPTY)
+  })
+
+  it("n'expose jamais la clé d'une question d'examen ouvert, même sous jeton valide (examen ouvert après émission)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([qOpen, q2])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: [
+        { questionId: qOpen, selectedAnswer: "C" },
+        { questionId: q2, selectedAnswer: "B" },
+      ],
+    })
+    expect(result.questionResults.map((r) => r.questionId)).toEqual([q2])
+    expect(result.totalQuestions).toBe(1)
+  })
+
+  it("refuse une entrée hors bornes zod (> 10 réponses)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([qImg])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: Array.from({ length: 11 }, () => ({
+        questionId: qImg,
+        selectedAnswer: "A",
+      })),
+    })
+    expect(result).toEqual(EMPTY)
+  })
+
+  it("refuse au-delà de 30 scorings/h pour la même IP", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([q2])
+    for (let i = 0; i < 30; i++) {
+      const r = await scoreQuizAnswers({
+        token,
+        answers: [{ questionId: q2, selectedAnswer: "B" }],
+      })
+      expect(r.totalQuestions).toBe(1)
+    }
+    const refused = await scoreQuizAnswers({
+      token,
+      answers: [{ questionId: q2, selectedAnswer: "B" }],
+    })
+    expect(refused).toEqual(EMPTY)
+  })
+})
+
+describe("loadRandomQuizQuestions (action publique)", () => {
+  it("renvoie les questions et un jeton couvrant exactement les ids servis", async () => {
+    withIp(`ip-${createId()}`)
+    const bundle = await loadRandomQuizQuestions({
+      count: 3,
+      domain: DOMAIN,
+    })
+    expect(bundle.questions).toHaveLength(3)
+    expect(bundle.token).not.toBeNull()
+    expect(verifyQuizToken(bundle.token!)).toEqual(
+      new Set(bundle.questions.map((q) => q._id)),
+    )
+  })
+
+  it("refuse au-delà de 30 tirages/h pour la même IP", async () => {
+    withIp(`ip-${createId()}`)
+    for (let i = 0; i < 30; i++) {
+      const bundle = await loadRandomQuizQuestions({
+        count: 1,
+        domain: DOMAIN,
+      })
+      expect(bundle.token).not.toBeNull()
+    }
+    const refused = await loadRandomQuizQuestions({
+      count: 1,
+      domain: DOMAIN,
+    })
+    expect(refused).toEqual({ questions: [], token: null })
+  })
+
+  it("refuse un count non numérique (zod) sans throw", async () => {
+    withIp(`ip-${createId()}`)
+    const bundle = await loadRandomQuizQuestions({ count: "abc" as never })
+    expect(bundle).toEqual({ questions: [], token: null })
   })
 })

--- a/tests/integration/questions-quiz-dal.test.ts
+++ b/tests/integration/questions-quiz-dal.test.ts
@@ -298,6 +298,20 @@ describe("scoreQuizAnswers (action publique)", () => {
     expect(result.totalQuestions).toBe(1)
   })
 
+  it("déduplique un id répété dans answers (compté une seule fois)", async () => {
+    withIp(`ip-${createId()}`)
+    const token = signQuizToken([q2])
+    const result = await scoreQuizAnswers({
+      token,
+      answers: [
+        { questionId: q2, selectedAnswer: "B" },
+        { questionId: q2, selectedAnswer: "B" },
+      ],
+    })
+    expect(result.totalQuestions).toBe(1)
+    expect(result.score).toBe(1)
+  })
+
   it("refuse une entrée hors bornes zod (> 10 réponses)", async () => {
     withIp(`ip-${createId()}`)
     const token = signQuizToken([qImg])

--- a/tests/integration/quiz-rate-limit.test.ts
+++ b/tests/integration/quiz-rate-limit.test.ts
@@ -1,0 +1,67 @@
+import { eq } from "drizzle-orm"
+import { afterAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { quizRateLimits } from "@/db/schema"
+import { createId } from "@/lib/ids"
+import {
+  cleanupQuizRateLimits,
+  consumeQuizRateLimit,
+} from "@/lib/quiz-rate-limit"
+
+// getClientIpKey (next/headers) n'est pas exercé ici — on teste le compteur
+// avec des clés synthétiques ; le mock évite juste l'import RSC.
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+const keyA = `test-key-${createId()}`
+const keyB = `test-key-${createId()}`
+
+afterAll(async () => {
+  for (const key of [keyA, keyB]) {
+    await db.delete(quizRateLimits).where(eq(quizRateLimits.key, key))
+  }
+})
+
+describe("consumeQuizRateLimit", () => {
+  it("autorise 30 appels/h puis refuse le 31e ; une autre clé n'est pas affectée", async () => {
+    for (let i = 0; i < 30; i++) {
+      expect(await consumeQuizRateLimit(keyA, "load")).toBe(true)
+    }
+    expect(await consumeQuizRateLimit(keyA, "load")).toBe(false)
+    expect(await consumeQuizRateLimit(keyB, "load")).toBe(true)
+  })
+
+  it("compte load et score indépendamment", async () => {
+    // keyA est épuisée en "load" (test précédent) mais vierge en "score".
+    expect(await consumeQuizRateLimit(keyA, "score")).toBe(true)
+  })
+
+  it("réinitialise le compteur quand la fenêtre expire", async () => {
+    await db
+      .update(quizRateLimits)
+      .set({ windowStart: new Date(Date.now() - 61 * 60 * 1000) })
+      .where(eq(quizRateLimits.key, keyA))
+    expect(await consumeQuizRateLimit(keyA, "load")).toBe(true)
+  })
+})
+
+describe("cleanupQuizRateLimits", () => {
+  it("purge les fenêtres de plus de 24 h, conserve les récentes", async () => {
+    await db
+      .update(quizRateLimits)
+      .set({ windowStart: new Date(Date.now() - 25 * 60 * 60 * 1000) })
+      .where(eq(quizRateLimits.key, keyB))
+    await cleanupQuizRateLimits()
+
+    const gone = await db
+      .select({ id: quizRateLimits.id })
+      .from(quizRateLimits)
+      .where(eq(quizRateLimits.key, keyB))
+    expect(gone).toHaveLength(0)
+
+    const kept = await db
+      .select({ id: quizRateLimits.id })
+      .from(quizRateLimits)
+      .where(eq(quizRateLimits.key, keyA))
+    expect(kept.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/integration/quiz-rate-limit.test.ts
+++ b/tests/integration/quiz-rate-limit.test.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm"
+import { headers } from "next/headers"
 import { afterAll, describe, expect, it, vi } from "vitest"
 import { db } from "@/db"
 import { quizRateLimits } from "@/db/schema"
@@ -6,11 +7,13 @@ import { createId } from "@/lib/ids"
 import {
   cleanupQuizRateLimits,
   consumeQuizRateLimit,
+  getClientIpKey,
 } from "@/lib/quiz-rate-limit"
 
-// getClientIpKey (next/headers) n'est pas exercé ici — on teste le compteur
-// avec des clés synthétiques ; le mock évite juste l'import RSC.
 vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+const mockHeaders = (h: Record<string, string>) =>
+  vi.mocked(headers).mockResolvedValue(new Headers(h) as never)
 
 const keyA = `test-key-${createId()}`
 const keyB = `test-key-${createId()}`
@@ -41,6 +44,32 @@ describe("consumeQuizRateLimit", () => {
       .set({ windowStart: new Date(Date.now() - 61 * 60 * 1000) })
       .where(eq(quizRateLimits.key, keyA))
     expect(await consumeQuizRateLimit(keyA, "load")).toBe(true)
+  })
+})
+
+describe("getClientIpKey", () => {
+  it("dérive la clé du premier élément de x-forwarded-for", async () => {
+    mockHeaders({ "x-forwarded-for": "9.9.9.9, 10.0.0.1" })
+    const fromXff = await getClientIpKey()
+    // Même IP via x-forwarded-for direct → même clé (1er élément retenu).
+    mockHeaders({ "x-forwarded-for": "9.9.9.9" })
+    expect(await getClientIpKey()).toBe(fromXff)
+  })
+
+  it("retombe sur x-real-ip quand x-forwarded-for est absent (même clé pour la même IP)", async () => {
+    mockHeaders({ "x-forwarded-for": "9.9.9.9" })
+    const fromXff = await getClientIpKey()
+    mockHeaders({ "x-real-ip": "9.9.9.9" })
+    expect(await getClientIpKey()).toBe(fromXff)
+  })
+
+  it("retombe sur le bucket « unknown » sans aucun en-tête d'IP", async () => {
+    mockHeaders({})
+    const unknown = await getClientIpKey()
+    mockHeaders({ "x-forwarded-for": "9.9.9.9" })
+    expect(await getClientIpKey()).not.toBe(unknown)
+    // Clé stable : jamais l'IP en clair, longueur bornée (HMAC tronqué).
+    expect(unknown).toHaveLength(32)
   })
 })
 

--- a/tests/questions/quiz-token.test.ts
+++ b/tests/questions/quiz-token.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { signQuizToken, verifyQuizToken } from "@/features/questions/quiz-token"
+
+vi.mock("@/lib/env/server", () => ({
+  env: { BETTER_AUTH_SECRET: "test-secret-please-change-000000000000" },
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("signQuizToken / verifyQuizToken", () => {
+  it("aller-retour : les ids signés sont vérifiables, insensibles à l'ordre", () => {
+    const token = signQuizToken(["q-b", "q-a"])
+    expect(verifyQuizToken(token)).toEqual(new Set(["q-a", "q-b"]))
+  })
+
+  it("accepte un lot vide", () => {
+    expect(verifyQuizToken(signQuizToken([]))).toEqual(new Set())
+  })
+
+  it("refuse un jeton expiré (> 1 h)", () => {
+    vi.useFakeTimers()
+    const token = signQuizToken(["q-a"])
+    vi.advanceTimersByTime(61 * 60 * 1000)
+    expect(verifyQuizToken(token)).toBeNull()
+  })
+
+  it("accepte un jeton encore frais (59 min)", () => {
+    vi.useFakeTimers()
+    const token = signQuizToken(["q-a"])
+    vi.advanceTimersByTime(59 * 60 * 1000)
+    expect(verifyQuizToken(token)).toEqual(new Set(["q-a"]))
+  })
+
+  it("refuse un payload altéré (ids substitués)", () => {
+    const token = signQuizToken(["q-a"])
+    const [, sig] = token.split(".")
+    const forged = Buffer.from(
+      JSON.stringify({ v: 1, ids: ["q-volee"], exp: Date.now() + 60_000 }),
+    ).toString("base64url")
+    expect(verifyQuizToken(`${forged}.${sig}`)).toBeNull()
+  })
+
+  it("refuse une signature altérée", () => {
+    const token = signQuizToken(["q-a"])
+    const flipped = token.endsWith("A")
+      ? `${token.slice(0, -1)}B`
+      : `${token.slice(0, -1)}A`
+    expect(verifyQuizToken(flipped)).toBeNull()
+  })
+
+  it("refuse les chaînes malformées", () => {
+    for (const bad of ["", "abc", "a.b.c", "%%%.###", "e30."]) {
+      expect(verifyQuizToken(bad)).toBeNull()
+    }
+  })
+
+  it("refuse plus de 10 ids (borne du produit)", () => {
+    const token = signQuizToken(Array.from({ length: 11 }, (_, i) => `q-${i}`))
+    expect(verifyQuizToken(token)).toBeNull()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "lib/aws.ts",
         "lib/stripe.ts",
         "lib/upload-rate-limit.ts",
+        "lib/quiz-rate-limit.ts",
         "lib/auth-guards.ts",
         "lib/dal.ts",
         "lib/auth-client.ts",


### PR DESCRIPTION
Closes #91. Closes #84. Closes #85. Closes #87. Closes #88.

Cette PR regroupe une tranche de la campagne de fix d'issues GitHub (empilée par
incréments TDD, chaque lot revu par une revue adversariale — design puis
implémentation). Elle démarre par le **P0 sécurité #91**, puis empile 4 lots
indépendants (#84/#85 marketing, #87 doc, #88 chore).

---

## #91 — [P0 sécurité] clé de réponse du quiz marketing public

### Problème

La Server Action publique `scoreQuizAnswers` (quiz marketing `/evaluation/quiz`,
sans compte) servait la clé de réponse — `correctAnswer` + explication +
références + images — de **n'importe quelle** question de la banque, pour des
`questionId` arbitraires et sans rate-limit. Deux attaques : fuite de la clé
**pendant un examen ouvert** (contournement de l'anti-triche #86/#93 sur le seul
canal public) et **scraping** des 3000+ QCM (l'actif principal) en ~60 requêtes.

### Correction

1. **Jeton HMAC stateless** (`features/questions/quiz-token.ts`, secret =
   `BETTER_AUTH_SECRET` avec séparation de domaine, TTL 1 h) :
   `loadRandomQuizQuestions` renvoie `{ questions, token }` ; `scoreQuizAnswers`
   ne corrige que l'**intersection** des réponses avec les ids réellement
   servis. La clé n'est plus délivrable que pour un lot qu'on a servi à ce
   client.
2. **Exclusion des examens ouverts** aux deux couches : au tirage (`NOT EXISTS`
   SQL dans `getRandomQuizQuestions`) **et** au scoring (re-check via
   `getOpenExamQuestionIds`, variante anonyme du verrou existant — un examen peut
   ouvrir pendant la vie du jeton).
3. **Rate-limit IP** des deux actions publiques : table `quiz_rate_limits` (clé =
   HMAC de l'IP, jamais l'IP en clair), 30/h/action. Purge par le cron
   `close-expired` (>24 h) et par `/api/e2e` `reset-exam`.
4. Durcissements : clamp du tirage `1..50` → `1..10` ; validation zod des deux
   entrées publiques ; loader infini remplacé par des écrans d'erreur génériques
   (y compris sur rejet de l'action, `.catch`) — pas d'oracle sur le refus.

**Résidus assumés** : oracle d'appartenance (re-scoring révèle qu'une question
est entrée dans un examen ouvert — métadonnée, jamais la clé) ; scraping
résiduel ~300 clés/h/IP (coupon-collector rate-limité) ; rate-limit basé sur
`x-forwarded-for` (fiable derrière Vercel).

**Déploiement** : la migration `drizzle/0011` (`quiz_rate_limits`) s'applique au
build de production (`migrate-deploy.ts`, avant le code). Aucune action manuelle.

---

## #84 + #85 — taux de réussite marketing honnête et centralisé

- **#84** : les claims éditoriaux `85%`/`4.9/5` sortent du DAL et du JSX vers une
  constante unique `MARKETING_CLAIMS` (`constants/index.tsx`). `rating` est retiré
  du type `MarketingStats` (le type ne ment plus).
- **#85** : `successRate` est réellement calculé sur les participations d'examens
  terminées, via une **fonction pure** `resolveSuccessRate`
  (`features/marketing/lib.ts`) et **une** requête agrégée `count(*) filter`.
  Seuils nommés : réussite `score ≥ 60`, crédibilité `≥ 50` participations,
  **plancher de publication `70 %`** (sous ce taux → claim éditorial, la page
  tarifs étant une page de vente). Dénominateur assumé : les participations de
  comptes soft-deleted comptent (on mesure des passages, pas des comptes actifs).

Tous les affichages lisent désormais la source centralisée (grep `85%` / `4.9/5`
vides dans `app`/`features`). Aucun changement visuel.

---

## #87 — doc Stripe réécrite

`docs/STRIPE_FRONTEND_SPEC.md` décrivait encore l'ancien backend Convex/Clerk.
Réécrit pour l'architecture actuelle (Server Action `createStripeCheckout` →
Checkout → webhook `/api/stripe/webhook` → `completeStripeTransaction` →
`userAccess`), chaque chemin et invariant (idempotence, cumul vs combo, cents/XAF,
anti-IDOR, bypass admin) vérifié contre le code.

## #88 — chore

Retrait du scaffolding mort « Bientôt » / prop `disabled` de
`profile-preferences.tsx` (notifications email livrées par #71). Aucun changement
visuel.

---

## Vérification

- `bun run check` · `bun run test` (**899**) · `bun run test:coverage` (exit 0,
  ≥ 80 %) · `bun run test:integration` (**270**) — tous verts.
- **E2E navigateur** (#91) : parcours anonyme complet (10 questions → score → 10
  corrections), quiz légitime non cassé.
- Revues adversariales (design **et** implémentation) sur chaque lot — verdict
  mergeable, constats triés. Bonus repéré en revue : un test de sécurité #91
  était flaky (altération de signature sur des bits de padding base64url →
  jeton falsifié parfois accepté) — rendu déterministe.
