### PR TITLE
fix: robustesse réseau des appels client de Server Actions (post-mortem Sentry NOMAQBANQ-1A)

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -69,6 +69,18 @@ storagePath,order}` pour rester assignable aux composants partagés
 
 - Page = Server Component qui fetch la DAL et passe en props à un `*-client.tsx` ;
   mutations via Server Actions + `router.refresh()` (plus de réactivité Convex).
+- **Appels client de Server Actions — jamais d'`await` nu** : un rejet réseau
+  (« Failed to fetch ») contourne le garde `if (!res.success)` → unhandled
+  rejection, spinner figé, optimiste non rollback (post-mortem Sentry
+  NOMAQBANQ-1A, 2026-07-12). Mutations : `callAction(() => action(x))`
+  (`lib/safe-action.ts`) — ne throw jamais, convertit le rejet en
+  `{ success: false, error }` discriminable par les gardes existants ;
+  `{ retries: n }` RÉSERVÉ aux actions idempotentes (upserts quiz). Lectures :
+  try/catch dans la transition, ou `.catch` sur toute chaîne `.then` d'effet
+  (toujours sortir du skeleton). Le moteur quiz traite tout throw de callback
+  comme `{ ok: false }` (rollback) et sérialise les envois de réponses par
+  question ; les toasts vivent dans les callbacks des pages. `authClient.*` ne
+  throw pas (résout `{ error }`) → lire le retour, pas de `callAction`.
 - **ESLint `react-hooks/purity`** (échoue `bun run check`) : pas de `Date.now()`
   ni `new Date()` argless dans le corps de rendu d'un composant (même un Server
   Component async) → extraire l'horloge dans un helper au scope module.

--- a/app/(admin)/admin/examens/[id]/_components/exam-leaderboard.tsx
+++ b/app/(admin)/admin/examens/[id]/_components/exam-leaderboard.tsx
@@ -36,6 +36,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { deleteParticipation } from "@/features/exams/actions"
 import type { LeaderboardEntry } from "@/features/exams/dal"
+import { callAction } from "@/lib/safe-action"
 
 interface ParticipantToDelete {
   participationId: string
@@ -70,9 +71,11 @@ export function ExamLeaderboard({
     if (!participantToDelete) return
 
     setIsDeleting(true)
-    const res = await deleteParticipation({
-      participationId: participantToDelete.participationId,
-    })
+    const res = await callAction(() =>
+      deleteParticipation({
+        participationId: participantToDelete.participationId,
+      }),
+    )
     setIsDeleting(false)
     if (res.success) {
       toast.success("Participation supprimée avec succès")

--- a/app/(admin)/admin/examens/[id]/_components/exam-questions-modal.tsx
+++ b/app/(admin)/admin/examens/[id]/_components/exam-questions-modal.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronLeft, ChevronRight, FileText } from "lucide-react"
 import { useState } from "react"
+import { toast } from "sonner"
 import QuestionDetailsDialog from "@/components/admin/question-details-dialog"
 import { QuestionCard, createViewAction } from "@/components/quiz/question-card"
 import { Button } from "@/components/ui/button"
@@ -48,8 +49,14 @@ export function ExamQuestionsModal({
 
   const handleViewDetails = async (questionId: string) => {
     setIsDetailsOpen(true)
-    const q = await loadQuestionById(questionId)
-    setSelectedQuestion(q)
+    try {
+      const q = await loadQuestionById(questionId)
+      setSelectedQuestion(q)
+    } catch {
+      // rejet réseau : refermer le dialog (sinon il reste ouvert et vide)
+      setIsDetailsOpen(false)
+      toast.error("Chargement impossible. Vérifiez votre réseau.")
+    }
   }
 
   return (

--- a/app/(admin)/admin/questions/_components/objectif-cmc-combobox.tsx
+++ b/app/(admin)/admin/questions/_components/objectif-cmc-combobox.tsx
@@ -40,9 +40,15 @@ export function ObjectifCMCCombobox({
   const [objectifs, setObjectifs] = useState<string[] | null>(null)
   useEffect(() => {
     let active = true
-    loadUniqueObjectifsCMC().then((list) => {
-      if (active) setObjectifs(list)
-    })
+    loadUniqueObjectifsCMC()
+      .then((list) => {
+        if (active) setObjectifs(list)
+      })
+      .catch(() => {
+        // rejet réseau : sortir du spinner — liste vide, la saisie libre
+        // d'un objectif reste possible
+        if (active) setObjectifs([])
+      })
     return () => {
       active = false
     }

--- a/app/(admin)/admin/questions/_components/question-form-page.tsx
+++ b/app/(admin)/admin/questions/_components/question-form-page.tsx
@@ -137,9 +137,15 @@ export function QuestionFormPage({ mode, questionId }: QuestionFormPageProps) {
   useEffect(() => {
     if (mode !== "edit" || !questionId) return
     let active = true
-    loadQuestionById(questionId).then((q) => {
-      if (active) setQuestion(q)
-    })
+    loadQuestionById(questionId)
+      .then((q) => {
+        if (active) setQuestion(q)
+      })
+      .catch(() => {
+        if (!active) return
+        setQuestion(null)
+        toast.error("Chargement impossible. Vérifiez votre réseau.")
+      })
     return () => {
       active = false
     }

--- a/app/(admin)/admin/questions/_components/question-side-panel.tsx
+++ b/app/(admin)/admin/questions/_components/question-side-panel.tsx
@@ -44,6 +44,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { deleteQuestion, loadQuestionById } from "@/features/questions/actions"
 import type { QuestionDetail } from "@/features/questions/dal"
 import { cdnUrl } from "@/lib/cdn"
+import { callAction } from "@/lib/safe-action"
 import { cn } from "@/lib/utils"
 
 interface QuestionSidePanelProps {
@@ -119,7 +120,7 @@ function PanelContent({
 
   const handleDelete = async () => {
     setIsDeleting(true)
-    const res = await deleteQuestion(questionId)
+    const res = await callAction(() => deleteQuestion(questionId))
     setIsDeleting(false)
     if (!res.success) {
       toast.error(res.error ?? "Erreur lors de la suppression")

--- a/app/(admin)/admin/questions/_components/question-side-panel.tsx
+++ b/app/(admin)/admin/questions/_components/question-side-panel.tsx
@@ -105,9 +105,15 @@ function PanelContent({
   // skeleton), pas de setState synchrone dans l'effet.
   useEffect(() => {
     let active = true
-    loadQuestionById(questionId).then((q) => {
-      if (active) setQuestion(q)
-    })
+    loadQuestionById(questionId)
+      .then((q) => {
+        if (active) setQuestion(q)
+      })
+      .catch(() => {
+        if (!active) return
+        setQuestion(null)
+        toast.error("Chargement impossible. Vérifiez votre réseau.")
+      })
     return () => {
       active = false
     }

--- a/app/(admin)/admin/transactions/_components/transactions-manager.tsx
+++ b/app/(admin)/admin/transactions/_components/transactions-manager.tsx
@@ -4,6 +4,7 @@ import { IconReceipt } from "@tabler/icons-react"
 import { Plus } from "lucide-react"
 import { motion } from "motion/react"
 import { useMemo, useState, useTransition } from "react"
+import { toast } from "sonner"
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
 import { DeleteTransactionDialog } from "@/components/shared/payments/delete-transaction-dialog"
 import { EditTransactionModal } from "@/components/shared/payments/edit-transaction-modal"
@@ -71,12 +72,16 @@ export const TransactionsManager = ({
     status: TransactionStatusFilter,
   ) => {
     startTransition(async () => {
-      const page = await loadAdminTransactions({
-        type: type === "all" ? undefined : type,
-        status: status === "all" ? undefined : status,
-      })
-      setItems(page.items.map(adminTransactionToRow))
-      setCursor(page.nextCursor)
+      try {
+        const page = await loadAdminTransactions({
+          type: type === "all" ? undefined : type,
+          status: status === "all" ? undefined : status,
+        })
+        setItems(page.items.map(adminTransactionToRow))
+        setCursor(page.nextCursor)
+      } catch {
+        toast.error("Actualisation impossible. Vérifiez votre réseau.")
+      }
     })
   }
 
@@ -100,29 +105,37 @@ export const TransactionsManager = ({
   const handleLoadMore = () => {
     if (!cursor) return
     startTransition(async () => {
-      const page = await loadAdminTransactions({
-        type: typeFilter === "all" ? undefined : typeFilter,
-        status: statusFilter === "all" ? undefined : statusFilter,
-        cursor,
-      })
-      setItems((prev) => [...prev, ...page.items.map(adminTransactionToRow)])
-      setCursor(page.nextCursor)
+      try {
+        const page = await loadAdminTransactions({
+          type: typeFilter === "all" ? undefined : typeFilter,
+          status: statusFilter === "all" ? undefined : statusFilter,
+          cursor,
+        })
+        setItems((prev) => [...prev, ...page.items.map(adminTransactionToRow)])
+        setCursor(page.nextCursor)
+      } catch {
+        toast.error("Impossible de charger plus de transactions.")
+      }
     })
   }
 
   // Après une mutation : recharge la 1re page des filtres courants + les stats.
   const refresh = () => {
     startTransition(async () => {
-      const [page, freshStats] = await Promise.all([
-        loadAdminTransactions({
-          type: typeFilter === "all" ? undefined : typeFilter,
-          status: statusFilter === "all" ? undefined : statusFilter,
-        }),
-        loadTransactionStats(),
-      ])
-      setItems(page.items.map(adminTransactionToRow))
-      setCursor(page.nextCursor)
-      setStats(freshStats)
+      try {
+        const [page, freshStats] = await Promise.all([
+          loadAdminTransactions({
+            type: typeFilter === "all" ? undefined : typeFilter,
+            status: statusFilter === "all" ? undefined : statusFilter,
+          }),
+          loadTransactionStats(),
+        ])
+        setItems(page.items.map(adminTransactionToRow))
+        setCursor(page.nextCursor)
+        setStats(freshStats)
+      } catch {
+        toast.error("Actualisation impossible. Vérifiez votre réseau.")
+      }
     })
   }
 

--- a/app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx
+++ b/app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { updateUserRole } from "@/features/users/actions"
 import type { AdminUserDetail } from "@/features/users/dal"
+import { callAction } from "@/lib/safe-action"
 
 interface UserRoleSectionProps {
   user: Pick<AdminUserDetail, "id" | "name" | "email" | "role">
@@ -37,10 +38,14 @@ export const UserRoleSection = ({
 
   const handleConfirm = () => {
     startTransition(async () => {
-      const result = await updateUserRole({
-        userId: user.id,
-        role: isAdmin ? "user" : "admin",
-      })
+      // callAction : un rejet fetch dans une transition remonterait à l'error
+      // boundary au rendu (React 19), pas seulement en unhandled rejection
+      const result = await callAction(() =>
+        updateUserRole({
+          userId: user.id,
+          role: isAdmin ? "user" : "admin",
+        }),
+      )
       if (result.success) {
         toast.success(
           isAdmin

--- a/app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx
+++ b/app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, CreditCard } from "lucide-react"
 import { motion } from "motion/react"
 import Link from "next/link"
 import { useState, useTransition } from "react"
+import { toast } from "sonner"
 import { ManualPaymentModal } from "@/components/shared/payments/manual-payment-modal"
 import {
   type Transaction,
@@ -63,22 +64,30 @@ export function UserDetailClient({
   const handleLoadMore = () => {
     if (!cursor) return
     startLoadMore(async () => {
-      const page = await loadAdminTransactions({ userId: user.id, cursor })
-      setItems((prev) => [...prev, ...page.items.map(adminTransactionToRow)])
-      setCursor(page.nextCursor)
+      try {
+        const page = await loadAdminTransactions({ userId: user.id, cursor })
+        setItems((prev) => [...prev, ...page.items.map(adminTransactionToRow)])
+        setCursor(page.nextCursor)
+      } catch {
+        toast.error("Impossible de charger plus de transactions.")
+      }
     })
   }
 
   // Après un octroi : recharge transactions (1re page) + statut d'accès.
   const handlePaymentSuccess = () => {
     startRefresh(async () => {
-      const [page, fresh] = await Promise.all([
-        loadAdminTransactions({ userId: user.id }),
-        loadUserAccessStatus(user.id),
-      ])
-      setItems(page.items.map(adminTransactionToRow))
-      setCursor(page.nextCursor)
-      setAccess(fresh)
+      try {
+        const [page, fresh] = await Promise.all([
+          loadAdminTransactions({ userId: user.id }),
+          loadUserAccessStatus(user.id),
+        ])
+        setItems(page.items.map(adminTransactionToRow))
+        setCursor(page.nextCursor)
+        setAccess(fresh)
+      } catch {
+        toast.error("Actualisation impossible. Vérifiez votre réseau.")
+      }
     })
   }
 

--- a/app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx
+++ b/app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx
@@ -243,16 +243,27 @@ function PanelContent({
   // Recharge les données du panel (depuis un handler, après un octroi d'accès).
   const refresh = () => {
     setPanelData(undefined)
-    loadUserPanelData(userId).then(setPanelData)
+    loadUserPanelData(userId)
+      .then(setPanelData)
+      .catch(() => {
+        setPanelData(null)
+        toast.error("Chargement impossible. Vérifiez votre réseau.")
+      })
   }
   // Chargement initial. `PanelContent` est monté avec `key={userId}` → un nouvel
   // utilisateur = nouveau montage (état `undefined` = skeleton), pas de setState
   // synchrone dans l'effet (uniquement dans le callback async).
   useEffect(() => {
     let active = true
-    loadUserPanelData(userId).then((d) => {
-      if (active) setPanelData(d)
-    })
+    loadUserPanelData(userId)
+      .then((d) => {
+        if (active) setPanelData(d)
+      })
+      .catch(() => {
+        if (!active) return
+        setPanelData(null)
+        toast.error("Chargement impossible. Vérifiez votre réseau.")
+      })
     return () => {
       active = false
     }

--- a/app/(admin)/admin/utilisateurs/_components/users-manager.tsx
+++ b/app/(admin)/admin/utilisateurs/_components/users-manager.tsx
@@ -4,6 +4,7 @@ import { IconUsers } from "@tabler/icons-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useRef, useState, useTransition } from "react"
 import { DateRange } from "react-day-picker"
+import { toast } from "sonner"
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
 import { ExportUsersButton } from "@/components/admin/export-users-button"
 import { TablePagination } from "@/components/admin/table-pagination"
@@ -104,17 +105,21 @@ export function UsersManager({
       return
     }
     startTransition(async () => {
-      const res = await loadUsersPage({
-        ...buildFilters(),
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-      })
-      setUsers(res.items)
-      setTotal(res.total)
-      // Clamp hors-borne (callback async → ESLint OK) : page devenue vide
-      // après une mutation → ramène à la dernière page valide.
-      if (res.items.length === 0 && page > 1 && res.total > 0) {
-        setPage(Math.ceil(res.total / pageSize))
+      try {
+        const res = await loadUsersPage({
+          ...buildFilters(),
+          offset: (page - 1) * pageSize,
+          limit: pageSize,
+        })
+        setUsers(res.items)
+        setTotal(res.total)
+        // Clamp hors-borne (callback async → ESLint OK) : page devenue vide
+        // après une mutation → ramène à la dernière page valide.
+        if (res.items.length === 0 && page > 1 && res.total > 0) {
+          setPage(Math.ceil(res.total / pageSize))
+        }
+      } catch {
+        toast.error("Actualisation impossible. Vérifiez votre réseau.")
       }
     })
   }, [buildFilters, page, pageSize])
@@ -122,17 +127,21 @@ export function UsersManager({
   // Recharge la page courante (après un octroi d'accès depuis le panneau).
   const reload = () => {
     startTransition(async () => {
-      const res = await loadUsersPage({
-        ...buildFilters(),
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-      })
-      setUsers(res.items)
-      setTotal(res.total)
-      // Même clamp hors-borne que l'effet : une mutation qui vide la page
-      // courante ramène à la dernière page valide.
-      if (res.items.length === 0 && page > 1 && res.total > 0) {
-        setPage(Math.ceil(res.total / pageSize))
+      try {
+        const res = await loadUsersPage({
+          ...buildFilters(),
+          offset: (page - 1) * pageSize,
+          limit: pageSize,
+        })
+        setUsers(res.items)
+        setTotal(res.total)
+        // Même clamp hors-borne que l'effet : une mutation qui vide la page
+        // courante ramène à la dernière page valide.
+        if (res.items.length === 0 && page > 1 && res.total > 0) {
+          setPage(Math.ceil(res.total / pageSize))
+        }
+      } catch {
+        toast.error("Actualisation impossible. Vérifiez votre réseau.")
       }
     })
   }

--- a/app/(dashboard)/tableau-de-bord/abonnements/_components/abonnements-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/abonnements/_components/abonnements-client.tsx
@@ -55,6 +55,7 @@ import type {
   ProductView,
 } from "@/features/payments/dal"
 import { formatExpiration } from "@/lib/format"
+import { callAction } from "@/lib/safe-action"
 import { cn } from "@/lib/utils"
 
 const accessTypeConfig = {
@@ -260,7 +261,12 @@ export const AbonnementsClient = ({
 
   const [, openPortalAction, isLoadingPortal] = useActionState(
     async () => {
-      const res = await createCustomerPortal("/tableau-de-bord/abonnements")
+      // callAction : sans lui, un rejet fetch dans une action useActionState
+      // remonte à l'error boundary au rendu (React 19) — ActionFailure porte
+      // `error`, le garde ci-dessous l'attrape aussi
+      const res = await callAction(() =>
+        createCustomerPortal("/tableau-de-bord/abonnements"),
+      )
       if ("error" in res) {
         if (!navigator.onLine) {
           toast.error("Pas de connexion internet. Vérifiez votre réseau.")

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
@@ -60,10 +60,15 @@ export const TrainingConfigForm = ({
 
   useEffect(() => {
     startObjLoad(async () => {
-      const res = await loadAvailableObjectifsCMC(
-        selectedDomain === "all" ? undefined : selectedDomain,
-      )
-      setFilteredObjectifs(res)
+      try {
+        const res = await loadAvailableObjectifsCMC(
+          selectedDomain === "all" ? undefined : selectedDomain,
+        )
+        setFilteredObjectifs(res)
+      } catch {
+        // rejet réseau : la liste reste sur l'état précédent, pas de toast
+        // bloquant (le changement de domaine peut être retenté)
+      }
     })
   }, [selectedDomain])
 

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
@@ -66,8 +66,11 @@ export const TrainingConfigForm = ({
         )
         setFilteredObjectifs(res)
       } catch {
-        // rejet réseau : la liste reste sur l'état précédent, pas de toast
-        // bloquant (le changement de domaine peut être retenté)
+        // rejet réseau : la liste affichée reste celle de l'ANCIEN domaine —
+        // signaler, sinon l'UX ment sans aucun indice
+        toast.error(
+          "Impossible de charger les objectifs du domaine. Vérifiez votre réseau.",
+        )
       }
     })
   }, [selectedDomain])

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-history-section.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-history-section.tsx
@@ -15,6 +15,7 @@ import {
 import { motion } from "motion/react"
 import { useRouter } from "next/navigation"
 import { useState, useTransition } from "react"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -71,9 +72,15 @@ export const TrainingHistorySection = ({
   const loadMore = () => {
     if (cursor === null) return
     startLoadMore(async () => {
-      const page = await loadTrainingHistory({ cursor, limit: 5 })
-      setSessions((prev) => [...prev, ...page.items])
-      setCursor(page.nextCursor)
+      try {
+        const page = await loadTrainingHistory({ cursor, limit: 5 })
+        setSessions((prev) => [...prev, ...page.items])
+        setCursor(page.nextCursor)
+      } catch {
+        toast.error(
+          "Impossible de charger l'historique. Vérifiez votre réseau.",
+        )
+      }
     })
   }
 

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx
@@ -17,6 +17,7 @@ import {
   saveTrainingAnswer,
 } from "@/features/training/actions"
 import type { TrainingSessionView } from "@/features/training/dal"
+import { callAction } from "@/lib/safe-action"
 
 type SessionData = NonNullable<TrainingSessionView>
 
@@ -110,11 +111,10 @@ export const TrainingSessionClient = ({
 
   const callbacks: QuizCallbacks = {
     onAnswer: async (questionId, selectedAnswer) => {
-      const res = await saveTrainingAnswer({
-        sessionId,
-        questionId,
-        selectedAnswer,
-      })
+      const res = await callAction(
+        () => saveTrainingAnswer({ sessionId, questionId, selectedAnswer }),
+        { retries: 1 }, // upsert idempotent — absorbe les micro-coupures
+      )
       if (!res.success) {
         toast.error("Réponse non enregistrée, réessayez.")
         return { ok: false, error: res.error }
@@ -134,7 +134,7 @@ export const TrainingSessionClient = ({
     // Flags d'entraînement restent locaux — no-op serveur
     onFlag: async () => ({ ok: true }),
     onFinish: async () => {
-      const res = await completeTrainingSession({ sessionId })
+      const res = await callAction(() => completeTrainingSession({ sessionId }))
       if (!res.success) {
         toast.error("Erreur", { description: res.error })
         return { ok: false }

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx
@@ -132,7 +132,7 @@ export const TrainingSessionClient = ({
       }
     },
     // Flags d'entraînement restent locaux — no-op serveur
-    onFlag: async () => {},
+    onFlag: async () => ({ ok: true }),
     onFinish: async () => {
       const res = await completeTrainingSession({ sessionId })
       if (!res.success) {

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
@@ -32,6 +32,7 @@ import type {
   ExamQuestionView,
   ExamSessionView,
 } from "@/features/exams/dal"
+import { callAction } from "@/lib/safe-action"
 
 interface EvaluationExam {
   title: string
@@ -128,7 +129,10 @@ export function EvaluationClient({
   // Callbacks
   const callbacks: QuizCallbacks = {
     onAnswer: async (questionId, selectedAnswer) => {
-      const res = await saveExamAnswer({ examId, questionId, selectedAnswer })
+      const res = await callAction(
+        () => saveExamAnswer({ examId, questionId, selectedAnswer }),
+        { retries: 1 }, // upsert idempotent — absorbe les micro-coupures
+      )
       if (!res.success) {
         toast.error("Réponse non enregistrée, réessayez.")
         return {
@@ -140,19 +144,22 @@ export function EvaluationClient({
       return { ok: true }
     },
     onFlag: async (questionId, isFlagged) => {
-      const res = await saveExamFlag({ examId, questionId, isFlagged })
+      const res = await callAction(
+        () => saveExamFlag({ examId, questionId, isFlagged }),
+        { retries: 1 },
+      )
       return { ok: res.success }
     },
     onFinish: async ({ isAutoSubmit }) => {
-      const result = await finalizeExam({ examId, isAutoSubmit })
+      const result = await callAction(() =>
+        finalizeExam({ examId, isAutoSubmit }),
+      )
       if (!result.success) {
-        if (
-          result.error.includes("déjà passé") ||
-          result.error.includes("plus active")
-        ) {
+        const error = result.error ?? "Erreur lors de la soumission"
+        if (error.includes("déjà passé") || error.includes("plus active")) {
           router.push("/tableau-de-bord/examen-blanc")
         }
-        toast.error(result.error)
+        toast.error(error)
         return { ok: false }
       }
       if (isAutoSubmit) {
@@ -170,29 +177,26 @@ export function EvaluationClient({
     },
     onPause: exam.enablePause
       ? async () => {
-          const res = await pauseExam({ examId })
+          const res = await callAction(() => pauseExam({ examId }))
           if (res.success) {
             toast.info("⏸️ Pause - Prenez une pause bien méritée !", {
               duration: 5000,
             })
           } else {
-            toast.error(res.error)
+            toast.error(res.error ?? "Erreur lors de la mise en pause")
           }
           return { ok: res.success }
         }
       : undefined,
     onResume: exam.enablePause
       ? async () => {
-          const res = await resumeExam({ examId })
+          const res = await callAction(() => resumeExam({ examId }))
           if (res.success) {
             toast.success("Pause terminée - Continuez l'examen !")
-          } else {
-            toast.error(res.error)
+            return { ok: true, totalPauseDurationMs: res.totalPauseDurationMs }
           }
-          return {
-            ok: res.success,
-            totalPauseDurationMs: res.totalPauseDurationMs,
-          }
+          toast.error(res.error ?? "Erreur lors de la reprise")
+          return { ok: false }
         }
       : undefined,
   }

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
@@ -140,7 +140,8 @@ export function EvaluationClient({
       return { ok: true }
     },
     onFlag: async (questionId, isFlagged) => {
-      await saveExamFlag({ examId, questionId, isFlagged })
+      const res = await saveExamFlag({ examId, questionId, isFlagged })
+      return { ok: res.success }
     },
     onFinish: async ({ isAutoSubmit }) => {
       const result = await finalizeExam({ examId, isAutoSubmit })

--- a/app/(dashboard)/tableau-de-bord/profil/_components/profile-danger-zone.tsx
+++ b/app/(dashboard)/tableau-de-bord/profil/_components/profile-danger-zone.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { deleteMyAccount } from "@/features/users/actions"
 import { authClient } from "@/lib/auth-client"
+import { callAction } from "@/lib/safe-action"
 
 export const ProfileDangerZone = ({ email }: { email: string }) => {
   const router = useRouter()
@@ -20,13 +21,15 @@ export const ProfileDangerZone = ({ email }: { email: string }) => {
   const onDelete = async () => {
     if (!matches) return
     setBusy(true)
-    const res = await deleteMyAccount({ confirmEmail })
+    const res = await callAction(() => deleteMyAccount({ confirmEmail }))
     if (!res.success) {
       setBusy(false)
       toast.error(res.error ?? "Suppression impossible")
       return
     }
-    await authClient.signOut()
+    // Le compte est supprimé côté serveur : rediriger même si le signOut
+    // échoue (la session ne survivra pas côté serveur de toute façon)
+    await authClient.signOut().catch(() => {})
     router.replace("/compte-supprime")
   }
 

--- a/app/(dashboard)/tableau-de-bord/profil/_components/profile-notifications.tsx
+++ b/app/(dashboard)/tableau-de-bord/profil/_components/profile-notifications.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 import { Switch } from "@/components/ui/switch"
 import { updateNotificationPreferences } from "@/features/notifications/actions"
 import type { NotificationPreferences } from "@/features/notifications/dal"
+import { callAction } from "@/lib/safe-action"
 
 export const ProfileNotifications = ({
   preferences,
@@ -19,7 +20,7 @@ export const ProfileNotifications = ({
     const prev = prefs
     setPrefs(next) // optimistic
     setBusy(true)
-    const res = await updateNotificationPreferences(next)
+    const res = await callAction(() => updateNotificationPreferences(next))
     setBusy(false)
     if (!res.success) {
       setPrefs(prev) // rollback

--- a/app/(dashboard)/tableau-de-bord/profil/_components/profile-password.tsx
+++ b/app/(dashboard)/tableau-de-bord/profil/_components/profile-password.tsx
@@ -23,6 +23,7 @@ import { Input } from "@/components/ui/input"
 import { setAccountPassword } from "@/features/users/actions"
 import { authClient } from "@/lib/auth-client"
 import { mapAuthError } from "@/lib/auth-errors"
+import { callAction } from "@/lib/safe-action"
 import {
   type ChangePasswordFormValues,
   type ResetPasswordFormValues,
@@ -44,7 +45,9 @@ const SetPasswordForm = () => {
   })
 
   const onSubmit = async (values: ResetPasswordFormValues) => {
-    const res = await setAccountPassword({ newPassword: values.password })
+    const res = await callAction(() =>
+      setAccountPassword({ newPassword: values.password }),
+    )
     if (!res.success) {
       toast.error(res.error ?? "Impossible de définir le mot de passe")
       return

--- a/app/(dashboard)/tableau-de-bord/profil/_components/profile-sessions.tsx
+++ b/app/(dashboard)/tableau-de-bord/profil/_components/profile-sessions.tsx
@@ -12,6 +12,7 @@ import {
   revokeUserSession,
 } from "@/features/users/actions"
 import type { UserSession } from "@/features/users/dal"
+import { callAction } from "@/lib/safe-action"
 
 export const ProfileSessions = ({ sessions }: { sessions: UserSession[] }) => {
   const router = useRouter()
@@ -20,7 +21,7 @@ export const ProfileSessions = ({ sessions }: { sessions: UserSession[] }) => {
 
   const revokeOne = async (id: string) => {
     setBusy(true)
-    const res = await revokeUserSession(id)
+    const res = await callAction(() => revokeUserSession(id))
     setBusy(false)
     if (!res.success) {
       toast.error(res.error ?? "Échec de la révocation")
@@ -32,7 +33,7 @@ export const ProfileSessions = ({ sessions }: { sessions: UserSession[] }) => {
 
   const revokeOthers = async () => {
     setBusy(true)
-    const res = await revokeOtherUserSessions()
+    const res = await callAction(() => revokeOtherUserSessions())
     setBusy(false)
     if (!res.success) {
       toast.error(res.error ?? "Échec")

--- a/components/admin/exams-list.tsx
+++ b/components/admin/exams-list.tsx
@@ -92,7 +92,7 @@ export function ExamsList({ exams, onExamSelect }: ExamsListProps) {
   }
 
   const handleReactivate = async (examId: string) => {
-    const res = await reactivateExam({ examId })
+    const res = await callAction(() => reactivateExam({ examId }))
     if (res.success) {
       toast.success("Examen réactivé avec succès")
       router.refresh()

--- a/components/admin/exams-list.tsx
+++ b/components/admin/exams-list.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/features/exams/actions"
 import type { AdminExamListItem } from "@/features/exams/dal"
 import { ExamStatus, getExamStatus } from "@/lib/exam-status"
+import { callAction } from "@/lib/safe-action"
 import { ExamCard } from "./exam-card"
 import { ExamStatusFilter } from "./exam-status-filter"
 
@@ -78,7 +79,7 @@ export function ExamsList({ exams, onExamSelect }: ExamsListProps) {
 
   const performDeactivate = async (examId: string) => {
     setIsPending(true)
-    const res = await deactivateExam({ examId })
+    const res = await callAction(() => deactivateExam({ examId }))
     setIsPending(false)
     if (res.success) {
       toast.success("Examen désactivé avec succès")
@@ -116,7 +117,7 @@ export function ExamsList({ exams, onExamSelect }: ExamsListProps) {
 
   const performDelete = async (examId: string) => {
     setIsPending(true)
-    const res = await deleteExam({ examId })
+    const res = await callAction(() => deleteExam({ examId }))
     setIsPending(false)
     if (res.success) {
       toast.success("Examen supprimé avec succès")

--- a/components/admin/question-browser/question-browser-context.tsx
+++ b/components/admin/question-browser/question-browser-context.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   useTransition,
 } from "react"
+import { toast } from "sonner"
 import type { ExamPickerOption } from "@/features/exams/dal"
 import { loadQuestionsPage } from "@/features/questions/actions"
 import type { QuestionListItem } from "@/features/questions/dal"
@@ -136,19 +137,25 @@ export function QuestionBrowserProvider({
   // jamais laisser une page vide sans pagination visible.
   const fetchPage = useCallback(() => {
     startFetch(async () => {
-      const res = await loadQuestionsPage({
-        ...queryArgs,
-        page,
-        limit: pageSize,
-      })
-      setQuestions(res.items.map(toRow))
-      setTotal(res.total)
-      setHasLoaded(true)
-      // Clamp hors-borne (callback async → ESLint OK) : page devenue vide
-      // → ramène à la dernière page valide (pas de boucle : quand total > 0,
-      // la dernière page a toujours des items).
-      if (res.items.length === 0 && page > 1 && res.total > 0) {
-        setPageState(Math.ceil(res.total / pageSize))
+      try {
+        const res = await loadQuestionsPage({
+          ...queryArgs,
+          page,
+          limit: pageSize,
+        })
+        setQuestions(res.items.map(toRow))
+        setTotal(res.total)
+        setHasLoaded(true)
+        // Clamp hors-borne (callback async → ESLint OK) : page devenue vide
+        // → ramène à la dernière page valide (pas de boucle : quand total > 0,
+        // la dernière page a toujours des items).
+        if (res.items.length === 0 && page > 1 && res.total > 0) {
+          setPageState(Math.ceil(res.total / pageSize))
+        }
+      } catch {
+        // rejet réseau : sortir du skeleton initial (liste vide/stale) + toast
+        setHasLoaded(true)
+        toast.error("Chargement impossible. Vérifiez votre réseau.")
       }
     })
   }, [queryArgs, page, pageSize])

--- a/components/admin/question-browser/question-preview-panel.tsx
+++ b/components/admin/question-browser/question-preview-panel.tsx
@@ -69,9 +69,14 @@ function PanelContent({ questionId }: { questionId: string }) {
 
   useEffect(() => {
     let active = true
-    loadQuestionById(questionId).then((q) => {
-      if (active) setState({ id: questionId, q })
-    })
+    loadQuestionById(questionId)
+      .then((q) => {
+        if (active) setState({ id: questionId, q })
+      })
+      .catch(() => {
+        // rejet réseau : sortir du skeleton via l'état « introuvable »
+        if (active) setState({ id: questionId, q: null })
+      })
     return () => {
       active = false
     }

--- a/components/quiz/pause-dialog.tsx
+++ b/components/quiz/pause-dialog.tsx
@@ -36,8 +36,12 @@ export const PauseDialog = ({
   const [pauseTimeRemaining, setPauseTimeRemaining] = useState(0)
   // L'auto-resume tourne dans un interval 1 s : sans one-shot, une reprise qui
   // échoue (réseau coupé) re-déclencherait onResume — et son toast d'erreur —
-  // à chaque tick. En cas d'échec, le bouton reste la voie de retentative.
-  const autoResumeFiredRef = useRef(false)
+  // à chaque tick. La garde est la CLÉ de la pause (pauseStartedAt), jamais
+  // remise à zéro : un booléen resetté en tête d'effet ne tient pas, `onResume`
+  // (inline, recréé à chaque render du runner) ré-exécute l'effet pendant que
+  // le premier resume est en vol. En cas d'échec, le bouton reste la voie de
+  // retentative.
+  const autoResumeFiredForRef = useRef<number | undefined>(undefined)
 
   // Derive progress from pauseTimeRemaining (no need for separate state)
   const totalPauseMs = pauseDurationMinutes * 60 * 1000
@@ -49,7 +53,6 @@ export const PauseDialog = ({
   // Update pause countdown
   useEffect(() => {
     if (!isOpen || !pauseStartedAt) return
-    autoResumeFiredRef.current = false // nouvelle pause = nouveau one-shot
 
     const updatePauseTime = () => {
       const remaining = calculatePauseTimeRemaining(
@@ -58,12 +61,12 @@ export const PauseDialog = ({
       )
       setPauseTimeRemaining(remaining)
 
-      // Auto-resume when pause timer expires (one-shot)
+      // Auto-resume when pause timer expires (one-shot par clé de pause)
       if (
         isPauseExpired(pauseStartedAt, pauseDurationMinutes) &&
-        !autoResumeFiredRef.current
+        autoResumeFiredForRef.current !== pauseStartedAt
       ) {
-        autoResumeFiredRef.current = true
+        autoResumeFiredForRef.current = pauseStartedAt
         onResume()
       }
     }

--- a/components/quiz/pause-dialog.tsx
+++ b/components/quiz/pause-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { Coffee, Play, Timer } from "lucide-react"
 import { motion } from "motion/react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import {
@@ -34,6 +34,10 @@ export const PauseDialog = ({
   isResuming = false,
 }: PauseDialogProps) => {
   const [pauseTimeRemaining, setPauseTimeRemaining] = useState(0)
+  // L'auto-resume tourne dans un interval 1 s : sans one-shot, une reprise qui
+  // échoue (réseau coupé) re-déclencherait onResume — et son toast d'erreur —
+  // à chaque tick. En cas d'échec, le bouton reste la voie de retentative.
+  const autoResumeFiredRef = useRef(false)
 
   // Derive progress from pauseTimeRemaining (no need for separate state)
   const totalPauseMs = pauseDurationMinutes * 60 * 1000
@@ -45,6 +49,7 @@ export const PauseDialog = ({
   // Update pause countdown
   useEffect(() => {
     if (!isOpen || !pauseStartedAt) return
+    autoResumeFiredRef.current = false // nouvelle pause = nouveau one-shot
 
     const updatePauseTime = () => {
       const remaining = calculatePauseTimeRemaining(
@@ -53,8 +58,12 @@ export const PauseDialog = ({
       )
       setPauseTimeRemaining(remaining)
 
-      // Auto-resume when pause timer expires
-      if (isPauseExpired(pauseStartedAt, pauseDurationMinutes)) {
+      // Auto-resume when pause timer expires (one-shot)
+      if (
+        isPauseExpired(pauseStartedAt, pauseDurationMinutes) &&
+        !autoResumeFiredRef.current
+      ) {
+        autoResumeFiredRef.current = true
         onResume()
       }
     }

--- a/components/quiz/results/session-results.tsx
+++ b/components/quiz/results/session-results.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react"
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
 import { QuestionCard } from "@/components/quiz/question-card"
 import { ResultsQuestionNavigator } from "@/components/quiz/results"
 import type { AnswersMap, QuizQuestion } from "@/components/quiz/runner/types"
@@ -153,21 +154,27 @@ export function SessionResults({
     )
     if (toLoad.length === 0) return
     let active = true
-    loadExplanations(toLoad).then((rows) => {
-      if (!active) return
-      setExplanationsMap((prev) => {
-        const next = new Map(prev)
-        for (const row of rows) {
-          next.set(row.questionId, {
-            explanation: row.explanation,
-            references: row.references,
-            explanationImages: row.explanationImages,
-          })
-        }
-        return next
+    loadExplanations(toLoad)
+      .then((rows) => {
+        if (!active) return
+        setExplanationsMap((prev) => {
+          const next = new Map(prev)
+          for (const row of rows) {
+            next.set(row.questionId, {
+              explanation: row.explanation,
+              references: row.references,
+              explanationImages: row.explanationImages,
+            })
+          }
+          return next
+        })
+        for (const id of toLoad) loadedIds.current.add(id)
       })
-      for (const id of toLoad) loadedIds.current.add(id)
-    })
+      .catch(() => {
+        // loadedIds non marqué : re-déplier la question retente le chargement
+        if (!active) return
+        toast.error("Explications indisponibles. Vérifiez votre réseau.")
+      })
     return () => {
       active = false
     }

--- a/components/quiz/runner/quiz-runner.tsx
+++ b/components/quiz/runner/quiz-runner.tsx
@@ -112,9 +112,10 @@ function QuizRunnerInner({
           onTakePause: () => {
             // Capture start time before async call, then delegate to the hook
             const startedAt = Date.now()
-            void session.pause().then(() => {
-              // session.isPaused may not have updated yet (async state); set optimistically
-              setLocalPauseStartedAt(startedAt)
+            void session.pause().then((ok) => {
+              // session.isPaused may not have updated yet (async state); set
+              // optimistically — but only when the pause actually succeeded
+              if (ok) setLocalPauseStartedAt(startedAt)
             })
           },
         }
@@ -124,8 +125,11 @@ function QuizRunnerInner({
   const handleResume = async () => {
     setIsResuming(true)
     try {
-      await session.resume()
-      setLocalPauseStartedAt(undefined)
+      const ok = await session.resume()
+      // Sur échec (réseau), garder le timestamp : le décompte de l'overlay
+      // continue et l'auto-resume reste armé — seule une reprise RÉUSSIE
+      // ferme la pause.
+      if (ok) setLocalPauseStartedAt(undefined)
     } finally {
       setIsResuming(false)
     }

--- a/components/quiz/runner/types.ts
+++ b/components/quiz/runner/types.ts
@@ -41,7 +41,8 @@ export type QuizCallbacks = {
   ) => Promise<
     { ok: true; reveal?: QuizRevealPayload } | { ok: false; error: string }
   >
-  onFlag: (questionId: string, isFlagged: boolean) => Promise<void>
+  // { ok } permet au moteur de rollback le flag local sur échec
+  onFlag: (questionId: string, isFlagged: boolean) => Promise<{ ok: boolean }>
   onFinish: (opts: {
     isAutoSubmit: boolean
   }) => Promise<{ ok: boolean; redirectTo?: string }>

--- a/components/quiz/runner/use-quiz-session.ts
+++ b/components/quiz/runner/use-quiz-session.ts
@@ -60,8 +60,10 @@ export type UseQuizSessionResult = {
   // server already recorded a pause, or after a successful resume). Lets the UI
   // hide the pause button — the server only allows one pause.
   pauseAlreadyUsed: boolean
-  pause: () => Promise<void>
-  resume: () => Promise<void>
+  // Résolvent `true` en succès seulement — l'UI (timestamps locaux de
+  // l'overlay) ne doit pas avancer sur une pause/reprise qui a échoué.
+  pause: () => Promise<boolean>
+  resume: () => Promise<boolean>
 
   // Timer (only when mode.timer is set)
   timer: {
@@ -102,6 +104,15 @@ export function useQuizSession({
       Object.entries(initialAnswers).map(([qid, a]) => [qid, a.selected]),
     ),
   )
+  // Flags : même mécanique que les réponses. Le miroir ref évite la closure
+  // périmée (le raccourci clavier « f » peut invoquer deux fois la même
+  // closure) ; l'envoi sérialisé + rollback vers la valeur confirmée évite
+  // les reverts non composables (deux échecs qui laissent l'inverse).
+  const flaggedRef = useRef<Set<string>>(new Set(initialFlags ?? []))
+  const flagSends = useRef<
+    Record<string, { inFlight: boolean; queued?: boolean }>
+  >({})
+  const persistedFlags = useRef<Set<string>>(new Set(initialFlags ?? []))
   const [flagged, setFlagged] = useState<Set<string>>(
     () => new Set(initialFlags ?? []),
   )
@@ -154,37 +165,59 @@ export function useQuizSession({
 
   // ---- Flag ----
 
+  const setFlagLocal = useCallback((qid: string, value: boolean) => {
+    if (value) {
+      flaggedRef.current.add(qid)
+    } else {
+      flaggedRef.current.delete(qid)
+    }
+    setFlagged(new Set(flaggedRef.current))
+  }, [])
+
   const toggleFlag = useCallback(() => {
     if (!currentQuestion) return
     const qid = currentQuestion._id
-    const newValue = !flagged.has(qid)
-    setFlagged((prev) => {
-      const next = new Set(prev)
-      if (newValue) {
-        next.add(qid)
-      } else {
-        next.delete(qid)
-      }
-      return next
-    })
-    const revert = () =>
-      setFlagged((prev) => {
-        const next = new Set(prev)
-        if (newValue) {
-          next.delete(qid)
-        } else {
-          next.add(qid)
+    const newValue = !flaggedRef.current.has(qid)
+    setFlagLocal(qid, newValue)
+
+    const state = (flagSends.current[qid] ??= { inFlight: false })
+    if (state.inFlight) {
+      state.queued = newValue
+      return
+    }
+    state.inFlight = true
+    // Envoi sérialisé (un seul onFlag en vol par question, coalescing du
+    // dernier état voulu). Silencieux : cosmétique, pas de bruit en passation.
+    void (async () => {
+      let current = newValue
+      for (;;) {
+        let ok: boolean
+        try {
+          ok = (await callbacks.onFlag(qid, current)).ok
+        } catch {
+          ok = false
         }
-        return next
-      })
-    // Silencieux (pas de toast) : cosmétique, pas de bruit en passation.
-    callbacks.onFlag(qid, newValue).then(
-      (res) => {
-        if (!res.ok) revert()
-      },
-      () => revert(),
-    )
-  }, [currentQuestion, flagged, callbacks])
+        if (ok) {
+          if (current) {
+            persistedFlags.current.add(qid)
+          } else {
+            persistedFlags.current.delete(qid)
+          }
+        }
+        const queued = state.queued
+        state.queued = undefined
+        if (queued !== undefined) {
+          current = queued
+          continue
+        }
+        state.inFlight = false
+        if (!ok) {
+          setFlagLocal(qid, persistedFlags.current.has(qid))
+        }
+        return
+      }
+    })()
+  }, [currentQuestion, callbacks, setFlagLocal])
 
   // ---- Answer select ----
 
@@ -291,19 +324,21 @@ export function useQuizSession({
   // ---- Pause / resume (rest break) ----
 
   const pause = useCallback(async () => {
-    if (!callbacks.onPause || isPaused) return
+    if (!callbacks.onPause || isPaused) return false
     try {
       const res = await callbacks.onPause()
       if (res.ok) {
         setIsPaused(true)
       }
+      return res.ok
     } catch {
       // rejet réseau : rester non-pausé, le callback de page a déjà toasté
+      return false
     }
   }, [callbacks, isPaused])
 
   const resume = useCallback(async () => {
-    if (!callbacks.onResume || !isPaused) return
+    if (!callbacks.onResume || !isPaused) return false
     try {
       const res = await callbacks.onResume()
       if (res.ok) {
@@ -312,8 +347,10 @@ export function useQuizSession({
         // The single rest pause is now consumed — hide the pause control.
         setPauseAlreadyUsed(true)
       }
+      return res.ok
     } catch {
       // rejet réseau : rester en pause, retentable via le bouton
+      return false
     }
   }, [callbacks, isPaused])
 

--- a/components/quiz/runner/use-quiz-session.ts
+++ b/components/quiz/runner/use-quiz-session.ts
@@ -88,6 +88,20 @@ export function useQuizSession({
   const [answers, setAnswers] = useState<AnswersMap>(() => ({
     ...initialAnswers,
   }))
+  // Un seul onAnswer en vol par question ; le clic le plus récent pendant un
+  // envoi remplace le précédent (coalescing) et part quand l'envoi se règle.
+  // Un éventuel retry côté callback vit DANS ce créneau → l'ordre des clics
+  // est préservé, un clic périmé ne peut pas écraser un clic plus récent.
+  const answerSends = useRef<
+    Record<string, { inFlight: boolean; queued?: string }>
+  >({})
+  // Dernière valeur CONFIRMÉE par le serveur — cible du rollback (jamais
+  // « l'état d'avant-clic », qu'un clic intermédiaire a pu rendre périmé).
+  const persistedAnswers = useRef<Record<string, string | undefined>>(
+    Object.fromEntries(
+      Object.entries(initialAnswers).map(([qid, a]) => [qid, a.selected]),
+    ),
+  )
   const [flagged, setFlagged] = useState<Set<string>>(
     () => new Set(initialFlags ?? []),
   )
@@ -143,19 +157,34 @@ export function useQuizSession({
   const toggleFlag = useCallback(() => {
     if (!currentQuestion) return
     const qid = currentQuestion._id
+    const newValue = !flagged.has(qid)
     setFlagged((prev) => {
       const next = new Set(prev)
-      const newValue = !next.has(qid)
       if (newValue) {
         next.add(qid)
       } else {
         next.delete(qid)
       }
-      // Fire-and-forget — errors are non-fatal for flagging
-      void callbacks.onFlag(qid, newValue)
       return next
     })
-  }, [currentQuestion, callbacks])
+    const revert = () =>
+      setFlagged((prev) => {
+        const next = new Set(prev)
+        if (newValue) {
+          next.delete(qid)
+        } else {
+          next.add(qid)
+        }
+        return next
+      })
+    // Silencieux (pas de toast) : cosmétique, pas de bruit en passation.
+    callbacks.onFlag(qid, newValue).then(
+      (res) => {
+        if (!res.ok) revert()
+      },
+      () => revert(),
+    )
+  }, [currentQuestion, flagged, callbacks])
 
   // ---- Answer select ----
 
@@ -177,24 +206,50 @@ export function useQuizSession({
       }
 
       // Test / examen (feedback différé) : enregistrement immédiat, pas de
-      // révélation par-question. Mise à jour optimiste + rollback si échec.
-      const prev = answers[qid]
+      // révélation par-question. Optimiste + envoi sérialisé par question.
       setAnswers((a) => ({ ...a, [qid]: { ...a[qid], selected } }))
 
-      const res = await callbacks.onAnswer(qid, selected)
-      if (!res.ok) {
-        setAnswers((a) => {
-          const next = { ...a }
-          if (prev === undefined) {
-            delete next[qid]
-          } else {
-            next[qid] = prev
-          }
-          return next
-        })
+      const state = (answerSends.current[qid] ??= { inFlight: false })
+      if (state.inFlight) {
+        state.queued = selected
+        return
+      }
+      state.inFlight = true
+      let current = selected
+      for (;;) {
+        let res: Awaited<ReturnType<QuizCallbacks["onAnswer"]>>
+        try {
+          res = await callbacks.onAnswer(qid, current)
+        } catch {
+          res = { ok: false, error: "Erreur réseau" }
+        }
+        const queued = state.queued
+        state.queued = undefined
+        if (queued !== undefined) {
+          // Supersédé par un clic plus récent : ni rollback ni validation —
+          // on envoie le dernier choix.
+          current = queued
+          continue
+        }
+        state.inFlight = false
+        if (res.ok) {
+          persistedAnswers.current[qid] = current
+        } else {
+          const persisted = persistedAnswers.current[qid]
+          setAnswers((a) => {
+            const next = { ...a }
+            if (persisted === undefined) {
+              delete next[qid]
+            } else {
+              next[qid] = { ...next[qid], selected: persisted }
+            }
+            return next
+          })
+        }
+        return
       }
     },
-    [currentQuestion, answers, callbacks, isImmediate, revealed],
+    [currentQuestion, callbacks, isImmediate, revealed],
   )
 
   // ---- Confirm (mode tuteur uniquement) ----
@@ -206,7 +261,12 @@ export function useQuizSession({
     const selected = pendingSelection[qid]
     if (!selected) return
 
-    const res = await callbacks.onAnswer(qid, selected)
+    let res: Awaited<ReturnType<QuizCallbacks["onAnswer"]>>
+    try {
+      res = await callbacks.onAnswer(qid, selected)
+    } catch {
+      return // rejet réseau : pending conservé pour réessai, pas de reveal
+    }
     if (!res.ok) return // toast géré dans onAnswer ; on garde le pending pour réessai
 
     if (res.reveal) {
@@ -228,20 +288,28 @@ export function useQuizSession({
 
   const pause = useCallback(async () => {
     if (!callbacks.onPause || isPaused) return
-    const res = await callbacks.onPause()
-    if (res.ok) {
-      setIsPaused(true)
+    try {
+      const res = await callbacks.onPause()
+      if (res.ok) {
+        setIsPaused(true)
+      }
+    } catch {
+      // rejet réseau : rester non-pausé, le callback de page a déjà toasté
     }
   }, [callbacks, isPaused])
 
   const resume = useCallback(async () => {
     if (!callbacks.onResume || !isPaused) return
-    const res = await callbacks.onResume()
-    if (res.ok) {
-      setTotalPauseDurationMs((prev) => res.totalPauseDurationMs ?? prev)
-      setIsPaused(false)
-      // The single rest pause is now consumed — hide the pause control.
-      setPauseAlreadyUsed(true)
+    try {
+      const res = await callbacks.onResume()
+      if (res.ok) {
+        setTotalPauseDurationMs((prev) => res.totalPauseDurationMs ?? prev)
+        setIsPaused(false)
+        // The single rest pause is now consumed — hide the pause control.
+        setPauseAlreadyUsed(true)
+      }
+    } catch {
+      // rejet réseau : rester en pause, retentable via le bouton
     }
   }, [callbacks, isPaused])
 
@@ -254,11 +322,15 @@ export function useQuizSession({
   const confirmFinish = useCallback(
     async (opts?: { isAutoSubmit?: boolean }) => {
       startTransition(async () => {
-        const result = await callbacks.onFinish({
-          isAutoSubmit: opts?.isAutoSubmit ?? false,
-        })
-        if (result.ok && result.redirectTo) {
-          // Navigation happens outside hook; caller handles redirect
+        try {
+          const result = await callbacks.onFinish({
+            isAutoSubmit: opts?.isAutoSubmit ?? false,
+          })
+          if (result.ok && result.redirectTo) {
+            // Navigation happens outside hook; caller handles redirect
+          }
+        } catch {
+          // rejet réseau : le dialog reste ouvert, retentable
         }
       })
     },

--- a/components/quiz/runner/use-quiz-session.ts
+++ b/components/quiz/runner/use-quiz-session.ts
@@ -223,18 +223,22 @@ export function useQuizSession({
         } catch {
           res = { ok: false, error: "Erreur réseau" }
         }
+        // Enregistrer le succès AVANT le test de coalescing : un envoi
+        // supersédé qui a réussi est bien persisté côté serveur — c'est la
+        // cible du rollback si l'envoi suivant échoue.
+        if (res.ok) {
+          persistedAnswers.current[qid] = current
+        }
         const queued = state.queued
         state.queued = undefined
         if (queued !== undefined) {
-          // Supersédé par un clic plus récent : ni rollback ni validation —
+          // Supersédé par un clic plus récent : ni rollback ni fin de boucle —
           // on envoie le dernier choix.
           current = queued
           continue
         }
         state.inFlight = false
-        if (res.ok) {
-          persistedAnswers.current[qid] = current
-        } else {
+        if (!res.ok) {
           const persisted = persistedAnswers.current[qid]
           setAnswers((a) => {
             const next = { ...a }

--- a/components/shared/payments/delete-transaction-dialog.tsx
+++ b/components/shared/payments/delete-transaction-dialog.tsx
@@ -41,7 +41,11 @@ export const DeleteTransactionDialog = ({
   // Impact d'accès chargé à l'ouverture (avertissement de révocation).
   useEffect(() => {
     if (transaction && open) {
-      loadTransactionAccessImpact(transaction._id).then(setAccessImpact)
+      // best-effort : l'avertissement de révocation est purement informatif,
+      // le serveur re-vérifie l'impact à la mutation
+      loadTransactionAccessImpact(transaction._id)
+        .then(setAccessImpact)
+        .catch(() => {})
     } else {
       setAccessImpact(null)
     }

--- a/components/shared/payments/edit-transaction-modal.tsx
+++ b/components/shared/payments/edit-transaction-modal.tsx
@@ -118,7 +118,11 @@ export const EditTransactionModal = ({
   // Impact d'accès chargé à l'ouverture (sert l'avertissement de révocation).
   useEffect(() => {
     if (transaction && open) {
-      loadTransactionAccessImpact(transaction._id).then(setAccessImpact)
+      // best-effort : l'avertissement de révocation est purement informatif,
+      // le serveur re-vérifie l'impact à la mutation
+      loadTransactionAccessImpact(transaction._id)
+        .then(setAccessImpact)
+        .catch(() => {})
     } else {
       setAccessImpact(null)
     }

--- a/docs/superpowers/handoffs/2026-07-12-campagne-fix-issues-post-96-handoff.md
+++ b/docs/superpowers/handoffs/2026-07-12-campagne-fix-issues-post-96-handoff.md
@@ -1,0 +1,64 @@
+# Handoff — Campagne fix issues GitHub, post-merge PR #96 (2026-07-12)
+
+Reprise dans une session fraîche après compaction. Ce fichier est le point de
+reprise ; la mémoire auto (`project_campagne_fix_issues_github.md`) porte le
+détail complet.
+
+## Ce qui vient d'être livré (PR #96 ✅ MERGÉE dans main, squash `c7638a2`)
+
+Une seule branche empilée `fix/91-quiz-public-answer-key`, mergée en squash.
+Les 5 issues sont **closes** :
+
+- **#91** (P0 sécurité) — quiz marketing public : jeton HMAC liant scoring↔tirage,
+  exclusion des examens ouverts (tirage SQL + re-check), rate-limit IP
+  (`quiz_rate_limits`), clamp 10, écrans d'erreur client. E2E validé.
+- **#84 + #85** — taux de réussite marketing : constante `MARKETING_CLAIMS`,
+  `resolveSuccessRate` (seuils 60/50/70), agrégat SQL `count(*) filter`, `rating`
+  retiré du type, affichages rebranchés.
+- **#87** — doc `docs/STRIPE_FRONTEND_SPEC.md` réécrite (Convex → Drizzle).
+- **#88** — scaffolding mort « Bientôt » retiré de `profile-preferences.tsx`.
+
+Chaque lot est passé par revue design + revue implémentation (adversariales,
+sessions séparées), triées. Gates au merge : `check` exit 0 · `test` 899 ·
+`test:coverage` exit 0 · `test:integration` 270.
+
+## État git à la reprise
+
+- Working tree **propre**. HEAD encore sur `fix/91-quiz-public-answer-key`
+  (obsolète : squash-mergée, ses commits ne sont pas ancêtres de `main` — normal).
+- `origin/main` = `c7638a2` (contient tout #96). **Local main est en retard.**
+- **Premier geste** : `git checkout main && git pull` (ou reset sur origin/main),
+  puis **nouvelle branche par issue**. Ne rien empiler sur `fix/91`.
+- ⚠️ **Stash `stash@{0}` = "On develop: !!GitHub_Desktop<develop>"** : c'est un
+  WIP de l'utilisateur (refonte dashboard), **PAS à moi**. Ne jamais le pop/drop.
+  Voir `feedback_never_stash_pop_blindly`.
+
+## Restant de la campagne (issues ouvertes vérifiées 2026-07-12)
+
+1. **#92** — Webhook Stripe : une session promo 100 % (`payment_status =
+no_payment_required`) n'accorde jamais l'accès (le gate est `=== "paid"`).
+   Self-contained, **pas d'accès prod requis**. Candidat évident pour la
+   prochaine session. Fichier : `app/api/stripe/webhook/route.ts` (le switch
+   `checkout.session.completed` ne traite que `payment_status === "paid"`).
+2. **#81** — Audit des transactions Stripe historiques (écart montant/devise,
+   décision de backfill). ⚠️ **Lecture PROD (Stripe live + base) — demander les
+   accès à l'utilisateur AVANT de commencer.** Sa décision ferme l'épic **#76**.
+3. **Épic #78** (stats marketing honnêtes) — ses sous-issues #84+#85 sont FAITES.
+   Le « rating 4.9/5 » reste éditorial **par design** (aucune table d'avis en
+   base). #78 est donc _potentiellement closable avec caveat_ — **décision
+   produit de l'utilisateur**, ne pas fermer d'office.
+4. **Épic #76** (Stripe montant/devise) — attend #81.
+
+## Conventions de la campagne (rappel)
+
+- Cycle par incrément : brainstorming → spec+plan (`docs/superpowers/{specs,plans}`)
+  → revue design (session séparée) → TDD (RED observé) → revue implém → triage →
+  commit. Rapports de revue = jetables, supprimés après triage.
+- `bun run test` (JAMAIS `bun test`) ; `bun run test:integration` = branche Neon
+  éphémère clonée de `develop` (~90-120 s, baseline JAMAIS vide → oracles exacts,
+  pas de tautologie). Ne jamais lancer `bun dev` soi-même.
+- ⚠️ **Après un `db:generate`, appliquer `bun run db:migrate` à la main sur dev**
+  (la branche Neon dev ne se migre pas seule ; prod migre au build). Sinon l'app
+  dev crashe 500 sur la nouvelle table. Voir `reference_vercel_migrate_on_deploy`.
+- Commits conventionnels SANS attribution Claude. Committer/pusher/PR seulement
+  quand l'utilisateur le demande ; sur main → brancher d'abord.

--- a/docs/superpowers/plans/2026-07-12-robustesse-reseau-server-actions.md
+++ b/docs/superpowers/plans/2026-07-12-robustesse-reseau-server-actions.md
@@ -1,0 +1,1226 @@
+# Robustesse réseau des appels client de Server Actions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aucun `await` nu de Server Action côté client : les rejets réseau (« Failed to fetch », Sentry NOMAQBANQ-1A) deviennent des `{ success: false, error }` gérés par les branches d'erreur existantes — plus d'unhandled rejection, de spinner figé ni de réponse d'examen perdue en silence.
+
+**Architecture:** Un helper client `lib/safe-action.ts` (`callAction`) convertit tout throw en `ActionFailure` (retry 1× optionnel, réservé aux upserts idempotents du quiz). Le moteur quiz partagé (`use-quiz-session.ts`) traite tout throw de callback comme `{ ok: false }` (rollback optimiste garanti) — défense en profondeur. Application mécanique en 3 phases : P1 étudiant (bug prod), P2 facturation/compte, P3 admin.
+
+**Tech Stack:** Next.js 16 Server Actions, React 19, Vitest (happy-dom, fake timers, renderHook), Playwright (`context.setOffline`).
+
+**Spec:** `docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md`
+
+**Rappels projet :** commits conventionnels SANS attribution Claude ; `bun run test` (JAMAIS `bun test`) ; ne jamais lancer `bun dev` soi-même ; e2e via `bun run test:e2e` (jamais `bunx playwright test`).
+
+**Doctrine (à appliquer partout, décidée au spec) :**
+
+- Mutation à retour structuré → `callAction(() => action(x))`. `callAction` **ne throw jamais**, donc les `setBusy(false)` post-`await` s'exécutent toujours — pas besoin de try/finally supplémentaire sauf si le handler contient d'autres `await` risqués.
+- Lecture (retour = données brutes) → try/catch dans la transition, ou `.catch` sur la chaîne `.then` d'un effet (sortir du skeleton).
+- `{ retries: 1 }` UNIQUEMENT sur `saveExamAnswer`, `saveTrainingAnswer`, `saveExamFlag` (upserts idempotents).
+- `authClient.*` ne throw pas (résout `{ error }`) → se corrige en lisant le retour, pas avec `callAction`.
+- Les toasts vivent dans les callbacks des pages ; le moteur quiz reste silencieux.
+
+---
+
+### Task 0: Branche, docs, baseline verte
+
+État constaté le 2026-07-12 après merge de la PR #96 : on est sur `main` à
+jour, working tree propre hors les 3 docs non suivies (spec, plan, handoff
+campagne précédente).
+
+- [ ] **Step 1: Créer la branche depuis main**
+
+```bash
+git checkout main && git pull
+git checkout -b fix/robustesse-reseau-server-actions
+```
+
+- [ ] **Step 2: Formater et committer spec + plan**
+
+```bash
+bunx prettier --write docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md docs/superpowers/plans/2026-07-12-robustesse-reseau-server-actions.md
+git add docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md docs/superpowers/plans/2026-07-12-robustesse-reseau-server-actions.md
+git commit -m "docs: spec + plan robustesse reseau des appels client de Server Actions"
+```
+
+- [ ] **Step 3: Baseline verte**
+
+Run: `bun run check && bun run test`
+Expected: PASS avant la première ligne de code.
+
+---
+
+## Phase 1 — Flux étudiant (bug prod)
+
+### Task 1: Helper `callAction` (unit, RED → GREEN)
+
+**Files:**
+
+- Create: `tests/lib/safe-action.test.ts`
+- Create: `lib/safe-action.ts`
+
+- [ ] **Step 1: Écrire le test unitaire (rouge)**
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NETWORK_ERROR_MESSAGE, callAction } from "@/lib/safe-action"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("callAction", () => {
+  it("laisse passer un succès inchangé", async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, data: 42 })
+    await expect(callAction(fn)).resolves.toEqual({ success: true, data: 42 })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("laisse passer une erreur serveur inchangée, sans la retenter", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: "Examen introuvable." })
+    await expect(callAction(fn, { retries: 2 })).resolves.toEqual({
+      success: false,
+      error: "Examen introuvable.",
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("convertit un rejet réseau en ActionFailure", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await expect(callAction(fn)).resolves.toEqual({
+      success: false,
+      error: NETWORK_ERROR_MESSAGE,
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("sans opts, ne retente jamais", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await callAction(fn)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries: 1 → retente après 1 s et réussit", async () => {
+    vi.useFakeTimers()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({ success: true })
+    const p = callAction(fn, { retries: 1 })
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(p).resolves.toEqual({ success: true })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it("retries: 1 → deux échecs = ActionFailure", async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    const p = callAction(fn, { retries: 1 })
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(p).resolves.toEqual({
+      success: false,
+      error: NETWORK_ERROR_MESSAGE,
+    })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test -- safe-action`
+Expected: FAIL — module `@/lib/safe-action` introuvable.
+
+- [ ] **Step 3: Implémenter le helper**
+
+```ts
+// lib/safe-action.ts
+// Client-safe : aucun import serveur. Convertit les rejets réseau d'un appel
+// de Server Action en échec structuré, discriminable par les gardes existants
+// (`!res.success` comme `"error" in res`).
+
+export type ActionFailure = { success: false; error: string }
+
+export const NETWORK_ERROR_MESSAGE =
+  "Connexion perdue. Vérifiez votre réseau et réessayez."
+
+const RETRY_DELAY_MS = 1000
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// `retries` est RÉSERVÉ aux actions idempotentes (upserts) : un « Failed to
+// fetch » peut survenir alors que la requête a atteint le serveur, le retry
+// ré-exécute donc l'action.
+export async function callAction<T>(
+  fn: () => Promise<T>,
+  opts?: { retries?: number },
+): Promise<T | ActionFailure> {
+  const retries = opts?.retries ?? 0
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch {
+      if (attempt < retries) {
+        await delay(RETRY_DELAY_MS)
+        continue
+      }
+      return { success: false, error: NETWORK_ERROR_MESSAGE }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Vérifier le vert**
+
+Run: `bun run test -- safe-action`
+Expected: 6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/safe-action.ts tests/lib/safe-action.test.ts
+git commit -m "feat: callAction - rejets reseau des Server Actions convertis en echec structure"
+```
+
+---
+
+### Task 2: Durcir le moteur quiz (throw de callback = `{ ok: false }`) (RED → GREEN)
+
+Le contrat `QuizCallbacks.onFlag` passe de `Promise<void>` à
+`Promise<{ ok: boolean }>` pour permettre le rollback du flag. Les deux
+fournisseurs de callbacks (`evaluation-client.tsx`,
+`training-session-client.tsx`) sont ajustés a minima dans cette task pour que
+`tsc` reste vert (le câblage `callAction` complet arrive en Tasks 3–4).
+
+**Files:**
+
+- Create: `tests/components/quiz/use-quiz-session-network.test.tsx` (même dossier que les tests existants du hook)
+- Modify: `tests/components/quiz/use-quiz-session.test.ts:36,293` — mocks `onFlag: vi.fn().mockResolvedValue(undefined)` → `mockResolvedValue({ ok: true })`. Sans ça, le nouveau `.then((res) => { if (!res.ok) … })` fait un TypeError sur `undefined` → unhandled rejection → gate rouge (revue design #2 ; invisible à tsc, `vi.fn()` renvoie `any`)
+- Modify: `components/quiz/runner/types.ts:44` (contrat onFlag)
+- Modify: `components/quiz/runner/use-quiz-session.ts` (answerSelect l.162-198 **avec sérialisation par question** — revue #1, confirmAnswer l.209, toggleFlag l.143-158, pause l.231, resume l.239, confirmFinish l.257)
+- Modify: `components/quiz/pause-dialog.tsx:46-66` (garde one-shot auto-resume — revue #3)
+- Modify: `app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx:142-144` (onFlag renvoie `{ ok }`)
+- Modify: `app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx:135` (onFlag stub renvoie `{ ok: true }`)
+
+- [ ] **Step 1: Écrire le test composant (rouge)**
+
+```tsx
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type {
+  QuizCallbacks,
+  QuizMode,
+  QuizQuestion,
+} from "@/components/quiz/runner/types"
+import { useQuizSession } from "@/components/quiz/runner/use-quiz-session"
+
+const QUESTIONS: QuizQuestion[] = [
+  { _id: "q1", question: "Q ?", options: ["A", "B", "C"], domain: "Cardio" },
+]
+
+const DEFERRED_MODE: QuizMode = {
+  kind: "exam",
+  accent: "blue",
+  timer: null,
+  pause: null,
+  feedback: "deferred",
+  showMeta: false,
+  labels: { title: "t", finishCta: "Terminer" },
+  backUrl: "/x",
+}
+
+const networkReject = () => Promise.reject(new TypeError("Failed to fetch"))
+
+const makeCallbacks = (over: Partial<QuizCallbacks>): QuizCallbacks => ({
+  onAnswer: vi.fn(async () => ({ ok: true }) as const),
+  onFlag: vi.fn(async () => ({ ok: true }) as const),
+  onFinish: vi.fn(async () => ({ ok: true }) as const),
+  ...over,
+})
+
+const renderSession = (
+  callbacks: QuizCallbacks,
+  initialPause?: { isPaused: boolean; totalPauseDurationMs: number },
+) =>
+  renderHook(() =>
+    useQuizSession({
+      questions: QUESTIONS,
+      initialAnswers: {},
+      initialPause,
+      mode: DEFERRED_MODE,
+      callbacks,
+    }),
+  )
+
+describe("use-quiz-session — rejets réseau des callbacks", () => {
+  it("answerSelect : rollback de l'optimiste quand onAnswer rejette", async () => {
+    const callbacks = makeCallbacks({ onAnswer: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    await act(async () => {
+      await result.current.answerSelect(0)
+    })
+    expect(result.current.answers["q1"]).toBeUndefined()
+  })
+
+  it("sérialisation : un clic pendant un envoi en vol est coalescé, envoyé après, sans rollback", async () => {
+    let rejectA!: (e: unknown) => void
+    const inFlightA = new Promise<never>((_, reject) => {
+      rejectA = reject
+    })
+    const onAnswer = vi
+      .fn()
+      .mockReturnValueOnce(inFlightA) // clic A : reste en vol
+      .mockResolvedValueOnce({ ok: true }) // clic B : réussit
+    const { result } = renderSession(makeCallbacks({ onAnswer }))
+    await act(async () => {
+      void result.current.answerSelect(0) // A
+    })
+    await act(async () => {
+      void result.current.answerSelect(1) // B pendant que A est en vol
+    })
+    expect(onAnswer).toHaveBeenCalledTimes(1) // B coalescé, pas encore parti
+    await act(async () => {
+      rejectA(new TypeError("Failed to fetch"))
+    })
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledTimes(2))
+    expect(onAnswer).toHaveBeenLastCalledWith("q1", "B")
+    // L'échec de A (supersédé) ne rollback PAS l'optimiste de B
+    expect(result.current.answers["q1"]?.selected).toBe("B")
+  })
+
+  it("rollback vers la dernière valeur CONFIRMÉE, pas l'état d'avant-clic", async () => {
+    const onAnswer = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true }) // A persisté
+      .mockRejectedValueOnce(new TypeError("Failed to fetch")) // B échoue
+    const { result } = renderSession(makeCallbacks({ onAnswer }))
+    await act(async () => {
+      await result.current.answerSelect(0) // A confirmé serveur
+    })
+    await act(async () => {
+      await result.current.answerSelect(1) // B échoue
+    })
+    expect(result.current.answers["q1"]?.selected).toBe("A")
+  })
+
+  it("toggleFlag : rollback du flag quand onFlag rejette", async () => {
+    const callbacks = makeCallbacks({ onFlag: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    act(() => {
+      result.current.toggleFlag()
+    })
+    await waitFor(() => expect(result.current.flagged.has("q1")).toBe(false))
+  })
+
+  it("toggleFlag : rollback du flag quand onFlag renvoie { ok: false }", async () => {
+    const callbacks = makeCallbacks({
+      onFlag: vi.fn(async () => ({ ok: false }) as const),
+    })
+    const { result } = renderSession(callbacks)
+    act(() => {
+      result.current.toggleFlag()
+    })
+    await waitFor(() => expect(result.current.flagged.has("q1")).toBe(false))
+  })
+
+  it("confirmFinish : pas de crash quand onFinish rejette, dialog réouvrable", async () => {
+    const callbacks = makeCallbacks({ onFinish: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    await act(async () => {
+      await result.current.confirmFinish()
+    })
+    await waitFor(() => expect(result.current.isSubmitting).toBe(false))
+  })
+
+  it("pause : pas de crash quand onPause rejette", async () => {
+    const callbacks = makeCallbacks({ onPause: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    await act(async () => {
+      await result.current.pause()
+    })
+    expect(result.current.isPaused).toBe(false)
+  })
+
+  it("resume : pas de crash quand onResume rejette (session montée en pause)", async () => {
+    // initialPause obligatoire : sinon le early-return `!isPaused` de resume()
+    // fait passer le test à vide sans toucher le callback (revue design #8)
+    const callbacks = makeCallbacks({ onResume: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks, {
+      isPaused: true,
+      totalPauseDurationMs: 0,
+    })
+    await act(async () => {
+      await result.current.resume()
+    })
+    expect(callbacks.onResume).toHaveBeenCalledTimes(1)
+    expect(result.current.isPaused).toBe(true)
+  })
+})
+```
+
+Note : le test « onFlag renvoie `{ ok: false }` » échouera aussi à la
+compilation tant que le contrat `onFlag` n'a pas changé — c'est voulu.
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test -- use-quiz-session-network`
+Expected: FAIL — rollback absents + unhandled rejections rapportées par vitest.
+
+- [ ] **Step 3: Changer le contrat onFlag dans `components/quiz/runner/types.ts`**
+
+```ts
+// Avant (l.44)
+onFlag: (questionId: string, isFlagged: boolean) => Promise<void>
+// Après — { ok } permet au moteur de rollback le flag local
+onFlag: (questionId: string, isFlagged: boolean) => Promise<{ ok: boolean }>
+```
+
+Ajustements minimaux des deux fournisseurs (repris proprement en Tasks 3–4) :
+
+```ts
+// evaluation-client.tsx (l.142-144)
+onFlag: async (questionId, isFlagged) => {
+  const res = await saveExamFlag({ examId, questionId, isFlagged })
+  return { ok: res.success }
+},
+
+// training-session-client.tsx (l.135) — flags locaux, no-op serveur
+onFlag: async () => ({ ok: true }),
+```
+
+- [ ] **Step 4: Durcir `use-quiz-session.ts`**
+
+`toggleFlag` (remplace l.143-158) — le fire-and-forget sort de l'updater et
+gagne un rollback :
+
+```ts
+const toggleFlag = useCallback(() => {
+  if (!currentQuestion) return
+  const qid = currentQuestion._id
+  const newValue = !flagged.has(qid)
+  setFlagged((prev) => {
+    const next = new Set(prev)
+    if (newValue) {
+      next.add(qid)
+    } else {
+      next.delete(qid)
+    }
+    return next
+  })
+  const revert = () =>
+    setFlagged((prev) => {
+      const next = new Set(prev)
+      if (newValue) {
+        next.delete(qid)
+      } else {
+        next.add(qid)
+      }
+      return next
+    })
+  // Silencieux (pas de toast) : cosmétique, pas de bruit en passation.
+  callbacks.onFlag(qid, newValue).then(
+    (res) => {
+      if (!res.ok) revert()
+    },
+    () => revert(),
+  )
+}, [currentQuestion, flagged, callbacks])
+```
+
+`answerSelect` (branche différée, l.179-196) — **réécrite avec sérialisation
+par question** (revue design #1 : sans elle, le retry d'un clic périmé peut
+écraser côté serveur un clic plus récent, en silence — les deux « réussissent »).
+Deux refs au niveau du hook :
+
+```ts
+// Un seul onAnswer en vol par question ; le clic le plus récent pendant un
+// envoi remplace le précédent (coalescing) et part quand l'envoi se règle.
+// Le retry de callAction vit DANS ce créneau → l'ordre des clics est préservé.
+const answerSends = useRef<
+  Record<string, { inFlight: boolean; queued?: string }>
+>({})
+// Dernière valeur CONFIRMÉE par le serveur — cible du rollback (jamais
+// « l'état d'avant-clic », qu'un clic intermédiaire a pu rendre périmé).
+const persistedAnswers = useRef<Record<string, string | undefined>>(
+  Object.fromEntries(
+    Object.entries(initialAnswers).map(([qid, a]) => [qid, a.selected]),
+  ),
+)
+```
+
+Corps de la branche différée (remplace l'optimiste + await + rollback actuels) :
+
+```ts
+// Test / examen (feedback différé) : optimiste + envoi sérialisé.
+setAnswers((a) => ({ ...a, [qid]: { ...a[qid], selected } }))
+
+const state = (answerSends.current[qid] ??= { inFlight: false })
+if (state.inFlight) {
+  state.queued = selected
+  return
+}
+state.inFlight = true
+let current = selected
+for (;;) {
+  let res: Awaited<ReturnType<QuizCallbacks["onAnswer"]>>
+  try {
+    res = await callbacks.onAnswer(qid, current)
+  } catch {
+    res = { ok: false }
+  }
+  const queued = state.queued
+  state.queued = undefined
+  if (queued !== undefined) {
+    // Supersédé par un clic plus récent : ni rollback ni validation —
+    // on envoie le dernier choix. (Si l'envoi supersédé a échoué, son toast
+    // est déjà parti côté page : bruit résiduel accepté, cf. spec §2.)
+    current = queued
+    continue
+  }
+  state.inFlight = false
+  if (res.ok) {
+    persistedAnswers.current[qid] = current
+  } else {
+    const persisted = persistedAnswers.current[qid]
+    setAnswers((a) => {
+      const next = { ...a }
+      if (persisted === undefined) {
+        delete next[qid]
+      } else {
+        next[qid] = { ...next[qid], selected: persisted }
+      }
+      return next
+    })
+  }
+  return
+}
+```
+
+Le `useCallback` d'`answerSelect` perd sa dépendance `answers` (le rollback
+lit `persistedAnswers`, une ref) — retirer `answers` du tableau de deps.
+
+`confirmAnswer` (l.209) :
+
+```ts
+let res: Awaited<ReturnType<QuizCallbacks["onAnswer"]>>
+try {
+  res = await callbacks.onAnswer(qid, selected)
+} catch {
+  return // pending conservé ; isConfirming libéré par le try/finally du runner
+}
+if (!res.ok) return
+```
+
+`pause` (l.229-235) et `resume` (l.237-246) — même forme :
+
+```ts
+const pause = useCallback(async () => {
+  if (!callbacks.onPause || isPaused) return
+  try {
+    const res = await callbacks.onPause()
+    if (res.ok) {
+      setIsPaused(true)
+    }
+  } catch {
+    // échec réseau : rester non-pausé, le callback de page a déjà toasté
+  }
+}, [callbacks, isPaused])
+```
+
+(`resume` : idem autour de l'`await`, corps de succès inchangé.)
+
+`confirmFinish` (l.254-266) :
+
+```ts
+startTransition(async () => {
+  try {
+    await callbacks.onFinish({ isAutoSubmit: opts?.isAutoSubmit ?? false })
+  } catch {
+    // échec réseau : le dialog reste ouvert, retentable
+  }
+})
+```
+
+`pause-dialog.tsx` (l.46-66) — garde one-shot sur l'auto-resume (revue #3 :
+l'`onResume()` tourne dans un `setInterval` 1 s → pause expirée + hors ligne =
+un toast d'erreur par seconde) :
+
+```ts
+const autoResumeFiredRef = useRef(false)
+
+useEffect(() => {
+  if (!isOpen || !pauseStartedAt) return
+  autoResumeFiredRef.current = false // nouvelle pause = nouveau one-shot
+
+  const updatePauseTime = () => {
+    // ... calcul existant inchangé
+    if (isPauseExpired(pauseStartedAt, pauseDurationMinutes)) {
+      if (!autoResumeFiredRef.current) {
+        autoResumeFiredRef.current = true
+        // En cas d'échec (réseau), pas de nouvelle tentative auto : le bouton
+        // btn-resume-exam reste la voie de retentative manuelle.
+        onResume()
+      }
+    }
+  }
+  // ... interval existant inchangé
+}, [isOpen, pauseStartedAt, pauseDurationMinutes, onResume])
+```
+
+Enfin, mettre à jour les deux mocks du test existant
+`tests/components/quiz/use-quiz-session.test.ts:36,293` :
+`onFlag: vi.fn().mockResolvedValue(undefined)` → `mockResolvedValue({ ok: true })`.
+
+- [ ] **Step 5: Vérifier le vert + non-régression**
+
+Run: `bun run test -- use-quiz-session-network && bun run check && bun run test`
+Expected: PASS partout (les tests QuizRunner/QuestionCard existants inclus).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/quiz/runner/types.ts components/quiz/runner/use-quiz-session.ts components/quiz/pause-dialog.tsx "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx" "app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx" tests/components/quiz/
+git commit -m "fix: moteur quiz - envois de reponses serialises par question + rejets de callbacks traites comme echecs"
+```
+
+---
+
+### Task 3: `evaluation-client.tsx` — callbacks via `callAction`
+
+**Files:**
+
+- Modify: `app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx:129-197`
+
+- [ ] **Step 1: Câbler `callAction` dans les 5 callbacks**
+
+Ajouter `import { callAction } from "@/lib/safe-action"` puis :
+
+```ts
+const callbacks: QuizCallbacks = {
+  onAnswer: async (questionId, selectedAnswer) => {
+    const res = await callAction(
+      () => saveExamAnswer({ examId, questionId, selectedAnswer }),
+      { retries: 1 }, // upsert idempotent — absorbe les micro-coupures
+    )
+    if (!res.success) {
+      toast.error("Réponse non enregistrée, réessayez.")
+      return {
+        ok: false,
+        error: res.error ?? "Erreur lors de l'enregistrement",
+      }
+    }
+    return { ok: true }
+  },
+  onFlag: async (questionId, isFlagged) => {
+    const res = await callAction(
+      () => saveExamFlag({ examId, questionId, isFlagged }),
+      { retries: 1 },
+    )
+    return { ok: res.success }
+  },
+  onFinish: async ({ isAutoSubmit }) => {
+    const result = await callAction(() =>
+      finalizeExam({ examId, isAutoSubmit }),
+    )
+    if (!result.success) {
+      const error = result.error ?? "Erreur lors de la soumission"
+      if (error.includes("déjà passé") || error.includes("plus active")) {
+        router.push("/tableau-de-bord/examen-blanc")
+      }
+      toast.error(error)
+      return { ok: false }
+    }
+    // ... branches de succès existantes inchangées (toasts + redirect)
+  },
+  onPause: exam.enablePause
+    ? async () => {
+        const res = await callAction(() => pauseExam({ examId }))
+        if (res.success) {
+          toast.info("⏸️ Pause - Prenez une pause bien méritée !", {
+            duration: 5000,
+          })
+        } else {
+          toast.error(res.error ?? "Erreur lors de la mise en pause")
+        }
+        return { ok: res.success }
+      }
+    : undefined,
+  onResume: exam.enablePause
+    ? async () => {
+        const res = await callAction(() => resumeExam({ examId }))
+        if (res.success) {
+          toast.success("Pause terminée - Continuez l'examen !")
+          return { ok: true, totalPauseDurationMs: res.totalPauseDurationMs }
+        }
+        toast.error(res.error ?? "Erreur lors de la reprise")
+        return { ok: false }
+      }
+    : undefined,
+}
+```
+
+Attention au narrowing : après `callAction`, `res` est
+`RetourAction | ActionFailure` — accéder aux champs de succès
+(`res.totalPauseDurationMs`, `result.startedAt`…) uniquement APRÈS le garde
+`res.success`. `handleStartExam` garde son try/catch existant (déjà protégé).
+
+- [ ] **Step 2: Vérifier**
+
+Run: `bun run check && bun run test`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx"
+git commit -m "fix: passation d'examen resiliente aux coupures reseau (callAction + retry sur les saves)"
+```
+
+---
+
+### Task 4: `training-session-client.tsx` — idem
+
+**Files:**
+
+- Modify: `app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx:111-149`
+
+- [ ] **Step 1: Câbler `callAction`**
+
+```ts
+onAnswer: async (questionId, selectedAnswer) => {
+  const res = await callAction(
+    () => saveTrainingAnswer({ sessionId, questionId, selectedAnswer }),
+    { retries: 1 },
+  )
+  if (!res.success) {
+    toast.error("Réponse non enregistrée, réessayez.")
+    return { ok: false, error: res.error }
+  }
+  // ... construction du reveal existante inchangée
+},
+onFlag: async () => ({ ok: true }),
+onFinish: async () => {
+  const res = await callAction(() => completeTrainingSession({ sessionId }))
+  if (!res.success) {
+    toast.error("Erreur", { description: res.error })
+    return { ok: false }
+  }
+  // ... succès existant inchangé (toast + redirect)
+},
+```
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx"
+git commit -m "fix: session d'entrainement resiliente aux coupures reseau"
+```
+
+---
+
+### Task 5: Lectures P1 non gardées (3 sites)
+
+**Files:**
+
+- Modify: `app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx:63` (transition `loadAvailableObjectifsCMC`)
+- Modify: `app/(dashboard)/tableau-de-bord/entrainement/_components/training-history-section.tsx:74` (transition `loadTrainingHistory`)
+- Modify: `components/quiz/results/session-results.tsx:149-174` (`loadExplanations(...).then(...)` à la l.156) — composant **partagé** (résultats examen étudiant + vue admin + entraînement) : le `.catch` + toast s'applique aux trois vues (acceptable) ; `sonner` n'y est pas encore importé, ajouter l'import
+
+- [ ] **Step 1: Garder les 3 lectures**
+
+Transitions (config-form, history) — try/catch dans le corps async, modèle
+`abonnements-client.tsx` `handleLoadMore` :
+
+```ts
+startLoadMore(async () => {
+  try {
+    const page = await loadTrainingHistory(/* args existants */)
+    // ... setState existants
+  } catch {
+    toast.error("Impossible de charger l'historique. Vérifiez votre réseau.")
+  }
+})
+```
+
+(même forme pour `loadAvailableObjectifsCMC` ; message : « Impossible de
+charger les objectifs CMC. » — pas de toast bloquant, la liste reste sur
+l'état précédent.)
+
+Chaîne d'effet (session-results) :
+
+```ts
+loadExplanations(toLoad)
+  .then((data) => {
+    // ... setState existants
+  })
+  .catch(() => {
+    // re-déplier la question retente (loadedIds non marqué) — feedback léger
+    toast.error("Explications indisponibles. Vérifiez votre réseau.")
+  })
+```
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx" "app/(dashboard)/tableau-de-bord/entrainement/_components/training-history-section.tsx" components/quiz/results/session-results.tsx
+git commit -m "fix: lectures quiz/entrainement gardees contre les rejets reseau"
+```
+
+---
+
+### Task 6: E2E offline (le scénario prod, gardé en régression)
+
+**Files:**
+
+- Create: `e2e/tests/examen-blanc-offline.spec.ts`
+- Modify: `playwright.config.ts` (ajouter le spec au `testMatch` du projet `chromium-auth`)
+
+- [ ] **Step 1: Écrire le spec**
+
+Boilerplate seed/POM : calquer sur `e2e/tests/examen-blanc.spec.ts` existant
+(seed `seed-exam` dédié en `beforeAll`, ciblage `exam-card-{id}` via le POM,
+`cleanup` en `afterAll`, `acceptWarningOrResume()`). La partie offline :
+
+```ts
+test("coupure réseau pendant la passation : toast + rollback, puis reprise", async ({
+  page,
+  context,
+}) => {
+  // ... démarrage examen via POM (seed dédié, acceptWarningOrResume)
+
+  // Réponse en ligne : sanity check du câblage
+  await page.getByTestId("answer-option-0").scrollIntoViewIfNeeded()
+  await page.getByTestId("answer-option-0").click()
+  await expect(page.getByTestId("answer-option-0")).toHaveAttribute(
+    "data-selected",
+    "true",
+  )
+
+  // Coupure réseau → le clic suivant échoue (retry 1× à 1 s inclus)
+  await context.setOffline(true)
+  await page.getByTestId("answer-option-1").click()
+  await expect(
+    page.getByText("Réponse non enregistrée, réessayez."),
+  ).toBeVisible({ timeout: 10_000 })
+  // Rollback : l'option 1 n'est PAS retenue, l'option 0 reste la réponse
+  await expect(page.getByTestId("answer-option-1")).not.toHaveAttribute(
+    "data-selected",
+    "true",
+  )
+
+  // Retour en ligne → le re-clic persiste
+  await context.setOffline(false)
+  await page.getByTestId("answer-option-1").click()
+  await expect(page.getByTestId("answer-option-1")).toHaveAttribute(
+    "data-selected",
+    "true",
+  )
+})
+```
+
+- [ ] **Step 2: Lancer le spec seul**
+
+Run: `bun run test:e2e e2e/tests/examen-blanc-offline.spec.ts --reporter=list`
+Expected: PASS (run ciblé, pas la suite complète).
+
+- [ ] **Step 3: Commit — clôture Phase 1**
+
+```bash
+git add e2e/tests/examen-blanc-offline.spec.ts playwright.config.ts
+git commit -m "test(e2e): passation d'examen sous coupure reseau (setOffline)"
+```
+
+---
+
+## Phase 2 — Facturation / compte
+
+### Task 7: `createCustomerPortal` (le 🔴 facturation)
+
+**Files:**
+
+- Modify: `app/(dashboard)/tableau-de-bord/abonnements/_components/abonnements-client.tsx:263`
+
+- [ ] **Step 1: Envelopper avec `callAction`**
+
+```ts
+const [, openPortalAction, isLoadingPortal] = useActionState(
+  async () => {
+    const res = await callAction(() =>
+      createCustomerPortal("/tableau-de-bord/abonnements"),
+    )
+    if ("error" in res) {
+      // branches existantes inchangées : navigator.onLine (désormais
+      // atteignable), « Aucun historique », toast générique
+      ...
+      return { success: false }
+    }
+    window.location.href = res.portalUrl
+    return { success: true }
+  },
+  { success: false },
+)
+```
+
+`ActionFailure` porte `error` → le garde `"error" in res` existant l'attrape ;
+plus aucun throw ne remonte à l'error boundary React 19.
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(dashboard)/tableau-de-bord/abonnements/_components/abonnements-client.tsx"
+git commit -m "fix: portail de facturation Stripe resilient aux coupures reseau (plus d'error boundary)"
+```
+
+---
+
+### Task 8: Profil (5 fichiers)
+
+**Files:**
+
+- Modify: `app/(dashboard)/tableau-de-bord/profil/_components/profile-notifications.tsx:22`
+- Modify: `app/(dashboard)/tableau-de-bord/profil/_components/profile-sessions.tsx:23,35`
+- Modify: `app/(dashboard)/tableau-de-bord/profil/_components/profile-password.tsx:47`
+- Modify: `app/(dashboard)/tableau-de-bord/profil/_components/profile-danger-zone.tsx:23,29`
+
+- [ ] **Step 1: `profile-notifications.tsx` — l'exemplaire complet**
+
+```ts
+const update = async (next: NotificationPreferences) => {
+  const prev = prefs
+  setPrefs(next) // optimistic
+  setBusy(true)
+  const res = await callAction(() => updateNotificationPreferences(next))
+  setBusy(false) // toujours atteint : callAction ne throw jamais
+  if (!res.success) {
+    setPrefs(prev) // rollback
+    toast.error(res.error ?? "Échec de la mise à jour")
+    return
+  }
+  toast.success("Préférences mises à jour")
+}
+```
+
+- [ ] **Step 2: Les 3 autres fichiers — même transformation**
+
+Pour chaque site, remplacer l'`await action(...)` nu par
+`await callAction(() => action(...))` sans toucher au flux : les
+`setBusy(false)` post-`await` redeviennent sûrs. Ajouter
+`toast.error(res.error ?? "...")` là où la branche `!res.success` n'existe
+pas encore.
+
+⚠️ Revue design #6 : `profile-sessions` et `profile-password` **toastent
+déjà** leur branche `!res.success` (`profile-sessions.tsx:25-27,37-39`,
+`profile-password.tsx:48-50`) — le seul trou est le rejet fetch. Ne PAS
+dupliquer ni remplacer les toasts existants : le wrap `callAction` suffit
+(son `ActionFailure.error` alimente le toast déjà en place).
+
+- `profile-sessions.tsx:23` (`revokeUserSession(id)`) et `:35`
+  (`revokeOtherUserSessions()`) : wrap `callAction`, rien d'autre.
+- `profile-password.tsx:47` (`setAccountPassword`) : wrap `callAction`,
+  gestion RHF et toast existants conservés.
+- `profile-danger-zone.tsx:23` (`deleteMyAccount`) : wrap `callAction` +
+  toast sur `!res.success` (à vérifier sur place).
+- `profile-danger-zone.tsx:29` (`authClient.signOut()`) : PAS de `callAction`
+  (authClient ne throw pas) — sécuriser sans changer le flux, et surtout
+  **conserver la destination `/compte-supprime`** (page qui explique la
+  fenêtre de réactivation 30 j — revue design #4) :
+
+```ts
+await authClient.signOut().catch(() => {})
+router.replace("/compte-supprime")
+```
+
+- [ ] **Step 3: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(dashboard)/tableau-de-bord/profil/_components/"
+git commit -m "fix: ecrans profil resilients aux coupures reseau (busy libere, rollback notifications)"
+```
+
+---
+
+### Task 9: `useMarketingStats` (skeleton marketing infini)
+
+La campagne marketing #84/#85 (`resolveSuccessRate`) est mergée (PR #96) —
+adapter les edits au code courant du hook et de son test (les numéros de
+ligne de l'audit datent d'avant le merge).
+
+**Files:**
+
+- Modify: `hooks/useMarketingStats.ts:15`
+- Modify: `tests/hooks/useMarketingStats.test.tsx` (cas d'échec)
+
+- [ ] **Step 1: Garder la chaîne du hook**
+
+⚠️ Revue design #5 : ne PAS chercher `MARKETING_CLAIMS` ni `resolveSuccessRate`
+— ces symboles n'existent pas dans l'arbre (la bascule #85 mergée vit côté
+serveur dans `features/marketing/dal.ts:56`, et les fallbacks client sont des
+`??` inline chez les 7 consommateurs : `home-landing.tsx:162,307`,
+`about-story.tsx:33`, `domains-grid.tsx:21-22`, etc.). Aucune centralisation
+à créer (YAGNI) : le mécanisme existant absorbe déjà `stats` absent.
+
+Dans le hook : ajouter le `.catch` en **conservant le garde `active` du
+cleanup** (`hooks/useMarketingStats.ts:14-20`, revue #10) et élargir
+explicitement le type d'état :
+
+```ts
+const [stats, setStats] = useState<MarketingStats | null | undefined>(undefined)
+
+useEffect(() => {
+  let active = true
+  loadMarketingStats()
+    .then((s) => {
+      if (active) setStats(s)
+    })
+    .catch(() => {
+      if (active) setStats(null) // sortie du skeleton, fallbacks inline `??`
+    })
+  return () => {
+    active = false
+  }
+}, [])
+```
+
+(Adapter à la forme exacte du hook courant — `isLoading` doit devenir `false`
+quand `stats === null`. Les 7 consommateurs ont été vérifiés en revue : tous
+en `stats?.x ?? fallback` ou gardés par `if (isLoading)` — aucun crash ni
+skeleton résiduel sur `null`.)
+
+- [ ] **Step 2: Ajouter le cas d'échec au test du hook**
+
+```tsx
+it("bascule hors du skeleton quand le chargement échoue", async () => {
+  vi.mocked(loadMarketingStats).mockRejectedValueOnce(
+    new TypeError("Failed to fetch"),
+  )
+  const { result } = renderHook(() => useMarketingStats())
+  await waitFor(() => expect(result.current.isLoading).toBe(false))
+})
+```
+
+(Adapter le nom du mock à la structure existante du fichier de test.)
+
+- [ ] **Step 3: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add hooks/useMarketingStats.ts tests/hooks/useMarketingStats.test.tsx
+git commit -m "fix: stats marketing - echec de chargement sans skeleton infini (fallback editorial)"
+```
+
+---
+
+## Phase 3 — Admin
+
+### Task 10: Les 4 modales verrouillables 🔴
+
+**Files:**
+
+- Modify: `app/(admin)/admin/examens/[id]/_components/exam-leaderboard.tsx:73` (`deleteParticipation`)
+- Modify: `components/admin/exams-list.tsx:81` (`deactivateExam`) et `:119` (`deleteExam`)
+- Modify: `app/(admin)/admin/questions/_components/question-side-panel.tsx:122` (`deleteQuestion`)
+
+- [ ] **Step 1: Transformation identique aux 4 sites**
+
+Modèle (exam-leaderboard ; les 3 autres sont isomorphes) :
+
+```ts
+setIsDeleting(true)
+const res = await callAction(() => deleteParticipation({/* args existants */}))
+setIsDeleting(false) // toujours atteint désormais
+if (!res.success) {
+  // Conserver le toast existant si la branche en a déjà un ; sinon :
+  toast.error(res.error ?? "Échec de la suppression. Vérifiez votre réseau.")
+  return
+}
+// ... succès existant inchangé (toast + refresh/fermeture)
+```
+
+Vérifier après coup : plus aucun `disabled={isDeleting}` ne peut rester
+figé (le state est libéré sur tous les chemins).
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(admin)/admin/examens/[id]/_components/exam-leaderboard.tsx" components/admin/exams-list.tsx "app/(admin)/admin/questions/_components/question-side-panel.tsx"
+git commit -m "fix(admin): modales de suppression/desactivation liberees apres un echec reseau"
+```
+
+---
+
+### Task 11: Mutations admin dont seul le rejet fetch est non géré
+
+⚠️ Revue design #6 : les branches `!success` de ces deux sites **toastent
+déjà** (`user-role-section.tsx:53`, `exams-list.tsx:99`) — ne pas dupliquer.
+Le travail se réduit au wrap `callAction`. Enjeu réel de `user-role-section` :
+l'`await` nu est DANS une transition (l.39) → un rejet fetch y remonte à
+l'**error boundary** au rendu (même mécanique que le cas Sentry
+`finalizeExam`), pas seulement en unhandled rejection.
+
+**Files:**
+
+- Modify: `app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx:40` (`updateUserRole`)
+- Modify: `components/admin/exams-list.tsx:94` (`reactivateExam`)
+
+- [ ] **Step 1: Wrap `callAction`, toasts existants conservés**
+
+```ts
+const res = await callAction(() => updateUserRole({/* args existants */}))
+// ... branches existantes inchangées : le toast `!res.success` en place
+// affiche désormais aussi NETWORK_ERROR_MESSAGE sur un rejet fetch
+```
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(admin)/admin/utilisateurs/[id]/_components/user-role-section.tsx" components/admin/exams-list.tsx
+git commit -m "fix(admin): toast d'echec sur updateUserRole et reactivateExam"
+```
+
+---
+
+### Task 12: Lectures admin `.then` sans `.catch` (9 sites, skeletons morts)
+
+**Files (tous en Modify) :**
+
+- `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx:246,253`
+- `app/(admin)/admin/questions/_components/question-form-page.tsx:140`
+- `app/(admin)/admin/questions/_components/question-side-panel.tsx:107`
+- `app/(admin)/admin/questions/_components/objectif-cmc-combobox.tsx:43`
+- `components/admin/question-browser/question-browser-context.tsx:139`
+- `components/admin/question-browser/question-preview-panel.tsx:72`
+- `app/(admin)/admin/examens/[id]/_components/exam-questions-modal.tsx:51`
+- `components/shared/payments/edit-transaction-modal.tsx:121`
+- `components/shared/payments/delete-transaction-dialog.tsx:44`
+
+- [ ] **Step 1: Ajouter un `.catch` qui sort du skeleton**
+
+Modèle (question-side-panel ; adapter le setState d'échec à chaque écran) :
+
+```ts
+loadQuestionById(questionId)
+  .then((q) => setQuestion(q))
+  .catch(() => {
+    toast.error("Chargement impossible. Vérifiez votre réseau.")
+    // sortir de l'état de chargement : fermer le panel/dialog OU afficher
+    // un message inline — selon ce que l'écran permet déjà proprement
+  })
+```
+
+Cas particuliers :
+
+- `question-browser-context.tsx:139` : la lecture est dans une transition →
+  try/catch dans le corps async (modèle Task 5) + marquer `hasLoaded` pour
+  sortir du skeleton initial.
+- `edit-transaction-modal.tsx:121` / `delete-transaction-dialog.tsx:44`
+  (`loadTransactionAccessImpact`) : l'avertissement de révocation est
+  best-effort → `.catch` silencieux avec un état « impact inconnu » affiché
+  (ne pas bloquer la modale).
+- `exam-questions-modal.tsx:51` : le dialog s'ouvre avant l'`await` → sur
+  échec, toast + `setIsDetailsOpen(false)`.
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(admin)/" components/admin/ components/shared/payments/
+git commit -m "fix(admin): les chargements .then sans .catch ne laissent plus de skeleton infini"
+```
+
+---
+
+### Task 13: Reloads admin en transition (listes stale silencieuses)
+
+**Files:**
+
+- Modify: `app/(admin)/admin/utilisateurs/_components/users-manager.tsx:107,125`
+- Modify: `app/(admin)/admin/utilisateurs/[id]/user-detail-client.tsx:66,75`
+- Modify: `app/(admin)/admin/transactions/_components/transactions-manager.tsx:74,103,116`
+
+- [ ] **Step 1: try/catch + toast dans chaque corps de transition**
+
+Modèle (users-manager ; les 7 sites sont isomorphes) :
+
+```ts
+startTransition(async () => {
+  try {
+    const page = await loadUsersPage(/* args existants */)
+    // ... setState existants
+  } catch {
+    toast.error("Actualisation impossible. Vérifiez votre réseau.")
+  }
+})
+```
+
+(Les `Promise.all(...)` de `user-detail-client.tsx:75` et
+`transactions-manager.tsx:116` s'enveloppent d'un seul try/catch.)
+
+- [ ] **Step 2: Vérifier + commit**
+
+Run: `bun run check && bun run test` — Expected: PASS.
+
+```bash
+git add "app/(admin)/admin/utilisateurs/" "app/(admin)/admin/transactions/"
+git commit -m "fix(admin): toasts d'echec sur les rechargements de listes (users/transactions)"
+```
+
+---
+
+### Task 14: Règle projet + gates finaux
+
+**Files:**
+
+- Modify: `.claude/rules/data-layer.md` (section « Écrans »)
+
+- [ ] **Step 1: Documenter la règle**
+
+Ajouter à la section « Écrans (Server Component + wrapper client) » :
+
+```md
+- **Appels client de Server Actions — jamais d'`await` nu** : un rejet réseau
+  (« Failed to fetch ») contourne le garde `if (!res.success)` → unhandled
+  rejection, spinner figé, optimiste non rollback (post-mortem Sentry
+  NOMAQBANQ-1A, 2026-07-12). Mutations : `callAction(() => action(x))`
+  (`lib/safe-action.ts`) — ne throw jamais, convertit le rejet en
+  `{ success: false, error }` ; `{ retries: n }` RÉSERVÉ aux actions
+  idempotentes (upserts quiz). Lectures : try/catch dans la transition, ou
+  `.catch` sur toute chaîne `.then` d'effet (toujours sortir du skeleton).
+  Le moteur quiz traite tout throw de callback comme `{ ok: false }`
+  (rollback) ; les toasts vivent dans les callbacks des pages.
+```
+
+- [ ] **Step 2: Gates finaux**
+
+Run: `bun run check && bun run test && bun run test:e2e e2e/tests/examen-blanc-offline.spec.ts --reporter=list`
+Expected: PASS partout ; coverage ≥ 75 %.
+
+- [ ] **Step 3: Commit + rappels de fin de campagne**
+
+```bash
+git add .claude/rules/data-layer.md
+git commit -m "docs: regle data-layer - jamais d'await nu de Server Action cote client"
+```
+
+Rappels post-merge (à faire par l'utilisateur, pas par le plan) :
+
+1. Résoudre l'issue Sentry NOMAQBANQ-1A après déploiement (elle ne recevra
+   plus d'événements — c'est voulu).
+2. Restaurer le stash `wip-marketing-84-85` sur sa branche si Task 0 l'a créé.
+3. Validation manuelle recommandée : DevTools → Network → Offline pendant une
+   passation réelle (`/e2e-scenario`).

--- a/docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md
+++ b/docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md
@@ -1,0 +1,261 @@
+# Spec — Robustesse réseau des appels client de Server Actions
+
+**Date** : 2026-07-12
+**Statut** : validé (brainstorming) ; revue adversariale design du 2026-07-12
+triée — architecture confirmée (~40 ancres vérifiées, invariants tenus), 4
+correctifs bloquants intégrés : sérialisation des envois de réponses par
+question (course retry/clic périmé), test existant du hook ajouté au périmètre
+(mocks `onFlag`), redirect `/compte-supprime` conservé, Task 9 réécrite sans
+symboles fantômes ; + garde one-shot auto-resume, prémisses « sans toast »
+corrigées, chemin `session-results` fixé
+**Origine** : Sentry NOMAQBANQ-1A (`TypeError: Failed to fetch`, prod 2026-07-12,
+page `/tableau-de-bord/examen-blanc/:examId/evaluation`)
+
+## Contexte
+
+Toutes les Server Actions du projet renvoient `{ success: false, error }` en
+cas d'erreur serveur, et les clients testent `if (!res.success)`. Mais quand le
+**fetch POST lui-même** rejette (connexion coupée — audience fréquemment sur
+réseaux mobiles instables), l'`await action()` côté client **throw** et cette
+branche n'est jamais atteinte. Les boundaries `error.tsx` (présentes à tous les
+niveaux) ne couvrent pas les rejections dans les event handlers async.
+
+Un audit exhaustif (~45 fichiers clients appelant des Server Actions) a relevé
+**~27 sites non protégés**, en trois familles de symptômes :
+
+1. **Perte silencieuse** : update optimiste posé avant l'`await`, rollback
+   confiné à la branche `!res.ok` → un throw le saute. Cas le plus grave :
+   `saveExamAnswer`/`saveTrainingAnswer` (la réponse reste affichée
+   sélectionnée mais n'est jamais persistée, zéro feedback).
+2. **UI verrouillée** : `setBusy(true)` → `await` → `setBusy(false)` sans
+   try/finally → le reset est sauté, spinner et bouton Annuler
+   (`disabled={busy}`) figés jusqu'au reload (4 modales admin).
+3. **Unhandled rejection silencieuse** : l'événement Sentry de prod
+   (`finalizeExam` dans une transition), plus une douzaine de lectures
+   `.then()` sans `.catch` (skeletons infinis).
+
+L'événement prod exact : étudiant au Cameroun, ~25 min de passation, POST de
+Server Action réussis en série, puis un POST échoue à 18 h 27 → unhandled
+rejection, aucune retentative, aucun toast.
+
+## Portée
+
+Trois couches, appliquées en trois phases (une campagne, commits séparés) :
+
+1. **Helper commun `lib/safe-action.ts`** : convertit les rejets réseau en
+   `{ success: false, error }` — la forme que tous les call sites savent déjà
+   gérer. Retry optionnel (1×) pour les actions idempotentes.
+2. **Durcissement du moteur quiz partagé** (`use-quiz-session.ts`,
+   `quiz-runner.tsx`, `pause-dialog.tsx`) : tout throw d'un callback est
+   traité comme `{ ok: false }` (rollback optimiste inclus), fire-and-forget
+   avec `.catch`.
+3. **Application mécanique aux sites audités** : P1 étudiant → P2
+   facturation/compte → P3 admin (inventaire complet en annexe).
+
+**Hors scope (YAGNI, réévaluer si récidive)** : bannière offline
+(`navigator.onLine` + events), queue de retry persistante (localStorage),
+télémétrie Sentry des échecs réseau gérés (événement attendu ; conséquence
+assumée : NOMAQBANQ-1A à résoudre manuellement après déploiement),
+généralisation aux lectures RSC côté serveur (autre canal, autre sémantique d'erreur).
+
+## 1. Helper `lib/safe-action.ts`
+
+Module client-safe (aucun import serveur), ~30 lignes :
+
+```ts
+export type ActionFailure = { success: false; error: string }
+
+export const NETWORK_ERROR_MESSAGE =
+  "Connexion perdue. Vérifiez votre réseau et réessayez."
+
+export async function callAction<T>(
+  fn: () => Promise<T>,
+  opts?: { retries?: number }, // défaut 0 — RÉSERVÉ aux actions idempotentes
+): Promise<T | ActionFailure>
+```
+
+Le générique est volontairement non contraint : le repo a deux conventions de
+retour (`{ success, error? }` majoritaire, et `{ error } | { payload }` pour
+`createCustomerPortal`). `ActionFailure` porte à la fois `success: false` et
+`error`, donc il est discriminable par les deux gardes existants
+(`!res.success` comme `"error" in res`).
+
+- `try { return await fn() } catch { … }` : tout rejet (réseau, abort) devient
+  `{ success: false, error: NETWORK_ERROR_MESSAGE }`. Les erreurs **serveur**
+  (`{ success: false, error }` renvoyées par l'action) passent inchangées —
+  `callAction` ne les retente jamais.
+- **Retry** : sur throw uniquement, au plus `opts.retries` retentatives après
+  un délai fixe de 1 000 ms. Un « Failed to fetch » peut survenir alors que la
+  requête a **atteint** le serveur (réponse perdue) → le retry ré-exécute
+  l'action. Il est donc réservé à la liste fermée des actions idempotentes :
+  `saveExamAnswer`, `saveTrainingAnswer`, `saveExamFlag` (upserts par clé
+  `(participation, question)`).
+- **Invariant à maintenir** : aucune Server Action du projet n'appelle
+  `redirect()` côté serveur (elles renvoient des valeurs ; la navigation est
+  faite au client via `router.push`). `callAction` n'a donc pas de cas spécial
+  `NEXT_REDIRECT`. Si une action redirigeante apparaît un jour, ne pas
+  l'envelopper.
+- Pas de capture Sentry ni de log : le toast est le feedback ; ce qui reste
+  non géré continue de remonter à Sentry (c'est le but).
+- `authClient.*` (Better Auth / @better-fetch) **ne throw pas** sur échec
+  réseau — il résout `{ error }`. Les sites authClient se corrigent en lisant
+  le retour, pas avec `callAction`.
+
+## 2. Durcissement du moteur quiz partagé
+
+Défense en profondeur : même si un futur écran oublie `callAction` dans ses
+callbacks, le moteur ne doit ni crasher ni corrompre son état. Règle de
+responsabilité : **le toast vit dans les callbacks des pages** (via
+`callAction`, dont le message alimente les branches `!res.success`
+existantes) ; **le moteur traite tout throw comme un échec silencieux**
+(`{ ok: false }`) et garantit ses invariants d'état.
+
+Dans `components/quiz/runner/use-quiz-session.ts` :
+
+- `answerSelect` (l.184) : try/catch autour de `callbacks.onAnswer` (un throw
+  vaut `{ ok: false }`) **et envoi sérialisé par question** (revue design #1) :
+  un seul `onAnswer` en vol par `questionId` ; un clic pendant l'envoi devient
+  « le dernier choix en attente » (coalescing) et part quand l'envoi courant
+  se règle — le retry de `callAction` vit DANS ce créneau, il ne peut donc
+  plus ré-appliquer un clic périmé par-dessus un clic plus récent. Le rollback
+  vise la **dernière valeur confirmée serveur** (ref `persistedAnswers`), pas
+  l'état d'avant-clic, et n'a jamais lieu si un clic plus récent a pris la
+  main. Bruit résiduel accepté : si un envoi supersédé échoue, son toast
+  (« Réponse non enregistrée ») part alors que le clic suivant peut réussir —
+  fenêtre sub-seconde, auto-corrigé visuellement.
+- `confirmAnswer` (l.209) : catch → return (le pending est conservé, l'état
+  `isConfirming` est déjà libéré par le try/finally du runner).
+- `confirmFinish` (l.257) : try/catch dans la transition (le cas Sentry) ; en
+  échec, le dialog reste ouvert pour retenter.
+- `pause`/`resume` (l.231/239) : try/catch → no-op en échec (l'état
+  `isPaused` n'est modifié qu'en succès, déjà le cas).
+- `toggleFlag` (l.155) : le contrat `QuizCallbacks.onFlag` passe de
+  `Promise<void>` à `Promise<{ ok: boolean }>` ; le moteur rollback le flag
+  local si `!ok` ou throw. Silencieux (pas de toast — cosmétique, pas de bruit
+  en passation).
+
+Aucun changement dans `quiz-runner.tsx` (fire-and-forget de pause, l.115 —
+sûr une fois `pause()` non-rejetante). Dans `pause-dialog.tsx` : **garde
+one-shot sur l'auto-resume** (revue design #3) — l'auto-`onResume()` tourne
+dans un `setInterval` 1 s, donc pause expirée + hors ligne = un toast d'erreur
+par seconde ; ne déclencher l'auto-resume qu'une fois par expiration, le
+bouton `btn-resume-exam` reste la voie de retentative manuelle.
+
+## 3. Application aux écrans — inventaire par phase
+
+Pattern par type de site :
+
+- **Mutation avec callback structuré** : `await callAction(() => action(x))`
+  (+ `{ retries: 1 }` pour les 3 saves quiz) — les branches toast existantes
+  gèrent le message.
+- **Mutation avec état busy** : `callAction` suffit — comme il ne throw
+  jamais, le `setBusy(false)` post-`await` s'exécute toujours ; ajouter le
+  toast sur `!res.success` s'il manque. (Un try/finally reste pertinent
+  seulement si le handler contient d'autres `await` susceptibles de throw —
+  modèle existant : `delete-transaction-dialog.tsx`.)
+- **Lecture `.then(setState)` en useEffect** : ajouter `.catch` → sortir du
+  skeleton (état d'erreur léger ou toast) ; le détail par écran est fixé au
+  plan.
+- **Lecture dans `startTransition`** : try/catch + toast (modèle existant :
+  `abonnements-client.tsx` `handleLoadMore`).
+
+### Phase 1 — Étudiant (bug prod)
+
+| Site                                                                                                                       | Action                                                           | Traitement                                                                  |
+| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `evaluation-client.tsx` onAnswer                                                                                           | `saveExamAnswer`                                                 | `callAction` + `retries: 1`                                                 |
+| `evaluation-client.tsx` onFlag                                                                                             | `saveExamFlag`                                                   | `callAction` + `retries: 1`, renvoie `{ ok }`                               |
+| `evaluation-client.tsx` onFinish                                                                                           | `finalizeExam`                                                   | `callAction` (pas de retry ; re-tentable manuellement, gère « déjà passé ») |
+| `evaluation-client.tsx` onPause/onResume                                                                                   | `pauseExam`/`resumeExam`                                         | `callAction`                                                                |
+| `training-session-client.tsx` onAnswer/onFinish                                                                            | `saveTrainingAnswer` (+`retries: 1`) / `completeTrainingSession` | `callAction`                                                                |
+| `training-config-form.tsx:63`                                                                                              | `loadAvailableObjectifsCMC`                                      | try/catch dans la transition                                                |
+| `training-history-section.tsx:74`                                                                                          | `loadTrainingHistory`                                            | try/catch + toast                                                           |
+| `components/quiz/results/session-results.tsx:156` (composant **partagé** : résultats examen étudiant, admin, entraînement) | `loadExamQuestionExplanations`                                   | `.catch` + toast (re-déplier retente déjà ; importer `sonner`)              |
+| Moteur quiz (couche 2)                                                                                                     | —                                                                | cf. §2                                                                      |
+
+### Phase 2 — Facturation / compte
+
+| Site                            | Action                          | Traitement                                                                                                                                                                                    |
+| ------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `abonnements-client.tsx:263` 🔴 | `createCustomerPortal`          | `callAction` dans l'action `useActionState` → la branche `navigator.onLine` existante (aujourd'hui inatteignable) fonctionne                                                                  |
+| `profile-sessions.tsx:23/35`    | `revokeUserSession(s)`          | try/catch/finally (libère `busy`) + toast                                                                                                                                                     |
+| `profile-notifications.tsx:22`  | `updateNotificationPreferences` | try/catch/finally + **rollback** de l'optimiste + toast                                                                                                                                       |
+| `profile-password.tsx:47`       | `setAccountPassword`            | try/catch + toast (RHF libère déjà `isSubmitting`)                                                                                                                                            |
+| `profile-danger-zone.tsx:23`    | `deleteMyAccount`               | try/catch/finally + toast                                                                                                                                                                     |
+| `profile-danger-zone.tsx:29`    | `authClient.signOut()`          | lire `{ error }` ; rediriger quand même (le compte est supprimé côté serveur), sans unhandled                                                                                                 |
+| `hooks/useMarketingStats.ts:15` | `loadMarketingStats`            | `.catch(() => setStats(null))` → sortie du skeleton ; les 7 consommateurs ont déjà leurs fallbacks inline (`stats?.x ?? "…"`) — vérifié en revue, aucun crash ni skeleton résiduel sur `null` |
+
+### Phase 3 — Admin
+
+| Famille                                                                                     | Sites                                                                                                                                                                                                                                                                                                | Traitement                                                                   |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| 🔴 Modales verrouillables (`setBusy` sans finally)                                          | `exam-leaderboard.tsx:73` (`deleteParticipation`), `exams-list.tsx:81/:119` (`deactivateExam`/`deleteExam`), `question-side-panel.tsx:122` (`deleteQuestion`)                                                                                                                                        | try/catch/**finally** + toast                                                |
+| Mutations dont seul le **rejet fetch** est non géré (les branches `!success` toastent déjà) | `user-role-section.tsx:40` (`updateUserRole` — l'`await` nu est DANS une transition : un rejet remonte à l'error boundary, même mécanique que le cas Sentry), `exams-list.tsx:94` (`reactivateExam`)                                                                                                 | wrap `callAction`, toasts existants conservés                                |
+| Lectures `.then` sans `.catch` (skeleton/dialog mort)                                       | `user-side-panel.tsx:246/253`, `question-form-page.tsx:140`, `question-side-panel.tsx:107`, `objectif-cmc-combobox.tsx:43`, `question-browser-context.tsx:139`, `question-preview-panel.tsx:72`, `exam-questions-modal.tsx:51`, `edit-transaction-modal.tsx:121`, `delete-transaction-dialog.tsx:44` | `.catch` → sortir du skeleton (toast + fermeture ou message d'erreur inline) |
+| Reloads en transition (liste stale)                                                         | `users-manager.tsx:107/125`, `user-detail-client.tsx:66/75`, `transactions-manager.tsx:74/103/116`                                                                                                                                                                                                   | try/catch + toast                                                            |
+
+Sites vérifiés **déjà protégés** (aucun changement) : `startExam`, quiz public
+(`loadRandomQuizQuestions`/`scoreQuizAnswers`), `pricing-grid`,
+`payment-success-client`, `bienvenue`, dialogs de suppression d'entraînement,
+uploaders S3 (avatar + images question), `manual-payment-modal`,
+`edit/delete-transaction` (mutations), `export-questions-button`,
+`user-multi-select`, `exam-create-form`, `exam-edit-form`,
+`question-form-page` (submit), `authClient.changePassword`.
+
+## 4. Documentation de la règle
+
+Ajout à `.claude/rules/data-layer.md` (section Écrans) : jamais d'`await` nu
+d'une Server Action côté client — `callAction` pour les mutations à retour
+structuré, try/finally pour les états busy, `.catch` sur tout fire-and-forget
+et toute chaîne `.then` d'effet. Référencer `lib/safe-action.ts`.
+
+## 5. Tests
+
+- **Unit `tests/lib/safe-action.test.ts`** (vitest, fake timers) : succès
+  passthrough ; erreur serveur passthrough sans retry ; throw →
+  `ActionFailure` ; `retries: 1` → 2 tentatives puis échec ; retry qui réussit
+  à la 2ᵉ ; défaut sans retry.
+- **Composant `tests/components/quiz/use-quiz-session-network.test.tsx`**
+  (renderHook, même dossier que les tests existants du hook) : `onAnswer` qui
+  throw → rollback de l'optimiste, pas d'unhandled rejection ; sérialisation —
+  un clic pendant un envoi en vol est coalescé et envoyé après, sans rollback
+  du clic récent ; échec du dernier envoi → rollback vers la dernière valeur
+  **confirmée**, pas l'état d'avant-clic ; `onFlag` qui throw ou renvoie
+  `{ ok: false }` → rollback du flag ; `confirmFinish` qui throw → pas de
+  crash ; `onResume` qui throw testé avec `initialPause: { isPaused: true }`
+  (sinon le early-return `!isPaused` fait passer le test à vide). Les mocks
+  `onFlag` du test existant (`use-quiz-session.test.ts:36,293`) passent à
+  `{ ok: true }` (contrat changé).
+- **E2E `e2e/tests/examen-blanc-offline.spec.ts`** (projet `chromium-auth`,
+  seed-exam dédié) : passation → `context.setOffline(true)` → clic réponse →
+  toast visible + option désélectionnée (rollback, `data-selected` absent) →
+  `setOffline(false)` → re-clic → `data-selected="true"`. Note : le retry 1×
+  (1 s) impose d'attendre l'échec définitif avant d'asserter le toast.
+- **Gates** : `bun run check`, `bun run test` (+ seuil coverage), e2e ciblé.
+
+## 6. Risques et limites
+
+- **Retry = ré-exécution potentielle** d'une action déjà appliquée (réponse
+  perdue en vol) : sans danger uniquement parce que la liste est fermée aux
+  upserts idempotents ET que les envois de réponses sont sérialisés par
+  question (§2) — l'idempotence unitaire ne protège pas de l'ordonnancement
+  entre clics successifs. Toute extension de la liste exige la même analyse.
+- **Perte de visibilité Sentry** sur les coupures réseau (assumé) : si un
+  écran régresse, l'unhandled rejection réapparaîtra — c'est le signal voulu.
+- **`useActionState` (React 19)** : un throw dans l'action remonte à l'error
+  boundary au rendu — c'est pourquoi `createCustomerPortal` est le seul site
+  classé « error boundary possible » ; le fix le neutralise à la source.
+- Le moteur quiz reste silencieux sur throw (pas de toast) si le callback de
+  page n'utilise pas `callAction` — mitigé par la règle documentée (§4).
+
+## 7. Critères d'acceptation
+
+1. Rejouer le scénario prod (DevTools offline pendant une passation, clic
+   réponse) : aucun événement `onunhandledrejection`, toast affiché, option
+   visuellement désélectionnée, re-clic après reconnexion persiste la réponse.
+2. Les 4 modales admin 🔴 se libèrent (bouton Annuler cliquable) après un
+   échec réseau.
+3. `createCustomerPortal` hors ligne → toast « Pas de connexion internet… »,
+   pas d'error boundary.
+4. Aucun `await` nu de Server Action dans les fichiers listés à l'inventaire ;
+   `bun run check` et la suite de tests passent.

--- a/docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md
+++ b/docs/superpowers/specs/2026-07-12-robustesse-reseau-server-actions-design.md
@@ -227,10 +227,15 @@ et toute chaîne `.then` d'effet. Référencer `lib/safe-action.ts`.
   `onFlag` du test existant (`use-quiz-session.test.ts:36,293`) passent à
   `{ ok: true }` (contrat changé).
 - **E2E `e2e/tests/examen-blanc-offline.spec.ts`** (projet `chromium-auth`,
-  seed-exam dédié) : passation → `context.setOffline(true)` → clic réponse →
-  toast visible + option désélectionnée (rollback, `data-selected` absent) →
-  `setOffline(false)` → re-clic → `data-selected="true"`. Note : le retry 1×
-  (1 s) impose d'attendre l'échec définitif avant d'asserter le toast.
+  seed-exam dédié) : passation → coupure simulée par `context.route` +
+  `route.abort("internetdisconnected")` sur les POST de Server Actions (PAS
+  `context.setOffline` : hors ligne, le dev server Turbopack laisse la requête
+  pendre au lieu de la rejeter — constaté à l'implémentation) → clic réponse →
+  toast visible + rollback vers la réponse persistée (`data-selected`) →
+  `unroute` → re-clic → `data-selected="true"` et survie à la navigation. Le
+  POST de la réponse en ligne est attendu (`waitForResponse`) avant la coupure
+  pour garantir la valeur de rollback. Note : le retry 1× (1 s) impose
+  d'attendre l'échec définitif avant d'asserter le toast.
 - **Gates** : `bun run check`, `bun run test` (+ seuil coverage), e2e ciblé.
 
 ## 6. Risques et limites

--- a/e2e/tests/examen-blanc-offline.spec.ts
+++ b/e2e/tests/examen-blanc-offline.spec.ts
@@ -1,0 +1,113 @@
+import { type APIRequestContext, type Route } from "@playwright/test"
+import { expect, test } from "../fixtures/base"
+
+/**
+ * Rejoue le scénario du post-mortem Sentry NOMAQBANQ-1A : coupure réseau
+ * pendant la passation → le clic de réponse doit échouer PROPREMENT (toast +
+ * rollback vers la dernière réponse persistée, pas d'unhandled rejection) puis
+ * réussir au retour du réseau.
+ *
+ * La coupure est simulée par `route.abort()` sur les POST de Server Actions
+ * (rejet immédiat du fetch, comme en prod) plutôt que `context.setOffline` :
+ * hors ligne, le dev server Turbopack laisse la requête PENDRE (websocket HMR
+ * mort, « Compiling… » bloqué) au lieu de la rejeter — le scénario ne se
+ * déclenche jamais.
+ */
+
+const SECRET = process.env.E2E_RESET_SECRET
+const PREFIX = "[E2E] Offline"
+
+const post = (request: APIRequestContext, data: object) =>
+  request.post("/api/e2e", {
+    data: { secret: SECRET, ...data },
+    failOnStatusCode: false,
+  })
+
+const isActionPost = (route: Route) =>
+  route.request().method() === "POST" &&
+  route.request().url().includes("/evaluation")
+
+let examId = ""
+
+test.describe("Examen Blanc — coupure réseau pendant la passation", () => {
+  test.describe.configure({ mode: "serial", timeout: 90_000 })
+
+  test.beforeAll(async ({ request }) => {
+    if (!SECRET) return
+    const seed = await post(request, {
+      action: "seed-exam",
+      title: `${PREFIX} Passation`,
+      questionCount: 5,
+    })
+    examId = (await seed.json()).examId
+  })
+
+  test.afterAll(async ({ request }) => {
+    if (!SECRET) return
+    await post(request, { action: "cleanup", prefix: PREFIX })
+  })
+
+  test("hors ligne : toast + rollback ; retour en ligne : la réponse persiste", async ({
+    examen,
+    page,
+    context,
+  }) => {
+    test.skip(!SECRET, "E2E_RESET_SECRET requis")
+    expect(examId).toBeTruthy()
+
+    await examen.goto()
+    await examen.clickStartExamById(examId)
+    const dialog = page.locator('[role="alertdialog"], [role="dialog"]')
+    await dialog.getByRole("button", { name: "Commencer l'examen" }).click()
+    await page.waitForURL(/\/evaluation/, { timeout: 15_000 })
+    await examen.acceptWarningOrResume()
+    await examen.waitForQuestion(1)
+
+    // Réponse en ligne — on attend la réponse du POST : garantit que A est
+    // PERSISTÉE côté serveur (c'est la valeur attendue du rollback).
+    const option0 = page.getByTestId("answer-option-0")
+    const option1 = page.getByTestId("answer-option-1")
+    await option0.scrollIntoViewIfNeeded()
+    const saved = page.waitForResponse(
+      (r) => r.request().method() === "POST" && r.url().includes("/evaluation"),
+      { timeout: 15_000 },
+    )
+    await option0.click()
+    await expect(option0).toHaveAttribute("data-selected", "true")
+    await saved
+
+    // « Coupure réseau » : les POST de Server Actions rejettent immédiatement
+    await context.route("**/*", (route) =>
+      isActionPost(route)
+        ? route.abort("internetdisconnected")
+        : route.continue(),
+    )
+    await option1.scrollIntoViewIfNeeded()
+    await option1.click()
+    // retry 1× à 1 s inclus avant l'échec définitif
+    await expect(
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: "Réponse non enregistrée" }),
+    ).toBeVisible({ timeout: 10_000 })
+    // Rollback vers la dernière réponse persistée : option 0 re-sélectionnée
+    await expect(option1).not.toHaveAttribute("data-selected", "true")
+    await expect(option0).toHaveAttribute("data-selected", "true")
+
+    // Retour en ligne → le re-clic persiste
+    await context.unroute("**/*")
+    await option1.click()
+    await expect(option1).toHaveAttribute("data-selected", "true", {
+      timeout: 10_000,
+    })
+
+    // La sélection survit à une navigation (preuve de persistance serveur)
+    await examen.nextQuestion()
+    await examen.waitForQuestion(2)
+    await examen.prevQuestion()
+    await examen.waitForQuestion(1)
+    await expect(
+      page.locator('[data-testid="answer-option-1"][data-selected="true"]'),
+    ).toBeVisible()
+  })
+})

--- a/hooks/useMarketingStats.ts
+++ b/hooks/useMarketingStats.ts
@@ -6,19 +6,27 @@ import type { MarketingStats } from "@/features/marketing/dal"
  * Stats marketing publiques via Server Action (remplace `useQuery` Convex).
  * Conserve la forme `{ stats, isLoading }` ; `setStats` dans `.then` (async) →
  * hors du piège `react-hooks/set-state-in-effect`.
+ * `null` = échec de chargement : sort du skeleton, les consommateurs retombent
+ * sur leurs fallbacks inline (`stats?.x ?? "…"`).
  */
 export function useMarketingStats() {
-  const [stats, setStats] = useState<MarketingStats | undefined>(undefined)
+  const [stats, setStats] = useState<MarketingStats | null | undefined>(
+    undefined,
+  )
 
   useEffect(() => {
     let active = true
-    loadMarketingStats().then((s) => {
-      if (active) setStats(s)
-    })
+    loadMarketingStats()
+      .then((s) => {
+        if (active) setStats(s)
+      })
+      .catch(() => {
+        if (active) setStats(null)
+      })
     return () => {
       active = false
     }
   }, [])
 
-  return { stats, isLoading: stats === undefined }
+  return { stats: stats ?? undefined, isLoading: stats === undefined }
 }

--- a/lib/safe-action.ts
+++ b/lib/safe-action.ts
@@ -1,0 +1,33 @@
+// Client-safe : aucun import serveur. Convertit les rejets réseau d'un appel
+// de Server Action en échec structuré, discriminable par les gardes existants
+// (`!res.success` comme `"error" in res`).
+
+export type ActionFailure = { success: false; error: string }
+
+export const NETWORK_ERROR_MESSAGE =
+  "Connexion perdue. Vérifiez votre réseau et réessayez."
+
+const RETRY_DELAY_MS = 1000
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// `retries` est RÉSERVÉ aux actions idempotentes (upserts) : un « Failed to
+// fetch » peut survenir alors que la requête a atteint le serveur, le retry
+// ré-exécute donc l'action.
+export async function callAction<T>(
+  fn: () => Promise<T>,
+  opts?: { retries?: number },
+): Promise<T | ActionFailure> {
+  const retries = opts?.retries ?? 0
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch {
+      if (attempt < retries) {
+        await delay(RETRY_DELAY_MS)
+        continue
+      }
+      return { success: false, error: NETWORK_ERROR_MESSAGE }
+    }
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
         /examen-blanc\.spec\.ts/,
         /examen-blanc-pause\.spec\.ts/,
         /examen-blanc-auto-submit\.spec\.ts/,
+        /examen-blanc-offline\.spec\.ts/,
         /resultats-examen\.spec\.ts/,
         /resultats-entrainement\.spec\.ts/,
         /profil\.spec\.ts/,

--- a/tests/components/quiz/use-quiz-session-network.test.tsx
+++ b/tests/components/quiz/use-quiz-session-network.test.tsx
@@ -169,6 +169,23 @@ describe("use-quiz-session — rejets réseau des callbacks", () => {
     await waitFor(() => expect(result.current.flagged.has("q1")).toBe(false))
   })
 
+  it("deux toggles de flag hors ligne : retombe sur l'état confirmé, pas l'inverse", async () => {
+    const callbacks = makeCallbacks({ onFlag: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    act(() => {
+      result.current.toggleFlag() // ON (envoi part)
+    })
+    act(() => {
+      result.current.toggleFlag() // OFF (coalescé derrière l'envoi en vol)
+    })
+    // Les deux envois échouent → rollback vers la valeur confirmée (jamais
+    // flaguée), pas une inversion des reverts
+    await waitFor(() => expect(callbacks.onFlag).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.flagged.has("q1")).toBe(false))
+    expect(callbacks.onFlag).toHaveBeenNthCalledWith(1, "q1", true)
+    expect(callbacks.onFlag).toHaveBeenNthCalledWith(2, "q1", false)
+  })
+
   it("confirmFinish : pas de crash quand onFinish rejette, dialog réouvrable", async () => {
     const callbacks = makeCallbacks({ onFinish: vi.fn(networkReject) })
     const { result } = renderSession(callbacks)

--- a/tests/components/quiz/use-quiz-session-network.test.tsx
+++ b/tests/components/quiz/use-quiz-session-network.test.tsx
@@ -1,0 +1,151 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type {
+  QuizCallbacks,
+  QuizMode,
+  QuizQuestion,
+} from "@/components/quiz/runner/types"
+import { useQuizSession } from "@/components/quiz/runner/use-quiz-session"
+
+const QUESTIONS: QuizQuestion[] = [
+  { _id: "q1", question: "Q ?", options: ["A", "B", "C"], domain: "Cardio" },
+]
+
+const DEFERRED_MODE: QuizMode = {
+  kind: "exam",
+  accent: "blue",
+  timer: null,
+  pause: null,
+  feedback: "deferred",
+  showMeta: false,
+  labels: { title: "t", finishCta: "Terminer" },
+  backUrl: "/x",
+}
+
+const networkReject = () => Promise.reject(new TypeError("Failed to fetch"))
+
+const makeCallbacks = (over: Partial<QuizCallbacks>): QuizCallbacks => ({
+  onAnswer: vi.fn(async () => ({ ok: true }) as const),
+  onFlag: vi.fn(async () => ({ ok: true })),
+  onFinish: vi.fn(async () => ({ ok: true })),
+  ...over,
+})
+
+const renderSession = (
+  callbacks: QuizCallbacks,
+  initialPause?: { isPaused: boolean; totalPauseDurationMs: number },
+) =>
+  renderHook(() =>
+    useQuizSession({
+      questions: QUESTIONS,
+      initialAnswers: {},
+      initialPause,
+      mode: DEFERRED_MODE,
+      callbacks,
+    }),
+  )
+
+describe("use-quiz-session — rejets réseau des callbacks", () => {
+  it("answerSelect : rollback de l'optimiste quand onAnswer rejette", async () => {
+    const callbacks = makeCallbacks({ onAnswer: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    await act(async () => {
+      await result.current.answerSelect(0)
+    })
+    expect(result.current.answers["q1"]).toBeUndefined()
+  })
+
+  it("sérialisation : un clic pendant un envoi en vol est coalescé, envoyé après, sans rollback", async () => {
+    let rejectA!: (e: unknown) => void
+    const inFlightA = new Promise<never>((_, reject) => {
+      rejectA = reject
+    })
+    const onAnswer = vi
+      .fn()
+      .mockReturnValueOnce(inFlightA) // clic A : reste en vol
+      .mockResolvedValueOnce({ ok: true }) // clic B : réussit
+    const { result } = renderSession(makeCallbacks({ onAnswer }))
+    await act(async () => {
+      void result.current.answerSelect(0) // A
+    })
+    await act(async () => {
+      void result.current.answerSelect(1) // B pendant que A est en vol
+    })
+    expect(onAnswer).toHaveBeenCalledTimes(1) // B coalescé, pas encore parti
+    await act(async () => {
+      rejectA(new TypeError("Failed to fetch"))
+    })
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledTimes(2))
+    expect(onAnswer).toHaveBeenLastCalledWith("q1", "B")
+    // L'échec de A (supersédé) ne rollback PAS l'optimiste de B
+    expect(result.current.answers["q1"]?.selected).toBe("B")
+  })
+
+  it("rollback vers la dernière valeur CONFIRMÉE, pas l'état d'avant-clic", async () => {
+    const onAnswer = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true }) // A persisté
+      .mockRejectedValueOnce(new TypeError("Failed to fetch")) // B échoue
+    const { result } = renderSession(makeCallbacks({ onAnswer }))
+    await act(async () => {
+      await result.current.answerSelect(0) // A confirmé serveur
+    })
+    await act(async () => {
+      await result.current.answerSelect(1) // B échoue
+    })
+    expect(result.current.answers["q1"]?.selected).toBe("A")
+  })
+
+  it("toggleFlag : rollback du flag quand onFlag rejette", async () => {
+    const callbacks = makeCallbacks({ onFlag: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    act(() => {
+      result.current.toggleFlag()
+    })
+    await waitFor(() => expect(result.current.flagged.has("q1")).toBe(false))
+  })
+
+  it("toggleFlag : rollback du flag quand onFlag renvoie { ok: false }", async () => {
+    const callbacks = makeCallbacks({
+      onFlag: vi.fn(async () => ({ ok: false })),
+    })
+    const { result } = renderSession(callbacks)
+    act(() => {
+      result.current.toggleFlag()
+    })
+    await waitFor(() => expect(result.current.flagged.has("q1")).toBe(false))
+  })
+
+  it("confirmFinish : pas de crash quand onFinish rejette, dialog réouvrable", async () => {
+    const callbacks = makeCallbacks({ onFinish: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    await act(async () => {
+      await result.current.confirmFinish()
+    })
+    await waitFor(() => expect(result.current.isSubmitting).toBe(false))
+  })
+
+  it("pause : pas de crash quand onPause rejette", async () => {
+    const callbacks = makeCallbacks({ onPause: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks)
+    await act(async () => {
+      await result.current.pause()
+    })
+    expect(result.current.isPaused).toBe(false)
+  })
+
+  it("resume : pas de crash quand onResume rejette (session montée en pause)", async () => {
+    // initialPause obligatoire : sinon le early-return `!isPaused` de resume()
+    // fait passer le test à vide sans toucher le callback
+    const callbacks = makeCallbacks({ onResume: vi.fn(networkReject) })
+    const { result } = renderSession(callbacks, {
+      isPaused: true,
+      totalPauseDurationMs: 0,
+    })
+    await act(async () => {
+      await result.current.resume()
+    })
+    expect(callbacks.onResume).toHaveBeenCalledTimes(1)
+    expect(result.current.isPaused).toBe(true)
+  })
+})

--- a/tests/components/quiz/use-quiz-session-network.test.tsx
+++ b/tests/components/quiz/use-quiz-session-network.test.tsx
@@ -81,6 +81,59 @@ describe("use-quiz-session — rejets réseau des callbacks", () => {
     expect(result.current.answers["q1"]?.selected).toBe("B")
   })
 
+  it("un envoi supersédé qui RÉUSSIT devient la valeur confirmée (rollback vers A, pas vers rien)", async () => {
+    let resolveA!: (v: { ok: true }) => void
+    const inFlightA = new Promise<{ ok: true }>((resolve) => {
+      resolveA = resolve
+    })
+    const onAnswer = vi
+      .fn()
+      .mockReturnValueOnce(inFlightA) // clic A : en vol
+      .mockRejectedValueOnce(new TypeError("Failed to fetch")) // clic B : échoue
+    const { result } = renderSession(makeCallbacks({ onAnswer }))
+    await act(async () => {
+      void result.current.answerSelect(0) // A
+    })
+    await act(async () => {
+      void result.current.answerSelect(1) // B coalescé pendant que A est en vol
+    })
+    await act(async () => {
+      resolveA({ ok: true }) // A réussit APRÈS le clic B → doit être confirmée
+    })
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledTimes(2))
+    // B échoue → rollback vers A (persistée), pas vers « sans réponse »
+    await waitFor(() =>
+      expect(result.current.answers["q1"]?.selected).toBe("A"),
+    )
+  })
+
+  it("3 clics rapides : seuls le premier et le DERNIER partent (coalescing écrasé)", async () => {
+    let resolveA!: (v: { ok: true }) => void
+    const inFlightA = new Promise<{ ok: true }>((resolve) => {
+      resolveA = resolve
+    })
+    const onAnswer = vi
+      .fn()
+      .mockReturnValueOnce(inFlightA)
+      .mockResolvedValue({ ok: true })
+    const { result } = renderSession(makeCallbacks({ onAnswer }))
+    await act(async () => {
+      void result.current.answerSelect(0) // A part
+    })
+    await act(async () => {
+      void result.current.answerSelect(1) // B coalescé…
+    })
+    await act(async () => {
+      void result.current.answerSelect(2) // …écrasé par C
+    })
+    await act(async () => {
+      resolveA({ ok: true })
+    })
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledTimes(2))
+    expect(onAnswer).toHaveBeenLastCalledWith("q1", "C")
+    expect(result.current.answers["q1"]?.selected).toBe("C")
+  })
+
   it("rollback vers la dernière valeur CONFIRMÉE, pas l'état d'avant-clic", async () => {
     const onAnswer = vi
       .fn()

--- a/tests/components/quiz/use-quiz-session.test.ts
+++ b/tests/components/quiz/use-quiz-session.test.ts
@@ -33,7 +33,7 @@ const makeCallbacks = (
   overrides: Partial<QuizCallbacks> = {},
 ): QuizCallbacks => ({
   onAnswer: vi.fn().mockResolvedValue({ ok: true }),
-  onFlag: vi.fn().mockResolvedValue(undefined),
+  onFlag: vi.fn().mockResolvedValue({ ok: true }),
   onFinish: vi.fn().mockResolvedValue({ ok: true }),
   ...overrides,
 })
@@ -290,7 +290,7 @@ describe("useQuizSession — initialAnswers & initialFlags", () => {
 
 describe("useQuizSession — toggle flag", () => {
   it("toggleFlag ajoute et retire la question courante + appelle onFlag", () => {
-    const onFlag = vi.fn().mockResolvedValue(undefined)
+    const onFlag = vi.fn().mockResolvedValue({ ok: true })
     const { result } = renderHook(() =>
       useQuizSession({
         questions: makeQuestions(3),

--- a/tests/components/quiz/use-quiz-session.test.ts
+++ b/tests/components/quiz/use-quiz-session.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type {
   AnswersMap,
@@ -289,7 +289,7 @@ describe("useQuizSession — initialAnswers & initialFlags", () => {
 })
 
 describe("useQuizSession — toggle flag", () => {
-  it("toggleFlag ajoute et retire la question courante + appelle onFlag", () => {
+  it("toggleFlag ajoute et retire la question courante + appelle onFlag", async () => {
     const onFlag = vi.fn().mockResolvedValue({ ok: true })
     const { result } = renderHook(() =>
       useQuizSession({
@@ -305,7 +305,9 @@ describe("useQuizSession — toggle flag", () => {
 
     act(() => result.current.toggleFlag())
     expect(result.current.flagged.has("q1")).toBe(false)
-    expect(onFlag).toHaveBeenCalledWith("q1", false)
+    // Envois sérialisés par question : le second onFlag part quand le premier
+    // est réglé, pas de façon synchrone
+    await waitFor(() => expect(onFlag).toHaveBeenCalledWith("q1", false))
   })
 })
 

--- a/tests/hooks/useMarketingStats.test.tsx
+++ b/tests/hooks/useMarketingStats.test.tsx
@@ -49,6 +49,18 @@ describe("useMarketingStats", () => {
     expect(result.current.stats).toEqual(mockStats)
   })
 
+  it("sort du skeleton quand le chargement échoue (rejet réseau)", async () => {
+    vi.mocked(loadMarketingStats).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    )
+
+    const { result } = renderHook(() => useMarketingStats())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // stats reste undefined → les consommateurs affichent leurs fallbacks `??`
+    expect(result.current.stats).toBeUndefined()
+  })
+
   it("appelle l'action au montage (stats publiques, pas d'auth requise)", () => {
     vi.mocked(loadMarketingStats).mockResolvedValue(mockStats)
 

--- a/tests/lib/safe-action.test.ts
+++ b/tests/lib/safe-action.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NETWORK_ERROR_MESSAGE, callAction } from "@/lib/safe-action"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("callAction", () => {
+  it("laisse passer un succès inchangé", async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, data: 42 })
+    await expect(callAction(fn)).resolves.toEqual({ success: true, data: 42 })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("laisse passer une erreur serveur inchangée, sans la retenter", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: "Examen introuvable." })
+    await expect(callAction(fn, { retries: 2 })).resolves.toEqual({
+      success: false,
+      error: "Examen introuvable.",
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("convertit un rejet réseau en ActionFailure", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await expect(callAction(fn)).resolves.toEqual({
+      success: false,
+      error: NETWORK_ERROR_MESSAGE,
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("sans opts, ne retente jamais", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await callAction(fn)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries: 1 → retente après 1 s et réussit", async () => {
+    vi.useFakeTimers()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({ success: true })
+    const p = callAction(fn, { retries: 1 })
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(p).resolves.toEqual({ success: true })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it("retries: 1 → deux échecs = ActionFailure", async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    const p = callAction(fn, { retries: 1 })
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(p).resolves.toEqual({
+      success: false,
+      error: NETWORK_ERROR_MESSAGE,
+    })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Contexte

Erreur prod du 2026-07-12 (Sentry NOMAQBANQ-1A) : un étudiant en pleine passation d'examen perd le réseau, le POST de Server Action rejette (« Failed to fetch »), et l'échec est invisible — unhandled rejection, aucune retentative, la réponse affichée n'est jamais persistée. Un audit exhaustif a relevé **~27 sites clients** partageant le même trou : `await serverAction()` nu, dont le garde `if (!res.success)` ne couvre pas le rejet du fetch lui-même.

## Ce que fait cette PR

**Helper commun `lib/safe-action.ts`** — `callAction(() => action(x))` ne throw jamais : tout rejet réseau devient `{ success: false, error }`, la forme que toutes les branches d'erreur existantes savent déjà gérer. Retry 1× (1 s) réservé à la liste fermée des upserts idempotents du quiz (`saveExamAnswer`, `saveTrainingAnswer`, `saveExamFlag`).

**Moteur quiz durci (`use-quiz-session`)** — les envois de réponses (et de flags) sont **sérialisés par question** : un seul envoi en vol, le clic le plus récent coalescé derrière, rollback vers la **dernière valeur confirmée serveur**. Ça ferme aussi une course pré-existante (un retry/envoi lent d'un clic périmé pouvait écraser un clic plus récent côté serveur, en silence). Tout throw de callback vaut `{ ok: false }` ; `pause`/`resume` remontent leur succès (décompte de pause vivant sur échec, auto-resume one-shot par clé).

**Application en 3 phases** — P1 étudiant (passation examen + entraînement + lectures), P2 facturation/compte (`createCustomerPortal` ne peut plus remonter à l'error boundary React 19 en plein flux de facturation ; écrans profil ; stats marketing), P3 admin (4 modales qui se verrouillaient définitivement sur coupure, 9 skeletons infinis, reloads de listes). Règle documentée dans `.claude/rules/data-layer.md`.

## Tests

- Unit `callAction` (6) + tests réseau du hook quiz (11, dont sérialisation, envoi supersédé qui réussit, composition des flags) — **910 tests verts**, coverage ~83 %
- **E2E `examen-blanc-offline.spec.ts`** : rejoue le scénario prod (coupure via `route.abort` sur les POST d'actions — `setOffline` pend en dev Turbopack, voir le spec) : toast + rollback + reprise après reconnexion
- Spec + plan committés (`docs/superpowers/`), passés en **revue adversariale de design** (11 constats intégrés, dont la course retry/clic périmé) puis **revue adversariale d'implémentation** (2 🟠 corrigés + durcissements)

## Après merge/déploiement

- Résoudre l'issue Sentry NOMAQBANQ-1A (elle ne recevra plus d'événements — c'est le but)
- Suivi possible (non bloquant) : état « erreur réseau + Réessayer » distinct d'« introuvable » sur 3 écrans admin