### PR TITLE
fix: UX deploy-skew + perf cron close-expired (suivi robustesse réseau)

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -75,7 +75,18 @@ storagePath,order}` pour rester assignable aux composants partagés
   NOMAQBANQ-1A, 2026-07-12). Mutations : `callAction(() => action(x))`
   (`lib/safe-action.ts`) — ne throw jamais, convertit le rejet en
   `{ success: false, error }` discriminable par les gardes existants ;
-  `{ retries: n }` RÉSERVÉ aux actions idempotentes (upserts quiz). Lectures :
+  `{ retries: n }` RÉSERVÉ aux actions idempotentes (upserts quiz).
+  **Deploy skew** : `callAction` détecte `UnrecognizedActionError` (bundle
+  périmé après déploiement) via `unstable_isUnrecognizedActionError`
+  (`next/navigation`), ne retente JAMAIS ce cas, renvoie `DEPLOY_SKEW_MESSAGE`
+  et affiche LUI-MÊME un toast central « Recharger » (id `deploy-skew`,
+  dédupliqué) — exception assumée à « les toasts vivent dans les pages » :
+  événement d'infrastructure, plusieurs pages toastent un message métier
+  hardcodé qui masquerait le remède. Piège tests : un
+  `vi.mock("next/navigation", …)` PARTIEL dans un test qui fait rejeter une
+  action via `callAction` doit fournir `unstable_isUnrecognizedActionError`
+  (ou utiliser `importOriginal`), sinon le rejet frappe le proxy Vitest avec
+  une erreur cryptique. Lectures :
   try/catch dans la transition, ou `.catch` sur toute chaîne `.then` d'effet
   (toujours sortir du skeleton). Le moteur quiz traite tout throw de callback
   comme `{ ok: false }` (rollback) et sérialise les envois de réponses par

--- a/app/api/cron/close-expired/route.ts
+++ b/app/api/cron/close-expired/route.ts
@@ -39,17 +39,15 @@ export async function GET(request: Request) {
   }
 
   try {
-    const [
-      examParticipations,
-      trainingSessions,
-      anonymizedAccounts,
-      quizRateLimitCleanup,
-    ] = await Promise.all([
-      closeExpiredExamParticipations(),
-      closeExpiredTrainingSessions(),
-      anonymizeExpiredDeletedAccounts(),
-      cleanupQuizRateLimits(),
-    ])
+    // Séquentiel volontairement (Sentry NOMAQBANQ-17) : en parallèle sur un
+    // pool froid, chaque tâche ouvre sa propre connexion Neon (3-4 handshakes
+    // de ~100 ms) — le détecteur N+1 flaggait cette rafale. En séquence, la
+    // première connexion est réutilisée ; un cron de fond n'a pas de latence
+    // à optimiser.
+    const examParticipations = await closeExpiredExamParticipations()
+    const trainingSessions = await closeExpiredTrainingSessions()
+    const anonymizedAccounts = await anonymizeExpiredDeletedAccounts()
+    const quizRateLimitCleanup = await cleanupQuizRateLimits()
 
     // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
     const notifications = await sendPendingNotifications()

--- a/app/api/cron/close-expired/route.ts
+++ b/app/api/cron/close-expired/route.ts
@@ -38,46 +38,83 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 })
   }
 
-  try {
-    // Séquentiel volontairement (Sentry NOMAQBANQ-17) : en parallèle sur un
-    // pool froid, chaque tâche ouvre sa propre connexion Neon (3-4 handshakes
-    // de ~100 ms) — le détecteur N+1 flaggait cette rafale. En séquence, la
-    // première connexion est réutilisée ; un cron de fond n'a pas de latence
-    // à optimiser.
-    const examParticipations = await closeExpiredExamParticipations()
-    const trainingSessions = await closeExpiredTrainingSessions()
-    const anonymizedAccounts = await anonymizeExpiredDeletedAccounts()
-    const quizRateLimitCleanup = await cleanupQuizRateLimits()
-
-    // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
-    const notifications = await sendPendingNotifications()
-
-    if (
-      examParticipations.closedCount > 0 ||
-      trainingSessions.closedCount > 0 ||
-      anonymizedAccounts.anonymizedCount > 0 ||
-      notifications.examResultsSent > 0 ||
-      notifications.accessRemindersSent > 0
-    ) {
-      console.log(
-        `[cron close-expired] examens fermés=${examParticipations.closedCount} ` +
-          `sessions fermées=${trainingSessions.closedCount} ` +
-          `comptes anonymisés=${anonymizedAccounts.anonymizedCount} ` +
-          `notif résultats=${notifications.examResultsSent} ` +
-          `notif accès=${notifications.accessRemindersSent}`,
-      )
+  // Séquentiel volontairement (Sentry NOMAQBANQ-17) : en parallèle sur un
+  // pool froid, chaque tâche ouvre sa propre connexion Neon (3-4 handshakes
+  // de ~100 ms) — le détecteur N+1 flaggait cette rafale. En séquence, la
+  // première connexion est réutilisée ; un cron de fond n'a pas de latence
+  // à optimiser.
+  //
+  // Chaque tâche est isolée : un échec persistant de l'une (ex. poison-row à
+  // la clôture examens) ne doit pas bloquer les suivantes — notamment
+  // l'anonymisation RGPD. (Sous l'ancien Promise.all, les tâches déjà
+  // lancées allaient au bout malgré un rejet ; la mise en séquence perdait
+  // cette propriété sans l'isolation.) Un échec quelconque → 500 après avoir
+  // tout tenté, pour conserver le retry du scheduler.
+  let failed = false
+  const run = async <T>(
+    label: string,
+    task: () => Promise<T>,
+    empty: T,
+  ): Promise<T> => {
+    try {
+      return await task()
+    } catch (error) {
+      failed = true
+      console.error(`[cron close-expired] ${label} en échec`, error)
+      return empty
     }
-
-    return Response.json({
-      examParticipations,
-      trainingSessions,
-      anonymizedAccounts,
-      notifications,
-      quizRateLimitCleanup,
-    })
-  } catch (error) {
-    // Erreur inattendue (DB…) → 500 ; Vercel logue + réessaie à la prochaine heure.
-    console.error("[cron close-expired] échec", error)
-    return new Response("Cron handler error", { status: 500 })
   }
+
+  const examParticipations = await run(
+    "clôture examens",
+    closeExpiredExamParticipations,
+    { closedCount: 0 },
+  )
+  const trainingSessions = await run(
+    "clôture entraînements",
+    closeExpiredTrainingSessions,
+    { closedCount: 0 },
+  )
+  const anonymizedAccounts = await run(
+    "anonymisation",
+    anonymizeExpiredDeletedAccounts,
+    { anonymizedCount: 0 },
+  )
+  const quizRateLimitCleanup = await run(
+    "purge rate-limit quiz",
+    cleanupQuizRateLimits,
+    { deletedCount: 0 },
+  )
+
+  // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
+  const notifications = await run("notifications", sendPendingNotifications, {
+    examResultsSent: 0,
+    accessRemindersSent: 0,
+  })
+
+  if (failed) return new Response("Cron handler error", { status: 500 })
+
+  if (
+    examParticipations.closedCount > 0 ||
+    trainingSessions.closedCount > 0 ||
+    anonymizedAccounts.anonymizedCount > 0 ||
+    notifications.examResultsSent > 0 ||
+    notifications.accessRemindersSent > 0
+  ) {
+    console.log(
+      `[cron close-expired] examens fermés=${examParticipations.closedCount} ` +
+        `sessions fermées=${trainingSessions.closedCount} ` +
+        `comptes anonymisés=${anonymizedAccounts.anonymizedCount} ` +
+        `notif résultats=${notifications.examResultsSent} ` +
+        `notif accès=${notifications.accessRemindersSent}`,
+    )
+  }
+
+  return Response.json({
+    examParticipations,
+    trainingSessions,
+    anonymizedAccounts,
+    notifications,
+    quizRateLimitCleanup,
+  })
 }

--- a/app/api/e2e/route.ts
+++ b/app/api/e2e/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/db/schema"
 import { env } from "@/lib/env/server"
 import { createId } from "@/lib/ids"
+import { computeScorePercent } from "@/lib/score"
 
 // Accès DB → runtime Node.
 export const runtime = "nodejs"
@@ -458,7 +459,7 @@ async function seedExam(opts: {
       return { questionId: q.id, selectedAnswer: wrong, isCorrect: false }
     })
     const correctCount = answers.filter((a) => a.isCorrect).length
-    score = Math.round((correctCount / count) * 100)
+    score = computeScorePercent(correctCount, count)
 
     participationId = createId()
     await db.insert(examParticipations).values({

--- a/docs/superpowers/plans/2026-07-12-skew-ux-cron-n-plus-1.md
+++ b/docs/superpowers/plans/2026-07-12-skew-ux-cron-n-plus-1.md
@@ -1,0 +1,877 @@
+# Suivi robustesse réseau (#98 deploy-skew + #99 N+1 cron) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (1) `callAction` détecte le deploy-skew (`UnrecognizedActionError`) et affiche un toast central « Recharger » sans retry ; (2) les crons de clôture passent en UPDATE ensembliste (arrondi half-up exact) et la route cron devient séquentielle ; (3) `finalizeExam` / `completeTrainingSession` s'alignent sur cet arrondi exact via `lib/score.ts`.
+
+**Architecture:** Partie #98 : tout vit dans `lib/safe-action.ts` (détection `unstable_isUnrecognizedActionError` de `next/navigation` + toast sonner dédupliqué), zéro churn aux 19 call sites. Partie #99 : `features/exams/cron.ts` et `features/training/cron.ts` remplacent leurs boucles d'UPDATE par un `update().set().from(subquery)` Drizzle unique (garde `status='in_progress'` re-vérifiée dans le WHERE final = même sémantique de concurrence) ; l'arrondi half-up exact du SQL devient la référence et les deux actions JS s'y alignent (`computeScorePercent`, arithmétique entière) ; `app/api/cron/close-expired/route.ts` séquentialise les tâches (une connexion froide au lieu de 3-4).
+
+**Tech Stack:** Next 16.2.10 (App Router), Drizzle 0.45 (node-postgres/Neon), sonner 2, Vitest (happy-dom pour `tests/`, node pour `tests/integration/`), Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-skew-ux-cron-n-plus-1-design.md` (révisée post-revue adversariale du 2026-07-12)
+
+**Préconditions:** branche fraîche depuis `main` à jour (ex. `fix/suivi-skew-cron`). Les docs spec/plan sont formatés Prettier et le rapport de revue supprimé (faits au triage — sinon `bun run check` échoue avant même tsc). Jamais de push sans accord. Messages de commit sans attribution Claude.
+
+---
+
+### Task 1: #98 — détection skew dans `callAction` (TDD)
+
+**Files:**
+
+- Modify: `lib/safe-action.ts`
+- Test: `tests/lib/safe-action.test.ts`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Dans `tests/lib/safe-action.test.ts`, ajouter les mocks EN TÊTE de fichier
+(avant les imports existants, hoistés par vitest) et le bloc de tests. Le
+prédicat Next est mocké (l'e2e de la Task 3 couvre le vrai) ; `sonner` est
+mocké pour asserter le toast :
+
+```ts
+import { toast } from "sonner"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  DEPLOY_SKEW_MESSAGE,
+  NETWORK_ERROR_MESSAGE,
+  callAction,
+} from "@/lib/safe-action"
+
+vi.mock("next/navigation", () => ({
+  unstable_isUnrecognizedActionError: (err: unknown) =>
+    err instanceof Error && err.name === "UnrecognizedActionError",
+}))
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }))
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+```
+
+(Le `describe("callAction")` existant est conservé tel quel — seul l'import et
+les mocks changent en tête.) Ajouter à la fin du fichier :
+
+```ts
+const skewError = () => {
+  const e = new Error('Server Action "40dfe0" was not found on the server.')
+  e.name = "UnrecognizedActionError"
+  return e
+}
+
+describe("callAction — deploy skew", () => {
+  it("convertit le skew en message dédié, sans jamais retenter", async () => {
+    const fn = vi.fn().mockRejectedValue(skewError())
+    await expect(callAction(fn, { retries: 2 })).resolves.toEqual({
+      success: false,
+      error: DEPLOY_SKEW_MESSAGE,
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("affiche le toast central dédupliqué avec l'action Recharger", async () => {
+    const fn = vi.fn().mockRejectedValue(skewError())
+    await callAction(fn)
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      DEPLOY_SKEW_MESSAGE,
+      expect.objectContaining({
+        id: "deploy-skew",
+        duration: Infinity,
+        action: expect.objectContaining({ label: "Recharger" }),
+      }),
+    )
+  })
+
+  it("un rejet réseau ordinaire ne déclenche pas le toast central", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await expect(callAction(fn)).resolves.toEqual({
+      success: false,
+      error: NETWORK_ERROR_MESSAGE,
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier l'échec**
+
+Run: `bun run test tests/lib/safe-action.test.ts`
+Expected: FAIL — `DEPLOY_SKEW_MESSAGE` n'est pas exporté (erreur d'import),
+les 6 tests existants passent encore une fois l'import corrigé.
+
+- [ ] **Step 3: Implémenter dans `lib/safe-action.ts`**
+
+Remplacer le contenu du fichier par (imports `next/navigation` et `sonner` =
+client-safe, l'invariant « aucun import serveur » tient) :
+
+```ts
+import { unstable_isUnrecognizedActionError } from "next/navigation"
+import { toast } from "sonner"
+
+// Client-safe : aucun import serveur. Convertit les rejets réseau d'un appel
+// de Server Action en échec structuré, discriminable par les gardes existants
+// (`!res.success` comme `"error" in res`).
+
+export type ActionFailure = { success: false; error: string }
+
+export const NETWORK_ERROR_MESSAGE =
+  "Connexion perdue. Vérifiez votre réseau et réessayez."
+
+export const DEPLOY_SKEW_MESSAGE =
+  "Une nouvelle version de l'application est disponible. Rechargez la page pour continuer."
+
+const RETRY_DELAY_MS = 1000
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// Deploy skew : le bundle périmé POSTe un ID d'action inconnu du nouveau
+// serveur — retenter est inutile par construction, seul un rechargement
+// répare. Toast émis ICI (exception à « les toasts vivent dans les pages ») :
+// plusieurs call sites toastent un message métier hardcodé qui masquerait le
+// remède. `id` fixe → dédupliqué, `duration: Infinity` → persiste jusqu'au
+// rechargement.
+const notifyDeploySkew = () => {
+  toast.error(DEPLOY_SKEW_MESSAGE, {
+    id: "deploy-skew",
+    duration: Infinity,
+    action: { label: "Recharger", onClick: () => window.location.reload() },
+  })
+}
+
+// `retries` est RÉSERVÉ aux actions idempotentes (upserts) : un « Failed to
+// fetch » peut survenir alors que la requête a atteint le serveur, le retry
+// ré-exécute donc l'action.
+export async function callAction<T>(
+  fn: () => Promise<T>,
+  opts?: { retries?: number },
+): Promise<T | ActionFailure> {
+  const retries = opts?.retries ?? 0
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (unstable_isUnrecognizedActionError(err)) {
+        notifyDeploySkew()
+        return { success: false, error: DEPLOY_SKEW_MESSAGE }
+      }
+      if (attempt < retries) {
+        await delay(RETRY_DELAY_MS)
+        continue
+      }
+      return { success: false, error: NETWORK_ERROR_MESSAGE }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Vérifier que tout passe**
+
+Run: `bun run test tests/lib/safe-action.test.ts`
+Expected: PASS — 9 tests (6 existants + 3 nouveaux).
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+bun run check
+git add lib/safe-action.ts tests/lib/safe-action.test.ts
+git commit -m "fix: message dedie + toast Recharger sur deploy-skew (UnrecognizedActionError, jamais de retry)"
+```
+
+---
+
+### Task 2: #98 — documenter la règle (et le piège des mocks partiels)
+
+**Files:**
+
+- Modify: `.claude/rules/data-layer.md` (section « Écrans », puce « Appels client de Server Actions »)
+
+- [ ] **Step 1: Compléter la puce `callAction`**
+
+Dans la puce « **Appels client de Server Actions — jamais d'`await` nu** »,
+après la phrase sur `{ retries: n }`, insérer :
+
+```markdown
+**Deploy skew** : `callAction` détecte `UnrecognizedActionError` (bundle
+périmé après déploiement) via `unstable_isUnrecognizedActionError`
+(`next/navigation`), ne retente JAMAIS ce cas, renvoie `DEPLOY_SKEW_MESSAGE`
+et affiche LUI-MÊME un toast central « Recharger » (id `deploy-skew`,
+dédupliqué) — exception assumée à « les toasts vivent dans les pages » :
+événement d'infrastructure, plusieurs pages toastent un message métier
+hardcodé qui masquerait le remède. Piège tests : un
+`vi.mock("next/navigation", …)` PARTIEL dans un test qui fait rejeter une
+action via `callAction` doit fournir `unstable_isUnrecognizedActionError`
+(ou utiliser `importOriginal`), sinon le rejet frappe le proxy Vitest avec
+une erreur cryptique.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/rules/data-layer.md
+git commit -m "docs: regle data-layer - gestion deploy-skew centralisee dans callAction"
+```
+
+---
+
+### Task 3: #98 — e2e du contrat Next réel
+
+**Files:**
+
+- Create: `e2e/tests/examen-blanc-deploy-skew.spec.ts`
+- Modify: `playwright.config.ts` (testMatch `chromium-auth`, après `/examen-blanc-offline\.spec\.ts/`)
+
+- [ ] **Step 1: Écrire le spec e2e**
+
+Modelé sur `examen-blanc-offline.spec.ts` (même seed, même interception),
+mais `route.fulfill` renvoie l'en-tête réel `x-nextjs-action-not-found: 1`
+(le client Next teste l'en-tête, pas le statut — vérifié dans
+`node_modules/next/dist/client/components/router-reducer/reducers/server-action-reducer.js`) :
+
+```ts
+import { type APIRequestContext, type Route } from "@playwright/test"
+import { expect, test } from "../fixtures/base"
+
+/**
+ * Rejoue le scénario Sentry NOMAQBANQ-1B : onglet d'examen ouvert pendant un
+ * déploiement → le POST d'action du bundle périmé reçoit
+ * `x-nextjs-action-not-found: 1` → le client Next lève
+ * `UnrecognizedActionError`. Attendu : toast central « Recharger » persistant,
+ * AUCUN retry (même avec `retries: 1` sur saveExamAnswer), rollback vers la
+ * réponse persistée, reprise normale une fois l'interception levée.
+ */
+
+const SECRET = process.env.E2E_RESET_SECRET
+const PREFIX = "[E2E] DeploySkew"
+
+const post = (request: APIRequestContext, data: object) =>
+  request.post("/api/e2e", {
+    data: { secret: SECRET, ...data },
+    failOnStatusCode: false,
+  })
+
+const isActionPost = (route: Route) =>
+  route.request().method() === "POST" &&
+  route.request().url().includes("/evaluation")
+
+let examId = ""
+
+test.describe("Examen Blanc — deploy skew pendant la passation", () => {
+  test.describe.configure({ mode: "serial", timeout: 90_000 })
+
+  test.beforeAll(async ({ request }) => {
+    if (!SECRET) return
+    const seed = await post(request, {
+      action: "seed-exam",
+      title: `${PREFIX} Passation`,
+      questionCount: 5,
+    })
+    examId = (await seed.json()).examId
+  })
+
+  test.afterAll(async ({ request }) => {
+    if (!SECRET) return
+    await post(request, { action: "cleanup", prefix: PREFIX })
+  })
+
+  test("skew : toast Recharger, un seul POST, rollback ; levée : la réponse persiste", async ({
+    examen,
+    page,
+    context,
+  }) => {
+    test.skip(!SECRET, "E2E_RESET_SECRET requis")
+    expect(examId).toBeTruthy()
+
+    await examen.goto()
+    await examen.clickStartExamById(examId)
+    const dialog = page.locator('[role="alertdialog"], [role="dialog"]')
+    await dialog.getByRole("button", { name: "Commencer l'examen" }).click()
+    await page.waitForURL(/\/evaluation/, { timeout: 15_000 })
+    await examen.acceptWarningOrResume()
+    await examen.waitForQuestion(1)
+
+    // Réponse en ligne persistée = valeur attendue du rollback.
+    const option0 = page.getByTestId("answer-option-0")
+    const option1 = page.getByTestId("answer-option-1")
+    await option0.scrollIntoViewIfNeeded()
+    const saved = page.waitForResponse(
+      (r) => r.request().method() === "POST" && r.url().includes("/evaluation"),
+      { timeout: 15_000 },
+    )
+    await option0.click()
+    await expect(option0).toHaveAttribute("data-selected", "true")
+    await saved
+
+    // « Déploiement » : le serveur ne reconnaît plus l'ID d'action.
+    let intercepted = 0
+    await context.route("**/*", (route) => {
+      if (!isActionPost(route)) return route.continue()
+      intercepted++
+      return route.fulfill({
+        status: 404,
+        headers: { "x-nextjs-action-not-found": "1" },
+        body: "",
+      })
+    })
+    await option1.scrollIntoViewIfNeeded()
+    await option1.click()
+
+    // Toast central persistant, avec le remède.
+    const skewToast = page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: "Une nouvelle version de l'application" })
+    await expect(skewToast).toBeVisible({ timeout: 10_000 })
+    await expect(
+      skewToast.getByRole("button", { name: "Recharger" }),
+    ).toBeVisible()
+
+    // Pas de retry : le retry réseau (1 s) de saveExamAnswer ne doit PAS
+    // s'appliquer au skew — on laisse passer la fenêtre avant de compter.
+    await page.waitForTimeout(1_500)
+    expect(intercepted).toBe(1)
+
+    // Rollback vers la réponse persistée.
+    await expect(option1).not.toHaveAttribute("data-selected", "true")
+    await expect(option0).toHaveAttribute("data-selected", "true")
+
+    // Interception levée → le re-clic persiste (parité bundle restaurée).
+    await context.unroute("**/*")
+    await option1.click()
+    await expect(option1).toHaveAttribute("data-selected", "true", {
+      timeout: 10_000,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Enregistrer le spec dans le projet `chromium-auth`**
+
+Dans `playwright.config.ts`, ajouter après la ligne
+`/examen-blanc-offline\.spec\.ts/,` :
+
+```ts
+        /examen-blanc-deploy-skew\.spec\.ts/,
+```
+
+- [ ] **Step 3: Lancer le spec ciblé**
+
+Run: `bun run test:e2e e2e/tests/examen-blanc-deploy-skew.spec.ts --reporter=list`
+Expected: 1 passed (Playwright démarre le dev server lui-même — ne pas lancer
+`bun dev`). Si l'auth flake : supprimer `e2e/.auth/` et relancer.
+
+- [ ] **Step 4: Gate + commit**
+
+Gate e2e = `type-check` + `lint` (règle `.claude/rules/e2e-testing.md` — PAS
+`bun run check` pour les tasks e2e) :
+
+```bash
+bun run type-check && bun run lint
+git add e2e/tests/examen-blanc-deploy-skew.spec.ts playwright.config.ts
+git commit -m "test: e2e deploy-skew - en-tete x-nextjs-action-not-found reel, toast Recharger, zero retry"
+```
+
+---
+
+### Task 4: #99 — helper `computeScorePercent` + alignement des actions JS (TDD)
+
+L'arrondi half-up **exact** (celui de `round()` SQL numeric, adopté par les
+crons en Tasks 5-6) devient la référence. `Math.round((c / t) * 100)` en
+float diverge sur les demi-points (23/40 → 57.4999… → 57 au lieu de 58) :
+sans cet alignement, un examen auto-soumis (cron) et le même examen soumis
+manuellement (`finalizeExam`) différeraient d'un point.
+
+**Files:**
+
+- Create: `lib/score.ts`
+- Create: `tests/lib/score.test.ts`
+- Modify: `features/exams/actions.ts:829-834` (finalizeExam)
+- Modify: `features/training/actions.ts:407-410` (completeTrainingSession)
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `tests/lib/score.test.ts` :
+
+```ts
+import { describe, expect, it } from "vitest"
+import { computeScorePercent } from "@/lib/score"
+
+describe("computeScorePercent", () => {
+  it("0 question → 0", () => {
+    expect(computeScorePercent(0, 0)).toBe(0)
+  })
+
+  it("cas nominaux", () => {
+    expect(computeScorePercent(2, 4)).toBe(50)
+    expect(computeScorePercent(1, 3)).toBe(33)
+    expect(computeScorePercent(23, 40)).toBe(58) // 57.5 exact — Math.round float donnait 57
+    expect(computeScorePercent(40, 40)).toBe(100)
+  })
+
+  it("half-up exact pour tout total ≤ 500 (parité avec round() SQL numeric)", () => {
+    for (let total = 1; total <= 500; total++) {
+      for (let correct = 0; correct <= total; correct++) {
+        const hundred = correct * 100
+        const remainder = hundred % total
+        const base = (hundred - remainder) / total
+        const expected = 2 * remainder >= total ? base + 1 : base
+        expect(computeScorePercent(correct, total)).toBe(expected)
+      }
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier l'échec**
+
+Run: `bun run test tests/lib/score.test.ts`
+Expected: FAIL — module `@/lib/score` introuvable.
+
+- [ ] **Step 3: Implémenter `lib/score.ts`**
+
+```ts
+// Arrondi half-up EXACT en arithmétique entière — parité stricte avec
+// `round(correct * 100.0 / total)` (numeric SQL) des crons de clôture.
+// `Math.round((correct / total) * 100)` en float diverge sur les demi-points
+// (ex. 23/40 → 57.4999… → 57 au lieu de 58).
+export const computeScorePercent = (correct: number, total: number): number =>
+  total > 0 ? Math.floor((200 * correct + total) / (2 * total)) : 0
+```
+
+- [ ] **Step 4: Vérifier que le test passe**
+
+Run: `bun run test tests/lib/score.test.ts`
+Expected: PASS (3 tests, dont le balayage exhaustif).
+
+- [ ] **Step 5: Brancher `finalizeExam`**
+
+Dans `features/exams/actions.ts`, ajouter l'import (groupe `@/`, ordre
+Prettier) :
+
+```ts
+import { computeScorePercent } from "@/lib/score"
+```
+
+puis remplacer :
+
+```ts
+const correctAnswers = agg?.correct ?? 0
+const totalQuestions = agg?.total ?? 0
+const score =
+  totalQuestions > 0 ? Math.round((correctAnswers / totalQuestions) * 100) : 0
+```
+
+par :
+
+```ts
+const correctAnswers = agg?.correct ?? 0
+const totalQuestions = agg?.total ?? 0
+const score = computeScorePercent(correctAnswers, totalQuestions)
+```
+
+- [ ] **Step 6: Brancher `completeTrainingSession`**
+
+Dans `features/training/actions.ts`, ajouter le même import, puis remplacer :
+
+```ts
+const correctCount = c?.correct ?? 0
+const totalQuestions = s.questionCount
+const score =
+  totalQuestions > 0 ? Math.round((correctCount / totalQuestions) * 100) : 0
+```
+
+par :
+
+```ts
+const correctCount = c?.correct ?? 0
+const totalQuestions = s.questionCount
+const score = computeScorePercent(correctCount, totalQuestions)
+```
+
+(Aucun autre site de score en JS : `analytics/dal.ts` arrondit des tendances
+d'affichage à 1 décimale — hors sujet, ne pas toucher.)
+
+- [ ] **Step 7: Gate + commit**
+
+```bash
+bun run check && bun run test
+git add lib/score.ts tests/lib/score.test.ts features/exams/actions.ts features/training/actions.ts
+git commit -m "fix: score en arithmetique entiere half-up exacte (parite avec l'arrondi SQL des crons)"
+```
+
+---
+
+### Task 5: #99 — `features/exams/cron.ts` en UPDATE ensembliste + cas sentinelle 23/40
+
+**Files:**
+
+- Modify: `features/exams/cron.ts` (réécriture complète)
+- Modify: `tests/integration/cron-close-expired.test.ts` (seed 40 questions / 23 correctes + assertions)
+
+- [ ] **Step 1: Ajouter le cas sentinelle au test d'intégration (red)**
+
+Dans `tests/integration/cron-close-expired.test.ts` :
+
+1. Après `const pDone = createId()`, ajouter :
+
+```ts
+const examHalf = createId()
+const pHalf = createId()
+const qIdsHalf = Array.from({ length: 40 }, () => createId())
+```
+
+2. Dans `beforeAll`, après l'insert des `questions` existant, ajouter :
+
+```ts
+await db.insert(questions).values(
+  qIdsHalf.map((id, i) => ({
+    id,
+    question: `QH ${i} ${suffix} ?`,
+    correctAnswer: "A",
+    options: ["A", "B", "C", "D"],
+    objectifCmc: `Obj ${suffix}`,
+    domain: `CRON-${suffix}`,
+  })),
+)
+```
+
+3. Étendre l'insert des examens et de leurs questions :
+
+```ts
+await db
+  .insert(exams)
+  .values([
+    mkExam(examPast, -DAY),
+    mkExam(examFuture, DAY),
+    mkExam(examHalf, -DAY),
+  ])
+```
+
+et après l'insert `examQuestions` existant :
+
+```ts
+await db.insert(examQuestions).values(
+  qIdsHalf.map((questionId, position) => ({
+    examId: examHalf,
+    questionId,
+    position,
+  })),
+)
+```
+
+4. Ajouter la participation au tableau `examParticipations` existant :
+
+```ts
+    {
+      id: pHalf,
+      examId: examHalf,
+      userId: U1,
+      status: "in_progress",
+      score: 0,
+      startedAt: new Date(now - 2 * DAY),
+    },
+```
+
+5. Après l'insert des `examAnswers` de `pPast`, ajouter :
+
+```ts
+// 40 questions, 23 bonnes réponses → 57.5 exact : sentinelle d'arrondi
+// half-up (le float JS donnait 57).
+await db.insert(examAnswers).values(
+  qIdsHalf.slice(0, 23).map((questionId) => ({
+    id: createId(),
+    participationId: pHalf,
+    questionId,
+    selectedAnswer: "A",
+    isCorrect: true,
+  })),
+)
+```
+
+6. Dans `afterAll`, élargir la purge des questions :
+
+```ts
+await db.delete(questions).where(inArray(questions.id, [...qIds, ...qIdsHalf]))
+```
+
+(`examHalf` est déjà couvert par `delete(exams).where(eq(exams.createdBy, U1))`.)
+
+7. Dans le premier test de `closeExpiredExamParticipations`, après les
+   assertions sur `pPast`, ajouter :
+
+```ts
+const half = await statusOf(pHalf)
+expect(half?.status).toBe("auto_submitted")
+expect(half?.score).toBe(58) // 23/40 = 57.5 exact → 58 (float JS : 57)
+```
+
+Note : contre l'implémentation actuelle (float JS), cette assertion vaut 57 —
+c'est le « red » de la réécriture. La vérification rouge/verte se fait en un
+seul run d'intégration en Task 8 (une branche Neon éphémère par run — pas de
+double exécution).
+
+- [ ] **Step 2: Réécrire le module**
+
+Remplacer le contenu de `features/exams/cron.ts` par :
+
+```ts
+import { and, eq, lt, sql } from "drizzle-orm"
+import "server-only"
+import { db } from "@/db"
+import {
+  examAnswers,
+  examParticipations,
+  examQuestions,
+  exams,
+} from "@/db/schema"
+
+export type CloseExpiredParticipationsResult = { closedCount: number }
+
+/**
+ * Ferme les participations `in_progress` dont l'examen est terminé (`endDate < now`),
+ * en calculant le score à partir des réponses enregistrées. Appelé par la route cron
+ * Vercel.
+ *
+ * - UNE requête ensembliste (UPDATE … FROM sous-requête bornée à 500) : pas de
+ *   N+1, une seule connexion du pool.
+ * - Garde `status='in_progress'` re-vérifiée dans le WHERE final : sous READ
+ *   COMMITTED la condition est réévaluée sur la version verrouillée de la ligne
+ *   → une soumission concurrente gagne, pas de clobber.
+ * - Arrondi `round()` numeric = half-up EXACT — la référence du projet ;
+ *   `finalizeExam` s'aligne via `computeScorePercent` (lib/score.ts).
+ * - Statut de fermeture = `auto_submitted` (parité Convex).
+ */
+export async function closeExpiredExamParticipations(): Promise<CloseExpiredParticipationsResult> {
+  const now = new Date()
+
+  const scored = db
+    .select({
+      id: examParticipations.id,
+      correct:
+        sql<number>`(select count(*) filter (where ${examAnswers.isCorrect})
+        from ${examAnswers}
+        where ${examAnswers.participationId} = ${examParticipations.id})`.as(
+          "correct",
+        ),
+      total: sql<number>`(select count(*)
+        from ${examQuestions}
+        where ${examQuestions.examId} = ${examParticipations.examId})`.as(
+        "total",
+      ),
+    })
+    .from(examParticipations)
+    .innerJoin(exams, eq(exams.id, examParticipations.examId))
+    .where(
+      and(eq(examParticipations.status, "in_progress"), lt(exams.endDate, now)),
+    )
+    .limit(500)
+    .as("scored")
+
+  const closed = await db
+    .update(examParticipations)
+    .set({
+      status: "auto_submitted",
+      score: sql`case when ${scored.total} > 0
+        then round(${scored.correct} * 100.0 / ${scored.total})::int
+        else 0 end`,
+      completedAt: now,
+    })
+    .from(scored)
+    .where(
+      and(
+        eq(examParticipations.id, scored.id),
+        eq(examParticipations.status, "in_progress"),
+      ),
+    )
+    .returning({ id: examParticipations.id })
+
+  return { closedCount: closed.length }
+}
+```
+
+(`processedCount` supprimé — consommé nulle part, vérifié route + tests.)
+
+- [ ] **Step 3: Gate types/lint**
+
+Run: `bun run check`
+Expected: PASS (aucun consommateur de `processedCount`).
+
+- [ ] **Step 4: (pas de commit — commit groupé #99 en Task 8 après l'intégration)**
+
+---
+
+### Task 6: #99 — `features/training/cron.ts` en UPDATE ensembliste
+
+**Files:**
+
+- Modify: `features/training/cron.ts` (réécriture complète)
+
+- [ ] **Step 1: Réécrire le module**
+
+```ts
+import { and, eq, lt, sql } from "drizzle-orm"
+import "server-only"
+import { db } from "@/db"
+import { trainingSessionItems, trainingSessions } from "@/db/schema"
+
+export type CloseExpiredTrainingResult = { closedCount: number }
+
+/**
+ * Ferme les sessions d'entraînement `in_progress` expirées (`expiresAt < now`,
+ * TTL 24h), score = % d'items corrects sur `questionCount`. Appelé par la route
+ * cron Vercel.
+ *
+ * - UNE requête ensembliste (UPDATE … FROM sous-requête bornée à 100), garde
+ *   `status='in_progress'` re-vérifiée dans le WHERE final (idem cron examens) :
+ *   pas de clobber d'une complétion concurrente.
+ * - Arrondi `round()` numeric = half-up EXACT (référence projet, cf. lib/score.ts).
+ * - Statut de fermeture = `abandoned` (parité Convex).
+ */
+export async function closeExpiredTrainingSessions(): Promise<CloseExpiredTrainingResult> {
+  const now = new Date()
+
+  const scored = db
+    .select({
+      id: trainingSessions.id,
+      questionCount: trainingSessions.questionCount,
+      correct:
+        sql<number>`(select count(*) filter (where ${trainingSessionItems.isCorrect})
+        from ${trainingSessionItems}
+        where ${trainingSessionItems.sessionId} = ${trainingSessions.id})`.as(
+          "correct",
+        ),
+    })
+    .from(trainingSessions)
+    .where(
+      and(
+        eq(trainingSessions.status, "in_progress"),
+        lt(trainingSessions.expiresAt, now),
+      ),
+    )
+    .limit(100)
+    .as("scored")
+
+  const closed = await db
+    .update(trainingSessions)
+    .set({
+      status: "abandoned",
+      score: sql`case when ${scored.questionCount} > 0
+        then round(${scored.correct} * 100.0 / ${scored.questionCount})::int
+        else 0 end`,
+      completedAt: now,
+    })
+    .from(scored)
+    .where(
+      and(
+        eq(trainingSessions.id, scored.id),
+        eq(trainingSessions.status, "in_progress"),
+      ),
+    )
+    .returning({ id: trainingSessions.id })
+
+  return { closedCount: closed.length }
+}
+```
+
+- [ ] **Step 2: Gate types/lint**
+
+Run: `bun run check`
+Expected: PASS.
+
+---
+
+### Task 7: #99 — route cron séquentielle
+
+**Files:**
+
+- Modify: `app/api/cron/close-expired/route.ts:41-52`
+
+- [ ] **Step 1: Remplacer le `Promise.all` par une séquence**
+
+Remplacer :
+
+```ts
+const [
+  examParticipations,
+  trainingSessions,
+  anonymizedAccounts,
+  quizRateLimitCleanup,
+] = await Promise.all([
+  closeExpiredExamParticipations(),
+  closeExpiredTrainingSessions(),
+  anonymizeExpiredDeletedAccounts(),
+  cleanupQuizRateLimits(),
+])
+```
+
+par :
+
+```ts
+// Séquentiel volontairement (Sentry NOMAQBANQ-17) : en parallèle sur un
+// pool froid, chaque tâche ouvre sa propre connexion Neon (3-4 handshakes
+// de ~100 ms) — le détecteur N+1 flaggait cette rafale. En séquence, la
+// première connexion est réutilisée ; un cron de fond n'a pas de latence
+// à optimiser.
+const examParticipations = await closeExpiredExamParticipations()
+const trainingSessions = await closeExpiredTrainingSessions()
+const anonymizedAccounts = await anonymizeExpiredDeletedAccounts()
+const quizRateLimitCleanup = await cleanupQuizRateLimits()
+```
+
+Le reste du handler (dont `sendPendingNotifications()` APRÈS les clôtures, et
+la forme de la réponse JSON) est inchangé.
+
+- [ ] **Step 2: Gate types/lint**
+
+Run: `bun run check`
+Expected: PASS.
+
+---
+
+### Task 8: #99 — vérification intégration + commit groupé
+
+**Files:** aucun nouveau — exécution des tests.
+
+- [ ] **Step 1: Suite d'intégration (branche Neon éphémère)**
+
+Run: `bun run test:integration`
+Expected: PASS, en particulier `cron-close-expired.test.ts` — assertions
+existantes inchangées (2/4 = 50, `auto_submitted`/`abandoned`, idempotence,
+« laisse les autres ») + le cas sentinelle `pHalf` → score 58 ;
+`notifications-cron.test.ts` (garde anti-double-envoi intacte — chemins non
+touchés) ; `exam-runner.test.ts`/`training.test.ts` (scores nominaux
+inchangés par l'alignement d'arrondi — divergence uniquement sur les
+demi-points float, absents des fixtures).
+
+- [ ] **Step 2: Commit groupé #99**
+
+```bash
+git add features/exams/cron.ts features/training/cron.ts "app/api/cron/close-expired/route.ts" tests/integration/cron-close-expired.test.ts
+git commit -m "perf: cron close-expired - clotures en UPDATE ensembliste et taches sequentielles (N+1 pg-pool.connect)"
+```
+
+---
+
+### Task 9: gates finaux
+
+- [ ] **Step 1: Suites complètes**
+
+```bash
+bun run check
+bun run test
+```
+
+Expected: PASS (le seuil de coverage CI reste au-dessus de 80 % —
+`lib/score.ts` est couvert à 100 % par son test unit).
+
+- [ ] **Step 2: E2E ciblés (les deux specs réseau)**
+
+Run: `bun run test:e2e e2e/tests/examen-blanc-offline.spec.ts e2e/tests/examen-blanc-deploy-skew.spec.ts --reporter=list`
+Expected: 2 passed — l'offline prouve que le chemin réseau ordinaire (retry +
+toast métier) n'a pas régressé avec la détection skew en amont.
+
+- [ ] **Step 3: Fin de branche**
+
+Proposer à l'utilisateur : revue d'implémentation adversariale
+(`/adversarial-review-prompt`, session séparée), puis push + PR vers `main`
+(#98 + #99 en `Closes`). Après déploiement : résoudre NOMAQBANQ-1B et
+NOMAQBANQ-17 dans Sentry et surveiller la récidive.

--- a/docs/superpowers/plans/2026-07-12-skew-ux-cron-n-plus-1.md
+++ b/docs/superpowers/plans/2026-07-12-skew-ux-cron-n-plus-1.md
@@ -729,24 +729,32 @@ export type CloseExpiredTrainingResult = { closedCount: number }
 export async function closeExpiredTrainingSessions(): Promise<CloseExpiredTrainingResult> {
   const now = new Date()
 
+  // LEFT JOIN + GROUP BY plutôt qu'une sous-requête corrélée : dans une
+  // sous-requête `.as()` MONO-table, Drizzle rend les colonnes SANS
+  // qualification — la corrélation (`"session_id" = "id"`) se lierait alors à
+  // la table interne (count toujours 0). Un JOIN force la qualification
+  // complète (cf. cron examens) et supprime la corrélation.
   const scored = db
     .select({
       id: trainingSessions.id,
       questionCount: trainingSessions.questionCount,
       correct:
-        sql<number>`(select count(*) filter (where ${trainingSessionItems.isCorrect})
-        from ${trainingSessionItems}
-        where ${trainingSessionItems.sessionId} = ${trainingSessions.id})`.as(
+        sql<number>`count(*) filter (where ${trainingSessionItems.isCorrect})`.as(
           "correct",
         ),
     })
     .from(trainingSessions)
+    .leftJoin(
+      trainingSessionItems,
+      eq(trainingSessionItems.sessionId, trainingSessions.id),
+    )
     .where(
       and(
         eq(trainingSessions.status, "in_progress"),
         lt(trainingSessions.expiresAt, now),
       ),
     )
+    .groupBy(trainingSessions.id)
     .limit(100)
     .as("scored")
 
@@ -771,6 +779,13 @@ export async function closeExpiredTrainingSessions(): Promise<CloseExpiredTraini
   return { closedCount: closed.length }
 }
 ```
+
+Gotcha découvert à l'implémentation (intégration rouge : score 0 au lieu de 50) : la première version utilisait une sous-requête corrélée comme le cron
+examens — mais dans une sous-requête `.as()` **mono-table**, Drizzle rend
+toutes les colonnes sans qualification, et la corrélation se lie à la table
+interne. Le cron examens, lui, contient un `innerJoin` dans sa sous-requête →
+Drizzle qualifie tout → la forme corrélée y est correcte (épinglée par la
+sentinelle 23/40 → 58). Vérifié via `.toSQL()`.
 
 - [ ] **Step 2: Gate types/lint**
 

--- a/docs/superpowers/specs/2026-07-12-skew-ux-cron-n-plus-1-design.md
+++ b/docs/superpowers/specs/2026-07-12-skew-ux-cron-n-plus-1-design.md
@@ -1,0 +1,281 @@
+# Spec — Suivi robustesse réseau : UX deploy-skew (#98) + N+1 cron close-expired (#99)
+
+**Date** : 2026-07-12
+**Statut** : validé (brainstorming) ; revue adversariale de design du
+2026-07-12 triée — verdict initial NON, 1 défaut de fond intégré (la parité
+d'arrondi `Math.round` ↔ `round()` SQL était fausse : le half-up **exact**
+devient la référence, les actions JS s'alignent via `lib/score.ts`) + 3
+correctifs de forme (gates e2e `type-check`+`lint`, note sur les mocks
+partiels de `next/navigation`, 19 call sites et non ~27)
+**Origine** : issues de suivi de la campagne « robustesse réseau des Server
+Actions » (PR #97, spec `2026-07-12-robustesse-reseau-server-actions-design.md`)
+— GitHub #98 (Sentry NOMAQBANQ-1B) et #99 (Sentry NOMAQBANQ-17)
+
+Deux chantiers indépendants, un seul document (deux parties), une seule branche
+d'implémentation depuis `main` à jour.
+
+---
+
+## Partie 1 — #98 : UX dédiée au deploy-skew (`UnrecognizedActionError`)
+
+### Contexte
+
+Le soir du déploiement de #97 : 239 événements Sentry (NOMAQBANQ-1B) sur
+3 étudiants, onglet d'examen ouvert pendant le déploiement. Leur bundle périmé
+POSTait des IDs de Server Action inconnus du nouveau serveur → Next répond avec
+l'en-tête `x-nextjs-action-not-found: 1` et le client lève
+`UnrecognizedActionError: Server Action "…" was not found on the server.`
+(`fetchServerAction`, vérifié dans l'événement Sentry réel et les sources
+`node_modules/next/dist/client/components/router-reducer/reducers/server-action-reducer.js`).
+
+Ces 239 événements étaient des **unhandled rejections** : les onglets périmés
+tournaient le bundle _pré-#97_, sans `callAction`. Au prochain déploiement, les
+bundles actuels attraperont l'erreur mais afficheront le message réseau
+générique (« Connexion perdue… ») en retentant inutilement — trompeur : seul un
+rechargement de page répare (les nouveaux IDs d'action arrivent avec le nouveau
+bundle). Le rechargement est sûr même en passation : l'état vit côté serveur,
+la reprise est automatique.
+
+**Constat d'audit décisif** : sur le hot path exact du bug
+(`evaluation-client.tsx`), `onAnswer` toaste un message **hardcodé**
+(« Réponse non enregistrée, réessayez. ») sans afficher `res.error`, et
+`onFlag` est silencieux. Un message dédié renvoyé par le seul canal
+`{ success: false, error }` n'atteindrait donc jamais l'étudiant dans le
+scénario principal. → Le remède doit être **central**.
+
+### Décision (option validée : toast central + bouton « Recharger »)
+
+Tout vit dans `lib/safe-action.ts` — zéro churn aux 19 call sites :
+
+1. **Détection** : `unstable_isUnrecognizedActionError(err)` importé de
+   `next/navigation` (API officielle Next 16, test `instanceof` contre la
+   classe de Next — insensible à la minification ; export vérifié dans la
+   version installée). Pas de matching de message.
+2. **Placement** : dans le `catch` de `callAction`, **avant** la logique retry
+   → retour immédiat, jamais de retentative même avec `retries` (inutile par
+   construction).
+3. **Message** (exporté pour tests et call sites éventuels) :
+
+   ```ts
+   export const DEPLOY_SKEW_MESSAGE =
+     "Une nouvelle version de l'application est disponible. Rechargez la page pour continuer."
+   ```
+
+4. **Toast central** : au moment de la détection, `callAction` déclenche
+   lui-même :
+
+   ```ts
+   toast.error(DEPLOY_SKEW_MESSAGE, {
+     id: "deploy-skew", // dédupliqué : une rafale d'échecs quiz ne stacke pas
+     duration: Infinity, // le rechargement est le seul remède
+     action: { label: "Recharger", onClick: () => window.location.reload() },
+   })
+   ```
+
+   puis renvoie `{ success: false, error: DEPLOY_SKEW_MESSAGE }`. Le `Toaster`
+   sonner est déjà monté au layout racine. `sonner` est client-safe, comme
+   `next/navigation` — le module reste sans import serveur.
+
+5. **Règle documentée** : exception explicite à « les toasts vivent dans les
+   pages » (`.claude/rules/data-layer.md`, section Écrans) — le deploy-skew est
+   un événement d'infrastructure app-level, pas une erreur métier ; le toast
+   métier de la page peut s'afficher en plus (bruit accepté : le toast central
+   porte le remède et persiste). Y documenter aussi le piège tests (revue
+   design) : un `vi.mock("next/navigation", …)` **partiel** dans un test qui
+   fait rejeter une action via `callAction` doit fournir
+   `unstable_isUnrecognizedActionError` (ou passer par `importOriginal`) — 9
+   fichiers de tests mockent déjà ce module partiellement sans casser
+   aujourd'hui, mais le premier futur test de rejet frapperait le proxy Vitest
+   avec une erreur cryptique.
+
+### Écarté
+
+- **Message dédié seul** (canal de retour) : n'atteint pas l'utilisateur sur le
+  hot path (cf. constat d'audit) sans retoucher les sites un à un.
+- **Reload auto hors passation** : détection de contexte fragile, risque de
+  boucle de rechargement. YAGNI.
+
+### Tests
+
+- **Unit `tests/lib/safe-action.test.ts`** (compléments) : `vi.mock`
+  de `next/navigation` (prédicat contrôlé) et de `sonner`.
+  - rejet skew → `{ success: false, error: DEPLOY_SKEW_MESSAGE }` ;
+  - `fn` appelé **une seule fois** malgré `retries: 2` ;
+  - `toast.error` appelé avec `id: "deploy-skew"` et une action « Recharger » ;
+  - rejet réseau ordinaire → comportement actuel inchangé
+    (`NETWORK_ERROR_MESSAGE`, retries honorés, pas de toast central).
+- **E2E `e2e/tests/examen-blanc-deploy-skew.spec.ts`** (projet
+  `chromium-auth`, à ajouter au `testMatch` ; seed via `seed-exam`, préfixe
+  dédié, cleanup en `afterAll`) : seul test qui exerce le **contrat Next
+  réel** (l'unit mocke le prédicat). Passation → interception des POST
+  d'action (`context.route` sur les POST `/evaluation`, comme
+  `examen-blanc-offline.spec.ts`) mais en **`route.fulfill({ status: 404,
+headers: { "x-nextjs-action-not-found": "1" } })`** (le client Next teste
+  l'en-tête, pas le statut) → clic réponse → assertions :
+  - toast « Une nouvelle version… » visible avec bouton « Recharger » ;
+  - **un seul POST intercepté** (compteur dans le handler — prouve l'absence de
+    retry malgré `retries: 1` sur `saveExamAnswer`) ;
+  - rollback : l'option cliquée n'est pas `data-selected` (la réponse
+    précédemment persistée l'est) ;
+  - `unroute` → re-clic → persistance normale.
+
+### Risques / limites
+
+- `unstable_` : l'API peut être renommée à un upgrade Next — cassure **à la
+  compilation** (import introuvable), jamais silencieuse. L'e2e couvre en plus
+  le contrat en-tête→erreur→prédicat de bout en bout.
+- Double toast possible (métier + central) sur certains écrans : assumé.
+- Cliquer « Recharger » en passation recharge vers la reprise automatique
+  (état serveur) — comportement déjà couvert par le flux `resuming` existant.
+
+---
+
+## Partie 2 — #99 : N+1 (`pg-pool.connect`) dans le cron close-expired
+
+### Contexte et constat d'audit
+
+Sentry NOMAQBANQ-17 (« N+1 Query », `pg-pool.connect`, culprit
+`GET /api/cron/close-expired`, 15 occurrences du 7 au 12 juillet). **Les
+15 traces sont des runs à zéro ligne traitée** : le span répété est
+`pg-pool.connect`, car le `Promise.all` de 4 tâches sur un pool froid (instance
+Fluid réveillée par le cron horaire GitHub) ouvre 3-4 connexions Neon en
+parallèle à ~60-134 ms de handshake chacune, plus 2 connects chauds
+séquentiels (requêtes notifications). C'est cette rafale que le détecteur
+flag — pas une boucle de données.
+
+Le code contient néanmoins de vrais N+1 **latents** dès qu'il y a des lignes :
+
+| Chemin                                   | Boucle                                                              | Verdict                                                                                                                                                                                                                                                             |
+| ---------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `features/exams/cron.ts`                 | jusqu'à 500 UPDATE unitaires (1/participation) dans une transaction | **à corriger** (règle projet « pas de N+1 »)                                                                                                                                                                                                                        |
+| `features/training/cron.ts`              | idem, jusqu'à 100                                                   | **à corriger**                                                                                                                                                                                                                                                      |
+| `features/notifications/cron.ts`         | 1 UPDATE de claim par ligne avant chaque email                      | **conservé** — claim atomique par ligne = garde anti-double-envoi (deux schedulers se recouvrent à minuit UTC) + fenêtre de crash minimale entre claim et envoi ; un claim ensembliste ouvrirait une fenêtre « 500 claims posés, emails jamais partis » sur timeout |
+| `features/users/cron.ts` (anonymisation) | 1 transaction par ligne                                             | **conservé** — isolation poison-row délibérée, volume ~0                                                                                                                                                                                                            |
+
+### Décision (option validée : ensembliste + séquentialisation)
+
+1. **`features/exams/cron.ts`** : remplacer SELECT + 2 agrégats + boucle
+   d'UPDATE par **un seul UPDATE ensembliste** (une requête, une connexion) :
+
+   ```sql
+   WITH expired AS (
+     SELECT p.id, p.exam_id
+     FROM exam_participations p
+     JOIN exams e ON e.id = p.exam_id
+     WHERE p.status = 'in_progress' AND e.end_date < $now
+     LIMIT 500
+   ), scored AS (
+     SELECT expired.id,
+       (SELECT count(*) FILTER (WHERE a.is_correct)
+          FROM exam_answers a WHERE a.participation_id = expired.id) AS correct,
+       (SELECT count(*) FROM exam_questions q
+          WHERE q.exam_id = expired.exam_id) AS total
+     FROM expired
+   )
+   UPDATE exam_participations p
+   SET status = 'auto_submitted',
+       score = CASE WHEN s.total > 0
+                    THEN round(s.correct * 100.0 / s.total) ELSE 0 END,
+       completed_at = $now
+   FROM scored s
+   WHERE p.id = s.id AND p.status = 'in_progress'
+   RETURNING p.id
+   ```
+
+   - Borne 500 conservée (CTE `LIMIT`). Arrondi : voir la sous-section
+     dédiée ci-dessous (le half-up exact SQL devient la référence).
+   - **Concurrence** : garde `p.status = 'in_progress'` re-vérifiée dans le
+     WHERE final — sous READ COMMITTED, la condition est réévaluée sur la
+     version verrouillée de la ligne (EvalPlanQual) → une soumission
+     concurrente gagne, pas de clobber. Sémantique identique à l'UPDATE gardé
+     ligne à ligne actuel.
+   - Retour simplifié `{ closedCount }` (= lignes RETURNING) ;
+     `processedCount` supprimé — consommé nulle part (vérifié : route et tests
+     ne lisent que `closedCount`).
+
+2. **`features/training/cron.ts`** : même transformation (LIMIT 100,
+   `total = question_count` de la ligne, statut de fermeture `abandoned`).
+3. **`app/api/cron/close-expired/route.ts`** : `Promise.all` → exécution
+   **séquentielle** des 4 tâches (cron de fond, latence indifférente) → une
+   seule connexion froide réutilisée au lieu de 3-4 handshakes parallèles — la
+   cause mesurée dans les traces. `sendPendingNotifications` reste après les
+   clôtures (inclut les `auto_submitted` du même run). Forme de la réponse
+   JSON inchangée (moins `processedCount`).
+4. **Notifications et anonymisation inchangées** (raisons au tableau
+   ci-dessus — le passage en ensembliste ne doit pas casser la garde
+   anti-double-envoi, hot-spot connu de la campagne notifications).
+
+Mécanisme Drizzle (query builder `with/update...from` vs `sql` brut typé) :
+choisi au plan — la sémantique SQL ci-dessus fait foi.
+
+### Arrondi des scores : le half-up exact devient la référence (revue design)
+
+La parité initialement affirmée entre `Math.round((correct / total) * 100)`
+(float JS, comportement actuel des crons ET de `finalizeExam` /
+`completeTrainingSession`) et `round(correct * 100.0 / total)` (numeric SQL,
+exact) est **fausse** : 18 contre-exemples pour `total ≤ 500` (revue design).
+Ex. 23/40 : le float donne 57.4999… → 57, le SQL 57.5 exact → 58. Sans
+alignement, un examen auto-soumis (cron SQL) et le même examen soumis
+manuellement (`finalizeExam` JS) divergeraient d'un point — hors du périmètre
+« mêmes scores », et invisible au test 2/4 = 50 (exact en float).
+
+Décision : **l'arrondi half-up exact est la référence.**
+
+- Crons : `round(x)::int` SQL, naturellement exact — rien à ajouter.
+- Actions JS : nouveau helper partagé `lib/score.ts` :
+
+  ```ts
+  export const computeScorePercent = (
+    correct: number,
+    total: number,
+  ): number =>
+    total > 0 ? Math.floor((200 * correct + total) / (2 * total)) : 0
+  ```
+
+  (équivalent entier de `floor(v + 1/2)`, aucun float intermédiaire non
+  exact), branché dans `finalizeExam` (`features/exams/actions.ts:831-834`) et
+  `completeTrainingSession` (`features/training/actions.ts:409-410`). Aucun
+  autre site de calcul de score en JS (vérifié — `analytics/dal.ts` arrondit
+  des tendances d'affichage à 1 décimale, hors sujet).
+
+### Tests
+
+- **Unit `tests/lib/score.test.ts`** : cas nominaux (0 total → 0, 2/4 → 50,
+  1/3 → 33, 23/40 → 58, 40/40 → 100) + balayage exhaustif `total ≤ 500`
+  contre l'arrondi half-up exact calculé en entiers (reste vs
+  demi-dénominateur) — c'est la preuve de parité avec `round()` SQL.
+- **`tests/integration/cron-close-expired.test.ts`** : les assertions
+  existantes (2/4 = 50, idempotence, « laisse les autres ») passent telles
+  quelles ; **ajout d'un cas sentinelle** 23/40 → 58 (examen expiré à
+  40 questions, 23 réponses correctes) qui échoue contre l'implémentation
+  float actuelle — c'est le « red » du TDD de la réécriture.
+- `notifications-cron.test.ts` (garde anti-double-envoi) : chemins non
+  touchés, doit rester vert.
+
+### Suivi post-déploiement
+
+Résoudre NOMAQBANQ-17 et NOMAQBANQ-1B dans Sentry après le déploiement ;
+surveiller la récidive (le détecteur ne devrait plus se déclencher sans rafale
+de connects froids ; NOMAQBANQ-1B ne reviendra qu'au déploiement suivant si le
+fix est inopérant).
+
+---
+
+## Critères d'acceptation
+
+1. **#98** : un rejet skew simulé (unit) renvoie `DEPLOY_SKEW_MESSAGE`, sans
+   retry, avec toast central dédupliqué ; l'e2e valide la chaîne réelle
+   en-tête Next → toast « Recharger » → un seul POST → rollback → reprise
+   après `unroute`.
+2. **#99** : plus aucune boucle d'UPDATE par ligne dans `features/exams/cron.ts`
+   et `features/training/cron.ts` (une requête ensembliste chacun) ; la route
+   exécute les tâches séquentiellement ; les assertions d'intégration
+   existantes passent telles quelles et le cas sentinelle 23/40 → 58 passe.
+3. **Parité d'arrondi** : `finalizeExam` et `completeTrainingSession`
+   produisent le même score que les crons pour toute paire
+   `(correct, total)` — garanti par le helper entier partagé + le balayage
+   exhaustif unit.
+4. Gates : `bun run check`, `bun run test`, `bun run test:integration` ; pour
+   la task e2e, `bun run type-check` + `bun run lint` (règle
+   `.claude/rules/e2e-testing.md`) + e2e ciblé
+   (`bun run test:e2e e2e/tests/examen-blanc-deploy-skew.spec.ts`).

--- a/docs/superpowers/specs/2026-07-12-skew-ux-cron-n-plus-1-design.md
+++ b/docs/superpowers/specs/2026-07-12-skew-ux-cron-n-plus-1-design.md
@@ -200,7 +200,12 @@ Le code contient néanmoins de vrais N+1 **latents** dès qu'il y a des lignes :
    seule connexion froide réutilisée au lieu de 3-4 handshakes parallèles — la
    cause mesurée dans les traces. `sendPendingNotifications` reste après les
    clôtures (inclut les `auto_submitted` du même run). Forme de la réponse
-   JSON inchangée (moins `processedCount`).
+   JSON inchangée (moins `processedCount`). **Isolation par tâche** (revue
+   d'implémentation) : chaque tâche est enveloppée d'un try/catch — un échec
+   persistant de l'une (poison-row) ne bloque pas les suivantes (notamment
+   l'anonymisation RGPD, propriété que le `Promise.all` avait de fait) ; un
+   échec quelconque → 500 après avoir tout tenté (retry du scheduler
+   conservé).
 4. **Notifications et anonymisation inchangées** (raisons au tableau
    ci-dessus — le passage en ensembliste ne doit pas casser la garde
    anti-double-envoi, hot-spot connu de la campagne notifications).

--- a/e2e/tests/examen-blanc-deploy-skew.spec.ts
+++ b/e2e/tests/examen-blanc-deploy-skew.spec.ts
@@ -1,0 +1,113 @@
+import { type APIRequestContext, type Route } from "@playwright/test"
+import { expect, test } from "../fixtures/base"
+
+/**
+ * Rejoue le scénario Sentry NOMAQBANQ-1B : onglet d'examen ouvert pendant un
+ * déploiement → le POST d'action du bundle périmé reçoit
+ * `x-nextjs-action-not-found: 1` → le client Next lève
+ * `UnrecognizedActionError`. Attendu : toast central « Recharger » persistant,
+ * AUCUN retry (même avec `retries: 1` sur saveExamAnswer), rollback vers la
+ * réponse persistée, reprise normale une fois l'interception levée.
+ */
+
+const SECRET = process.env.E2E_RESET_SECRET
+const PREFIX = "[E2E] DeploySkew"
+
+const post = (request: APIRequestContext, data: object) =>
+  request.post("/api/e2e", {
+    data: { secret: SECRET, ...data },
+    failOnStatusCode: false,
+  })
+
+const isActionPost = (route: Route) =>
+  route.request().method() === "POST" &&
+  route.request().url().includes("/evaluation")
+
+let examId = ""
+
+test.describe("Examen Blanc — deploy skew pendant la passation", () => {
+  test.describe.configure({ mode: "serial", timeout: 90_000 })
+
+  test.beforeAll(async ({ request }) => {
+    if (!SECRET) return
+    const seed = await post(request, {
+      action: "seed-exam",
+      title: `${PREFIX} Passation`,
+      questionCount: 5,
+    })
+    examId = (await seed.json()).examId
+  })
+
+  test.afterAll(async ({ request }) => {
+    if (!SECRET) return
+    await post(request, { action: "cleanup", prefix: PREFIX })
+  })
+
+  test("skew : toast Recharger, un seul POST, rollback ; levée : la réponse persiste", async ({
+    examen,
+    page,
+    context,
+  }) => {
+    test.skip(!SECRET, "E2E_RESET_SECRET requis")
+    expect(examId).toBeTruthy()
+
+    await examen.goto()
+    await examen.clickStartExamById(examId)
+    const dialog = page.locator('[role="alertdialog"], [role="dialog"]')
+    await dialog.getByRole("button", { name: "Commencer l'examen" }).click()
+    await page.waitForURL(/\/evaluation/, { timeout: 15_000 })
+    await examen.acceptWarningOrResume()
+    await examen.waitForQuestion(1)
+
+    // Réponse en ligne persistée = valeur attendue du rollback.
+    const option0 = page.getByTestId("answer-option-0")
+    const option1 = page.getByTestId("answer-option-1")
+    await option0.scrollIntoViewIfNeeded()
+    const saved = page.waitForResponse(
+      (r) => r.request().method() === "POST" && r.url().includes("/evaluation"),
+      { timeout: 15_000 },
+    )
+    await option0.click()
+    await expect(option0).toHaveAttribute("data-selected", "true")
+    await saved
+
+    // « Déploiement » : le serveur ne reconnaît plus l'ID d'action.
+    let intercepted = 0
+    await context.route("**/*", (route) => {
+      if (!isActionPost(route)) return route.continue()
+      intercepted++
+      return route.fulfill({
+        status: 404,
+        headers: { "x-nextjs-action-not-found": "1" },
+        body: "",
+      })
+    })
+    await option1.scrollIntoViewIfNeeded()
+    await option1.click()
+
+    // Toast central persistant, avec le remède.
+    const skewToast = page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: "Une nouvelle version de l'application" })
+    await expect(skewToast).toBeVisible({ timeout: 10_000 })
+    await expect(
+      skewToast.getByRole("button", { name: "Recharger" }),
+    ).toBeVisible()
+
+    // Pas de retry : le retry réseau (1 s) de saveExamAnswer ne doit PAS
+    // s'appliquer au skew — on laisse passer la fenêtre avant de compter.
+    await page.waitForTimeout(1_500)
+    expect(intercepted).toBe(1)
+
+    // Rollback vers la réponse persistée.
+    await expect(option1).not.toHaveAttribute("data-selected", "true")
+    await expect(option0).toHaveAttribute("data-selected", "true")
+
+    // Interception levée → le re-clic persiste (parité bundle restaurée).
+    await context.unroute("**/*")
+    await option1.click()
+    await expect(option1).toHaveAttribute("data-selected", "true", {
+      timeout: 10_000,
+    })
+  })
+})

--- a/features/exams/actions.ts
+++ b/features/exams/actions.ts
@@ -15,6 +15,7 @@ import {
 } from "@/db/schema"
 import { requireRole, requireSession } from "@/lib/auth-guards"
 import { createId } from "@/lib/ids"
+import { computeScorePercent } from "@/lib/score"
 import { hasAccess } from "../payments/dal"
 import { type SelectableUser, searchSelectableUsers } from "../users/dal"
 import {
@@ -828,10 +829,7 @@ export const finalizeExam = async (
         .where(eq(examAnswers.participationId, p.id))
       const correctAnswers = agg?.correct ?? 0
       const totalQuestions = agg?.total ?? 0
-      const score =
-        totalQuestions > 0
-          ? Math.round((correctAnswers / totalQuestions) * 100)
-          : 0
+      const score = computeScorePercent(correctAnswers, totalQuestions)
 
       await tx
         .update(examParticipations)

--- a/features/exams/cron.ts
+++ b/features/exams/cron.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, lt, sql } from "drizzle-orm"
+import { and, eq, lt, sql } from "drizzle-orm"
 import "server-only"
 import { db } from "@/db"
 import {
@@ -8,29 +8,39 @@ import {
   exams,
 } from "@/db/schema"
 
-export type CloseExpiredParticipationsResult = {
-  closedCount: number
-  processedCount: number
-}
+export type CloseExpiredParticipationsResult = { closedCount: number }
 
 /**
  * Ferme les participations `in_progress` dont l'examen est terminé (`endDate < now`),
- * en calculant le score à partir des réponses enregistrées. Remplace
- * `exams.closeExpiredParticipations` (cron Convex horaire). Appelé par la route cron
+ * en calculant le score à partir des réponses enregistrées. Appelé par la route cron
  * Vercel.
  *
- * - Borné à 500 par exécution (le cron repasse à la prochaine heure).
- * - UPDATE gardé `status='in_progress'` : si l'utilisateur a soumis entre la lecture
- *   et l'écriture, l'UPDATE est un no-op (on ne clobbere pas une vraie soumission).
+ * - UNE requête ensembliste (UPDATE … FROM sous-requête bornée à 500) : pas de
+ *   N+1, une seule connexion du pool.
+ * - Garde `status='in_progress'` re-vérifiée dans le WHERE final : sous READ
+ *   COMMITTED la condition est réévaluée sur la version verrouillée de la ligne
+ *   → une soumission concurrente gagne, pas de clobber.
+ * - Arrondi `round()` numeric = half-up EXACT — la référence du projet ;
+ *   `finalizeExam` s'aligne via `computeScorePercent` (lib/score.ts).
  * - Statut de fermeture = `auto_submitted` (parité Convex).
  */
 export async function closeExpiredExamParticipations(): Promise<CloseExpiredParticipationsResult> {
   const now = new Date()
 
-  const expired = await db
+  const scored = db
     .select({
       id: examParticipations.id,
-      examId: examParticipations.examId,
+      correct:
+        sql<number>`(select count(*) filter (where ${examAnswers.isCorrect})
+        from ${examAnswers}
+        where ${examAnswers.participationId} = ${examParticipations.id})`.as(
+          "correct",
+        ),
+      total: sql<number>`(select count(*)
+        from ${examQuestions}
+        where ${examQuestions.examId} = ${examParticipations.examId})`.as(
+        "total",
+      ),
     })
     .from(examParticipations)
     .innerJoin(exams, eq(exams.id, examParticipations.examId))
@@ -38,56 +48,25 @@ export async function closeExpiredExamParticipations(): Promise<CloseExpiredPart
       and(eq(examParticipations.status, "in_progress"), lt(exams.endDate, now)),
     )
     .limit(500)
-  if (expired.length === 0) return { closedCount: 0, processedCount: 0 }
+    .as("scored")
 
-  const partIds = expired.map((p) => p.id)
-  const examIds = [...new Set(expired.map((p) => p.examId))]
+  const closed = await db
+    .update(examParticipations)
+    .set({
+      status: "auto_submitted",
+      score: sql`case when ${scored.total} > 0
+        then round(${scored.correct} * 100.0 / ${scored.total})::int
+        else 0 end`,
+      completedAt: now,
+    })
+    .from(scored)
+    .where(
+      and(
+        eq(examParticipations.id, scored.id),
+        eq(examParticipations.status, "in_progress"),
+      ),
+    )
+    .returning({ id: examParticipations.id })
 
-  const [correctRows, totalRows] = await Promise.all([
-    db
-      .select({
-        participationId: examAnswers.participationId,
-        correct:
-          sql<number>`count(*) filter (where ${examAnswers.isCorrect})`.mapWith(
-            Number,
-          ),
-      })
-      .from(examAnswers)
-      .where(inArray(examAnswers.participationId, partIds))
-      .groupBy(examAnswers.participationId),
-    db
-      .select({
-        examId: examQuestions.examId,
-        total: sql<number>`count(*)`.mapWith(Number),
-      })
-      .from(examQuestions)
-      .where(inArray(examQuestions.examId, examIds))
-      .groupBy(examQuestions.examId),
-  ])
-  const correctMap = new Map(
-    correctRows.map((r) => [r.participationId, r.correct]),
-  )
-  const totalMap = new Map(totalRows.map((r) => [r.examId, r.total]))
-
-  let closedCount = 0
-  await db.transaction(async (tx) => {
-    for (const p of expired) {
-      const total = totalMap.get(p.examId) ?? 0
-      const correct = correctMap.get(p.id) ?? 0
-      const score = total > 0 ? Math.round((correct / total) * 100) : 0
-      const updated = await tx
-        .update(examParticipations)
-        .set({ status: "auto_submitted", score, completedAt: now })
-        .where(
-          and(
-            eq(examParticipations.id, p.id),
-            eq(examParticipations.status, "in_progress"),
-          ),
-        )
-        .returning({ id: examParticipations.id })
-      if (updated.length > 0) closedCount++
-    }
-  })
-
-  return { closedCount, processedCount: expired.length }
+  return { closedCount: closed.length }
 }

--- a/features/exams/cron.ts
+++ b/features/exams/cron.ts
@@ -50,6 +50,10 @@ export async function closeExpiredExamParticipations(): Promise<CloseExpiredPart
     .limit(500)
     .as("scored")
 
+  // ⚠️ Drizzle rend les champs SQL.Aliased de la sous-requête ("correct",
+  // "total") NON qualifiés dans le SET — valide uniquement tant qu'aucune
+  // colonne de `exam_participations` ne porte ces noms (sinon « column
+  // reference is ambiguous » au runtime, invisible à tsc).
   const closed = await db
     .update(examParticipations)
     .set({

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema"
 import { requireSession } from "@/lib/auth-guards"
 import { createId } from "@/lib/ids"
+import { computeScorePercent } from "@/lib/score"
 import { getOpenExamLockedQuestionIds } from "../exams/dal"
 import { hasAccess } from "../payments/dal"
 import {
@@ -406,8 +407,7 @@ export const completeTrainingSession = async ({
 
     const correctCount = c?.correct ?? 0
     const totalQuestions = s.questionCount
-    const score =
-      totalQuestions > 0 ? Math.round((correctCount / totalQuestions) * 100) : 0
+    const score = computeScorePercent(correctCount, totalQuestions)
 
     // Garde de statut (règle concurrence du repo) : le cron d'expiration ou un
     // appel concurrent peut avoir clos la session entre la lecture et l'écriture.

--- a/features/training/cron.ts
+++ b/features/training/cron.ts
@@ -48,6 +48,10 @@ export async function closeExpiredTrainingSessions(): Promise<CloseExpiredTraini
     .limit(100)
     .as("scored")
 
+  // ⚠️ Drizzle rend le champ SQL.Aliased de la sous-requête ("correct") NON
+  // qualifié dans le SET — valide uniquement tant qu'aucune colonne de
+  // `training_sessions` ne porte ce nom (sinon « column reference is
+  // ambiguous » au runtime, invisible à tsc).
   const closed = await db
     .update(trainingSessions)
     .set({

--- a/features/training/cron.ts
+++ b/features/training/cron.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, lt, sql } from "drizzle-orm"
+import { and, eq, lt, sql } from "drizzle-orm"
 import "server-only"
 import { db } from "@/db"
 import { trainingSessionItems, trainingSessions } from "@/db/schema"
@@ -6,68 +6,65 @@ import { trainingSessionItems, trainingSessions } from "@/db/schema"
 export type CloseExpiredTrainingResult = { closedCount: number }
 
 /**
- * Ferme les sessions d'entraînement `in_progress` expirées (`expiresAt < now`, TTL
- * 24h), en calculant le score à partir des items répondus. Remplace
- * `training.closeExpiredTrainingSessions` (cron Convex horaire). Appelé par la route
+ * Ferme les sessions d'entraînement `in_progress` expirées (`expiresAt < now`,
+ * TTL 24h), score = % d'items corrects sur `questionCount`. Appelé par la route
  * cron Vercel.
  *
- * - Borné à 100 par exécution.
- * - UPDATE gardé `status='in_progress'` (idem cron examens) : pas de clobber d'une
- *   complétion concurrente.
- * - Statut de fermeture = `abandoned` (parité Convex). Score = % d'items corrects sur
- *   `questionCount`.
+ * - UNE requête ensembliste (UPDATE … FROM sous-requête bornée à 100), garde
+ *   `status='in_progress'` re-vérifiée dans le WHERE final (idem cron examens) :
+ *   pas de clobber d'une complétion concurrente.
+ * - Arrondi `round()` numeric = half-up EXACT (référence projet, cf. lib/score.ts).
+ * - Statut de fermeture = `abandoned` (parité Convex).
  */
 export async function closeExpiredTrainingSessions(): Promise<CloseExpiredTrainingResult> {
   const now = new Date()
 
-  const expired = await db
+  // LEFT JOIN + GROUP BY plutôt qu'une sous-requête corrélée : dans une
+  // sous-requête `.as()` MONO-table, Drizzle rend les colonnes SANS
+  // qualification — la corrélation (`"session_id" = "id"`) se lierait alors à
+  // la table interne (count toujours 0). Un JOIN force la qualification
+  // complète (cf. cron examens) et supprime la corrélation.
+  const scored = db
     .select({
       id: trainingSessions.id,
       questionCount: trainingSessions.questionCount,
+      correct:
+        sql<number>`count(*) filter (where ${trainingSessionItems.isCorrect})`.as(
+          "correct",
+        ),
     })
     .from(trainingSessions)
+    .leftJoin(
+      trainingSessionItems,
+      eq(trainingSessionItems.sessionId, trainingSessions.id),
+    )
     .where(
       and(
         eq(trainingSessions.status, "in_progress"),
         lt(trainingSessions.expiresAt, now),
       ),
     )
+    .groupBy(trainingSessions.id)
     .limit(100)
-  if (expired.length === 0) return { closedCount: 0 }
+    .as("scored")
 
-  const ids = expired.map((s) => s.id)
-  const correctRows = await db
-    .select({
-      sessionId: trainingSessionItems.sessionId,
-      correct:
-        sql<number>`count(*) filter (where ${trainingSessionItems.isCorrect})`.mapWith(
-          Number,
-        ),
+  const closed = await db
+    .update(trainingSessions)
+    .set({
+      status: "abandoned",
+      score: sql`case when ${scored.questionCount} > 0
+        then round(${scored.correct} * 100.0 / ${scored.questionCount})::int
+        else 0 end`,
+      completedAt: now,
     })
-    .from(trainingSessionItems)
-    .where(inArray(trainingSessionItems.sessionId, ids))
-    .groupBy(trainingSessionItems.sessionId)
-  const correctMap = new Map(correctRows.map((r) => [r.sessionId, r.correct]))
+    .from(scored)
+    .where(
+      and(
+        eq(trainingSessions.id, scored.id),
+        eq(trainingSessions.status, "in_progress"),
+      ),
+    )
+    .returning({ id: trainingSessions.id })
 
-  let closedCount = 0
-  await db.transaction(async (tx) => {
-    for (const s of expired) {
-      const correct = correctMap.get(s.id) ?? 0
-      const score =
-        s.questionCount > 0 ? Math.round((correct / s.questionCount) * 100) : 0
-      const updated = await tx
-        .update(trainingSessions)
-        .set({ status: "abandoned", score, completedAt: now })
-        .where(
-          and(
-            eq(trainingSessions.id, s.id),
-            eq(trainingSessions.status, "in_progress"),
-          ),
-        )
-        .returning({ id: trainingSessions.id })
-      if (updated.length > 0) closedCount++
-    }
-  })
-
-  return { closedCount }
+  return { closedCount: closed.length }
 }

--- a/lib/safe-action.ts
+++ b/lib/safe-action.ts
@@ -1,3 +1,6 @@
+import { unstable_isUnrecognizedActionError } from "next/navigation"
+import { toast } from "sonner"
+
 // Client-safe : aucun import serveur. Convertit les rejets réseau d'un appel
 // de Server Action en échec structuré, discriminable par les gardes existants
 // (`!res.success` comme `"error" in res`).
@@ -7,9 +10,26 @@ export type ActionFailure = { success: false; error: string }
 export const NETWORK_ERROR_MESSAGE =
   "Connexion perdue. Vérifiez votre réseau et réessayez."
 
+export const DEPLOY_SKEW_MESSAGE =
+  "Une nouvelle version de l'application est disponible. Rechargez la page pour continuer."
+
 const RETRY_DELAY_MS = 1000
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// Deploy skew : le bundle périmé POSTe un ID d'action inconnu du nouveau
+// serveur — retenter est inutile par construction, seul un rechargement
+// répare. Toast émis ICI (exception à « les toasts vivent dans les pages ») :
+// plusieurs call sites toastent un message métier hardcodé qui masquerait le
+// remède. `id` fixe → dédupliqué, `duration: Infinity` → persiste jusqu'au
+// rechargement.
+const notifyDeploySkew = () => {
+  toast.error(DEPLOY_SKEW_MESSAGE, {
+    id: "deploy-skew",
+    duration: Infinity,
+    action: { label: "Recharger", onClick: () => window.location.reload() },
+  })
+}
 
 // `retries` est RÉSERVÉ aux actions idempotentes (upserts) : un « Failed to
 // fetch » peut survenir alors que la requête a atteint le serveur, le retry
@@ -22,7 +42,11 @@ export async function callAction<T>(
   for (let attempt = 0; ; attempt++) {
     try {
       return await fn()
-    } catch {
+    } catch (err) {
+      if (unstable_isUnrecognizedActionError(err)) {
+        notifyDeploySkew()
+        return { success: false, error: DEPLOY_SKEW_MESSAGE }
+      }
       if (attempt < retries) {
         await delay(RETRY_DELAY_MS)
         continue

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -1,0 +1,6 @@
+// Arrondi half-up EXACT en arithmétique entière — parité stricte avec
+// `round(correct * 100.0 / total)` (numeric SQL) des crons de clôture.
+// `Math.round((correct / total) * 100)` en float diverge sur les demi-points
+// (ex. 23/40 → 57.4999… → 57 au lieu de 58).
+export const computeScorePercent = (correct: number, total: number): number =>
+  total > 0 ? Math.floor((200 * correct + total) / (2 * total)) : 0

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
         /examen-blanc-pause\.spec\.ts/,
         /examen-blanc-auto-submit\.spec\.ts/,
         /examen-blanc-offline\.spec\.ts/,
+        /examen-blanc-deploy-skew\.spec\.ts/,
         /resultats-examen\.spec\.ts/,
         /resultats-entrainement\.spec\.ts/,
         /profil\.spec\.ts/,

--- a/tests/integration/cron-close-expired.test.ts
+++ b/tests/integration/cron-close-expired.test.ts
@@ -42,6 +42,8 @@ const qIdsHalf = Array.from({ length: 40 }, () => createId())
 const tsExpired = createId()
 const tsFuture = createId()
 const tsDone = createId()
+const tsHalf = createId()
+const tsEmpty = createId()
 
 beforeAll(async () => {
   const now = Date.now()
@@ -190,13 +192,16 @@ beforeAll(async () => {
     completedAt: status === "completed" ? new Date(now - DAY) : null,
     expiresAt: new Date(now + expiresOffset),
   })
-  await db
-    .insert(trainingSessions)
-    .values([
-      mkSession(tsExpired, U1, "in_progress", -DAY),
-      mkSession(tsFuture, U2, "in_progress", DAY),
-      mkSession(tsDone, U3, "completed", -DAY),
-    ])
+  await db.insert(trainingSessions).values([
+    mkSession(tsExpired, U1, "in_progress", -DAY),
+    mkSession(tsFuture, U2, "in_progress", DAY),
+    mkSession(tsDone, U3, "completed", -DAY),
+    // 40 questions / 23 items corrects → 57.5 exact : sentinelle d'arrondi
+    // half-up côté training (miroir de pHalf).
+    { ...mkSession(tsHalf, U1, "in_progress", -DAY), questionCount: 40 },
+    // Aucun item : exerce la branche « ligne NULL » du LEFT JOIN.
+    mkSession(tsEmpty, U2, "in_progress", -DAY),
+  ])
   // 4 items, 2 corrects pour tsExpired → score attendu 50.
   await db.insert(trainingSessionItems).values(
     qIds.map((questionId, position) => ({
@@ -206,6 +211,16 @@ beforeAll(async () => {
       position,
       selectedAnswer: position < 3 ? "A" : null,
       isCorrect: position < 2 ? true : position < 3 ? false : null,
+    })),
+  )
+  await db.insert(trainingSessionItems).values(
+    qIdsHalf.slice(0, 23).map((questionId, position) => ({
+      id: createId(),
+      sessionId: tsHalf,
+      questionId,
+      position,
+      selectedAnswer: "A",
+      isCorrect: true,
     })),
   )
 })
@@ -288,5 +303,13 @@ describe("closeExpiredTrainingSessions", () => {
 
     expect((await sessionOf(tsFuture))?.status).toBe("in_progress")
     expect((await sessionOf(tsDone))?.status).toBe("completed")
+
+    const half = await sessionOf(tsHalf)
+    expect(half?.status).toBe("abandoned")
+    expect(half?.score).toBe(58) // 23/40 = 57.5 exact → 58 (float JS : 57)
+
+    const empty = await sessionOf(tsEmpty)
+    expect(empty?.status).toBe("abandoned")
+    expect(empty?.score).toBe(0) // zéro item : branche NULL du LEFT JOIN
   })
 })

--- a/tests/integration/cron-close-expired.test.ts
+++ b/tests/integration/cron-close-expired.test.ts
@@ -35,6 +35,10 @@ const pPast = createId()
 const pFuture = createId()
 const pDone = createId()
 
+const examHalf = createId()
+const pHalf = createId()
+const qIdsHalf = Array.from({ length: 40 }, () => createId())
+
 const tsExpired = createId()
 const tsFuture = createId()
 const tsDone = createId()
@@ -58,6 +62,16 @@ beforeAll(async () => {
       domain: `CRON-${suffix}`,
     })),
   )
+  await db.insert(questions).values(
+    qIdsHalf.map((id, i) => ({
+      id,
+      question: `QH ${i} ${suffix} ?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj ${suffix}`,
+      domain: `CRON-${suffix}`,
+    })),
+  )
 
   const mkExam = (id: string, endOffset: number) => ({
     id,
@@ -70,7 +84,11 @@ beforeAll(async () => {
   })
   await db
     .insert(exams)
-    .values([mkExam(examPast, -DAY), mkExam(examFuture, DAY)])
+    .values([
+      mkExam(examPast, -DAY),
+      mkExam(examFuture, DAY),
+      mkExam(examHalf, -DAY),
+    ])
   await db
     .insert(examQuestions)
     .values(
@@ -78,6 +96,13 @@ beforeAll(async () => {
         qIds.map((questionId, position) => ({ examId, questionId, position })),
       ),
     )
+  await db.insert(examQuestions).values(
+    qIdsHalf.map((questionId, position) => ({
+      examId: examHalf,
+      questionId,
+      position,
+    })),
+  )
 
   await db.insert(examParticipations).values([
     {
@@ -105,6 +130,14 @@ beforeAll(async () => {
       startedAt: new Date(now - 2 * DAY),
       completedAt: new Date(now - DAY - 1000),
     },
+    {
+      id: pHalf,
+      examId: examHalf,
+      userId: U1,
+      status: "in_progress",
+      score: 0,
+      startedAt: new Date(now - 2 * DAY),
+    },
   ])
   // 4 questions, 2 bonnes réponses pour pPast → score attendu 50.
   await db.insert(examAnswers).values([
@@ -130,6 +163,17 @@ beforeAll(async () => {
       isCorrect: false,
     },
   ])
+  // 40 questions, 23 bonnes réponses → 57.5 exact : sentinelle d'arrondi
+  // half-up (le float JS donnait 57).
+  await db.insert(examAnswers).values(
+    qIdsHalf.slice(0, 23).map((questionId) => ({
+      id: createId(),
+      participationId: pHalf,
+      questionId,
+      selectedAnswer: "A",
+      isCorrect: true,
+    })),
+  )
 
   const mkSession = (
     id: string,
@@ -171,7 +215,9 @@ afterAll(async () => {
   await db
     .delete(trainingSessions)
     .where(inArray(trainingSessions.userId, USERS))
-  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db
+    .delete(questions)
+    .where(inArray(questions.id, [...qIds, ...qIdsHalf]))
   await db.delete(user).where(inArray(user.id, USERS))
 })
 
@@ -211,6 +257,10 @@ describe("closeExpiredExamParticipations", () => {
 
     expect((await statusOf(pFuture))?.status).toBe("in_progress")
     expect((await statusOf(pDone))?.status).toBe("completed")
+
+    const half = await statusOf(pHalf)
+    expect(half?.status).toBe("auto_submitted")
+    expect(half?.score).toBe(58) // 23/40 = 57.5 exact → 58 (float JS : 57)
   })
 
   it("idempotent : une participation déjà fermée n'est pas re-traitée", async () => {

--- a/tests/lib/safe-action.test.ts
+++ b/tests/lib/safe-action.test.ts
@@ -1,8 +1,20 @@
+import { toast } from "sonner"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { NETWORK_ERROR_MESSAGE, callAction } from "@/lib/safe-action"
+import {
+  DEPLOY_SKEW_MESSAGE,
+  NETWORK_ERROR_MESSAGE,
+  callAction,
+} from "@/lib/safe-action"
+
+vi.mock("next/navigation", () => ({
+  unstable_isUnrecognizedActionError: (err: unknown) =>
+    err instanceof Error && err.name === "UnrecognizedActionError",
+}))
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }))
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.clearAllMocks()
 })
 
 describe("callAction", () => {
@@ -60,5 +72,45 @@ describe("callAction", () => {
       error: NETWORK_ERROR_MESSAGE,
     })
     expect(fn).toHaveBeenCalledTimes(2)
+  })
+})
+
+const skewError = () => {
+  const e = new Error('Server Action "40dfe0" was not found on the server.')
+  e.name = "UnrecognizedActionError"
+  return e
+}
+
+describe("callAction — deploy skew", () => {
+  it("convertit le skew en message dédié, sans jamais retenter", async () => {
+    const fn = vi.fn().mockRejectedValue(skewError())
+    await expect(callAction(fn, { retries: 2 })).resolves.toEqual({
+      success: false,
+      error: DEPLOY_SKEW_MESSAGE,
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("affiche le toast central dédupliqué avec l'action Recharger", async () => {
+    const fn = vi.fn().mockRejectedValue(skewError())
+    await callAction(fn)
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      DEPLOY_SKEW_MESSAGE,
+      expect.objectContaining({
+        id: "deploy-skew",
+        duration: Infinity,
+        action: expect.objectContaining({ label: "Recharger" }),
+      }),
+    )
+  })
+
+  it("un rejet réseau ordinaire ne déclenche pas le toast central", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await expect(callAction(fn)).resolves.toEqual({
+      success: false,
+      error: NETWORK_ERROR_MESSAGE,
+    })
+    expect(toast.error).not.toHaveBeenCalled()
   })
 })

--- a/tests/lib/score.test.ts
+++ b/tests/lib/score.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { computeScorePercent } from "@/lib/score"
+
+describe("computeScorePercent", () => {
+  it("0 question → 0", () => {
+    expect(computeScorePercent(0, 0)).toBe(0)
+  })
+
+  it("cas nominaux", () => {
+    expect(computeScorePercent(2, 4)).toBe(50)
+    expect(computeScorePercent(1, 3)).toBe(33)
+    expect(computeScorePercent(23, 40)).toBe(58) // 57.5 exact — Math.round float donnait 57
+    expect(computeScorePercent(40, 40)).toBe(100)
+  })
+
+  it("half-up exact pour tout total ≤ 500 (parité avec round() SQL numeric)", () => {
+    for (let total = 1; total <= 500; total++) {
+      for (let correct = 0; correct <= total; correct++) {
+        const hundred = correct * 100
+        const remainder = hundred % total
+        const base = (hundred - remainder) / total
+        const expected = 2 * remainder >= total ? base + 1 : base
+        expect(computeScorePercent(correct, total)).toBe(expected)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Résumé

Suivi de la campagne robustesse réseau (PR #97) — les deux issues de clôture, plus un correctif de parité d'arrondi découvert en revue de design.

### #98 — UX deploy-skew (`UnrecognizedActionError`, Sentry NOMAQBANQ-1B)

- `callAction` détecte le skew via `unstable_isUnrecognizedActionError` (`next/navigation`, insensible à la minification), **ne retente jamais** ce cas, renvoie un message dédié et affiche **lui-même** un toast persistant avec bouton « Recharger » (id fixe → dédupliqué). Central car plusieurs pages toastent un message métier hardcodé qui masquerait le remède.
- E2E qui exerce le contrat Next **réel** (`route.fulfill` avec l'en-tête `x-nextjs-action-not-found: 1`) : toast + bouton visibles, un seul POST malgré `retries: 1`, rollback, reprise après levée.

### #99 — N+1 `pg-pool.connect` dans le cron (Sentry NOMAQBANQ-17)

- Les traces montrent que le détecteur flaggait les **connexions froides parallèles** du `Promise.all` (runs à zéro ligne), pas une boucle de données — mais les boucles latentes existaient (500/100 UPDATE unitaires).
- Clôtures examens/entraînements réécrites en **un UPDATE ensembliste** chacune (garde `status='in_progress'` re-vérifiée → même sémantique de concurrence ; borne 500/100 conservée). Gotcha Drizzle documenté : sous-requête `.as()` mono-table = colonnes déqualifiées → forme LEFT JOIN + GROUP BY côté training.
- Route cron **séquentielle** (une connexion froide réutilisée) avec **isolation par tâche** : une poison-row n'empêche plus l'anonymisation RGPD ni les notifications ; 500 après avoir tout tenté (retry scheduler conservé). Claim anti-double-envoi des notifications inchangé.

### Parité d'arrondi (revue de design)

`Math.round((c/t)*100)` en float divergeait du `round()` SQL sur les demi-points (23/40 : 57 vs 58). Le half-up **exact** devient la référence : helper entier `lib/score.ts` branché dans `finalizeExam` et `completeTrainingSession`, sentinelles 23/40 → 58 en intégration (examens + training) + balayage exhaustif unit ≤ 500.

## Tests

- `bun run check` ✓ — 916 unit ✓ — 268 intégration ✓ (branche Neon éphémère)
- E2E ciblés : `examen-blanc-offline` + `examen-blanc-deploy-skew` ✓
- Deux revues adversariales en sessions séparées : design (1 bloquant intégré : l'arrondi) et implémentation (verdict OUI, 3 durcissements 🟡 appliqués)

## Post-déploiement

Résoudre NOMAQBANQ-1B et NOMAQBANQ-17 dans Sentry et surveiller la récidive.

Closes #98
Closes #99