### PR TITLE
fix: fiabilité Sentry — pool pg, gate d'environnement, crash $RS résultats (#103 #104 #105)

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -100,6 +100,14 @@ storagePath,order}` pour rester assignable aux composants partagés
   (Node) vs client → _hydration mismatch_ (« 2 880 » ≠ « 2 880 » à l'œil ; l'arbre
   est régénéré côté client et l'état local peut sauter). Toujours passer une locale
   fixe : `n.toLocaleString("fr-CA")`.
+- **Hydration — bruit tiers filtré** : les crashs `$RS` (`Cannot read properties
+of null (reading 'parentNode')`, script inline du streaming React) causés par
+  un tiers qui mute le DOM (traduction, extension, proxy) sont DROPPÉS par le
+  `beforeSend` d'`instrumentation-client.ts` (double condition message + frame
+  `$RS`, volontairement étroite). Ne JAMAIS élargir ce filtre à d'autres erreurs
+  d'hydratation sans audit préalable de l'arbre rendu (grep `toLocaleString()`/
+  `new Date()`/`Date.now()`/`useId`/`typeof window` sur les composants rendus
+  côté serveur) — un vrai mismatch applicatif doit rester visible dans Sentry.
 - **ESLint `react-hooks/set-state-in-effect`** : pas de `setState` synchrone dans
   un `useEffect`. Fetch-par-id → tracker l'id chargé (`useState<{id,q}>` +
   comparer `state?.id === currentId`) au lieu d'un reset synchrone.

--- a/db/index.ts
+++ b/db/index.ts
@@ -8,6 +8,13 @@ import * as schema from "./schema"
 // Use the POOLED (-pooler) connection string for the runtime.
 const pool = new Pool({ connectionString: env.DATABASE_URL, max: 5 })
 
+// Sans listener, une connexion idle coupée par Neon (reprise d'instance, reset
+// réseau) émet `error` sur le pool → uncaughtException fatale. Le pool remplace
+// le client mort tout seul ; il n'y a rien d'autre à faire que ne pas crasher.
+pool.on("error", (err) => {
+  console.warn("[pg pool] connexion idle perdue", err.message)
+})
+
 // On Vercel, let the runtime drain idle connections before suspending an instance.
 if (process.env.VERCEL) attachDatabasePool(pool)
 

--- a/db/index.ts
+++ b/db/index.ts
@@ -12,7 +12,10 @@ const pool = new Pool({ connectionString: env.DATABASE_URL, max: 5 })
 // réseau) émet `error` sur le pool → uncaughtException fatale. Le pool remplace
 // le client mort tout seul ; il n'y a rien d'autre à faire que ne pas crasher.
 pool.on("error", (err) => {
-  console.warn("[pg pool] connexion idle perdue", err.message)
+  // err.code (57P01, ECONNRESET…) est le seul discriminant entre coupure
+  // bénigne et problème émergent sur le canal logs Vercel.
+  const code = (err as NodeJS.ErrnoException).code ?? "sans-code"
+  console.warn("[pg pool] connexion idle perdue", code, err.message)
 })
 
 // On Vercel, let the runtime drain idle connections before suspending an instance.

--- a/docs/superpowers/plans/2026-07-13-sentry-fiabilite.md
+++ b/docs/superpowers/plans/2026-07-13-sentry-fiabilite.md
@@ -1,0 +1,354 @@
+# Campagne fiabilité Sentry (#103, #104, #105) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Éliminer le crash fatal du Pool pg (#103), couper le bruit Sentry dev/e2e en gardant les previews (#105), et statuer sur le crash $RS/hydratation de la page résultats d'entraînement par investigation encadrée (#104).
+
+**Architecture:** Trois changements indépendants, un commit par issue, sur une branche unique `fix/sentry-fiabilite`. #105 et #103 sont des changements de config pure (3 configs Sentry, `db/index.ts`). #104 est une investigation avec arbre de décision B1/B2/B3 encodé dans le spec — seul le chemin retenu produit du code.
+
+**Tech Stack:** Next.js 16, @sentry/nextjs 10.x, pg Pool + @vercel/functions, Vercel (Fluid Compute).
+
+**Spec:** `docs/superpowers/specs/2026-07-13-sentry-fiabilite-design.md`
+
+**Ordre:** Task 0 (branche) → Task 1 (#105) → Task 2 (#103) → Task 3 (#104). Le bruit est coupé d'abord, l'investigation vient en dernier.
+
+**Convention projet:** pas d'attribution Claude dans les commits. `bun run check` = prettier + tsc + eslint, doit passer avant chaque commit.
+
+---
+
+### Task 0: Branche de campagne + spec/plan committés
+
+**Files:** aucun changement de code.
+
+- [ ] **Step 1: Créer la branche depuis main à jour**
+
+```bash
+git checkout main && git pull && git checkout -b fix/sentry-fiabilite
+```
+
+- [ ] **Step 2: Committer le spec et le plan**
+
+```bash
+git add docs/superpowers/specs/2026-07-13-sentry-fiabilite-design.md docs/superpowers/plans/2026-07-13-sentry-fiabilite.md
+git commit -m "docs: spec + plan campagne fiabilité Sentry (#103 #104 #105)"
+```
+
+---
+
+### Task 1: #105 — Gate d'environnement Sentry (dev coupé, previews conservées)
+
+**Files:**
+
+- Modify: `instrumentation-client.ts`
+- Modify: `sentry.server.config.ts`
+- Modify: `sentry.edge.config.ts`
+- Modify: `playwright.config.ts` (kill-switch pour le chemin e2e CI qui force `NODE_ENV=production`)
+
+Pas de test unitaire (config d'init SDK, aucun point d'accroche testable sans mocker `Sentry.init` pour rien). Vérification = build + comportement en dev.
+
+- [ ] **Step 1: Vérifier que `NEXT_PUBLIC_VERCEL_ENV` sera disponible**
+
+Sur Vercel, `NEXT_PUBLIC_VERCEL_ENV` n'existe que si « Automatically expose System Environment Variables » est actif. **`vercel env ls` ne peut PAS répondre** (il liste les variables du projet, pas les variables système ni le toggle). Vérifier en lecture seule via l'API :
+
+```bash
+vercel api "/v9/projects/nomaqbanq" 2>&1 | grep -o '"autoExposeSystemEnvs":[a-z]*'
+```
+
+Expected: `"autoExposeSystemEnvs":true`. (Si le slug du projet diffère, le prendre dans `.vercel/project.json`.) Si `false` : l'activer dans le dashboard (Settings → Environment Variables → « Automatically expose System Environment Variables »). Ne PAS créer la variable à la main. Si non activable immédiatement, continuer quand même : le fallback `?? "production"` du Step 2 couvre l'intervalle (dégradé accepté par le spec).
+
+- [ ] **Step 2: Modifier `instrumentation-client.ts`**
+
+Ajouter `enabled` et `environment` en tête d'options de `Sentry.init` (le reste du fichier ne change pas) :
+
+```ts
+Sentry.init({
+  dsn: "https://c7c726531f3e9dc07a6488f3bd7ae9b4@o4510410010787842.ingest.us.sentry.io/4510410016227333",
+
+  // Dev local et e2e (y compris le build prod du chemin CI, via le kill-switch)
+  // ne doivent jamais polluer le projet Sentry de prod.
+  enabled:
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_SENTRY_DISABLED !== "1",
+  // VERCEL_ENV n'existe pas dans le bundle navigateur ; fallback "production"
+  // (et pas "development") : `enabled` garantit déjà qu'on est en build prod.
+  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "production",
+
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: false,
+      blockAllMedia: false,
+    }),
+  ],
+  // ... (tracesSampleRate, enableLogs, replays*, sendDefaultPii inchangés)
+})
+```
+
+- [ ] **Step 3: Modifier `sentry.server.config.ts`**
+
+```ts
+Sentry.init({
+  dsn: "https://c7c726531f3e9dc07a6488f3bd7ae9b4@o4510410010787842.ingest.us.sentry.io/4510410016227333",
+
+  // Dev local et e2e (y compris le build prod du chemin CI, via le kill-switch)
+  // ne doivent jamais polluer le projet Sentry de prod.
+  enabled:
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_SENTRY_DISABLED !== "1",
+  environment: process.env.VERCEL_ENV ?? "development",
+
+  // ... (tracesSampleRate, enableLogs, sendDefaultPii inchangés)
+})
+```
+
+- [ ] **Step 4: Modifier `sentry.edge.config.ts` et `playwright.config.ts`**
+
+`sentry.edge.config.ts` : mêmes deux options que le serveur (`enabled` avec kill-switch, `environment: process.env.VERCEL_ENV ?? "development"`).
+
+`playwright.config.ts` — poser le kill-switch dans `webServer.env` (le build CI `bun run build && bun run start` inline la variable dans le bundle client ; serveur/edge la lisent au runtime) :
+
+```ts
+  webServer: {
+    command: process.env.CI
+      ? "bun run build && bun run start"
+      : "bun dev --turbopack",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NODE_ENV: process.env.CI ? "production" : "development",
+      // Le chemin CI tourne en build production : sans ce kill-switch, le DSN
+      // hardcodé enverrait le bruit HeadlessChrome dans le projet Sentry de prod.
+      NEXT_PUBLIC_SENTRY_DISABLED: "1",
+    },
+  },
+```
+
+- [ ] **Step 5: Gates**
+
+```bash
+bun run check && bun run build
+```
+
+Expected: les trois passent. Si `bun run build` échoue sur autre chose que ces fichiers (cache), `rm -rf .next` puis relancer.
+
+- [ ] **Step 6: Vérification comportementale en dev**
+
+Demander à l'utilisateur de lancer `bun dev` (JAMAIS le lancer soi-même — règle projet), puis charger une page et confirmer dans la sortie réseau du navigateur qu'aucune requête ne part vers `/monitoring` ni `*.ingest.us.sentry.io`. Alternative sans serveur : accepté de s'appuyer sur la sémantique documentée de `enabled` + la vérification post-déploiement (plus d'événements `::1` dans Sentry).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add instrumentation-client.ts sentry.server.config.ts sentry.edge.config.ts playwright.config.ts
+git commit -m "chore: gate Sentry hors production + tag environment (closes #105)"
+```
+
+---
+
+### Task 2: #103 — Handler d'erreur sur le Pool pg
+
+**Files:**
+
+- Modify: `db/index.ts`
+
+Pas de test dédié (câblage d'infra sur le cycle de vie du pool ; la seule assertion utile — « un listener error existe » — testerait l'implémentation, pas un comportement). Vérification post-déploiement : NOMAQBANQ-Z ne se rouvre pas.
+
+- [ ] **Step 1: Ajouter le handler dans `db/index.ts`**
+
+Fichier complet après modification :
+
+```ts
+import { attachDatabasePool } from "@vercel/functions"
+import { drizzle } from "drizzle-orm/node-postgres"
+import { Pool } from "pg"
+import { env } from "@/lib/env/server"
+import * as schema from "./schema"
+
+// One pool created at module scope, reused across requests (Vercel Fluid Compute).
+// Use the POOLED (-pooler) connection string for the runtime.
+const pool = new Pool({ connectionString: env.DATABASE_URL, max: 5 })
+
+// Sans listener, une connexion idle coupée par Neon (reprise d'instance, reset
+// réseau) émet `error` sur le pool → uncaughtException fatale. Le pool remplace
+// le client mort tout seul ; il n'y a rien d'autre à faire que ne pas crasher.
+pool.on("error", (err) => {
+  console.warn("[pg pool] connexion idle perdue", err.message)
+})
+
+// On Vercel, let the runtime drain idle connections before suspending an instance.
+if (process.env.VERCEL) attachDatabasePool(pool)
+
+export const db = drizzle(pool, { schema })
+export type Db = typeof db
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/index.ts
+git commit -m "fix: ne plus crasher sur la perte d'une connexion idle du pool pg (closes #103)"
+```
+
+---
+
+### Task 3: #104 — Investigation crash $RS/hydratation, puis chemin B1, B2 ou B3
+
+**Files (selon le chemin retenu en Phase B):**
+
+- B1 : le(s) composant(s) fautif(s) identifié(s) en Phase A (+ test si code applicatif)
+- B2 : Modify: `instrumentation-client.ts` + Modify: `.claude/rules/data-layer.md`
+- B3 : Modify: `instrumentation-client.ts` (contexte de diagnostic uniquement)
+
+**Phase A — Investigation (timebox ~30-45 min, s'arrêter au premier verdict net)**
+
+- [ ] **Step A1: Inspecter les 3 événements Sentry (tags, navigateurs, releases)**
+
+```bash
+sentry issue events NOMAQBANQ-14
+sentry event list NOMAQBANQ-14 --json 2>/dev/null | head -c 8000
+```
+
+Chercher : diversité des navigateurs/OS (3 users différents ?), présence systématique du breadcrumb React #418, tout marqueur de traduction ou d'app embarquée (user-agent WebView, `wv`, versions Chrome).
+
+- [ ] **Step A2: Visionner le replay**
+
+```bash
+sentry replay view b57925147b3a45a082f677685fb780dc --web
+```
+
+(`--web` ouvre le navigateur — le rendu replay n'est pas exploitable en CLI ; la forme courte `-w` n'est pas documentée sur cette sous-commande.) Observer : la page traduite ou non, le moment du crash (pendant le streaming initial vs navigation), toute UI tierce visible.
+
+- [ ] **Step A3: Audit d'hydratation de l'arbre rendu**
+
+Périmètre = **tout l'arbre réellement rendu par la page**, pas seulement les fichiers au nom évocateur : `components/quiz/results/**`, la page, layout `(dashboard)` + sidebar/shell partagés, ET les sous-arbres importés par `SessionResults` — `components/quiz/question-card/` (la 1re question est dépliée par défaut → rendue côté serveur), `components/quiz/session/` (SessionToolbar), `hooks/`.
+
+```bash
+# suspects classiques dans le périmètre
+grep -rnE "toLocaleString\(\)|toLocaleDateString\(\)|toLocaleTimeString\(\)|new Date\(\)|Date\.now\(\)|Math\.random\(\)|typeof window|useId|crypto\.randomUUID" \
+  components/quiz/results components/quiz/question-card components/quiz/session hooks \
+  "app/(dashboard)/tableau-de-bord/entrainement/[sessionId]/resultats" "app/(dashboard)/layout.tsx" components/shared 2>/dev/null
+```
+
+(Le pré-audit du design + la revue adversariale ont blanchi `components/quiz/results/**`, la page, `question-card/`, `session/` et `use-is-visible` — re-dérouler quand même le grep complet avant de conclure. Hit attendu et hors sujet : `components/shared/payments/access-badge.tsx` a un `Date.now()` — composant paiements, hors arbre résultats.) Chercher aussi : rendu conditionnel sur media query au premier render, props sérialisées différemment (undefined vs absent).
+
+- [ ] **Step A4: Tentative de repro navigateur (skill playwright-cli / e2e-scenario)**
+
+Contre un serveur lancé par l'utilisateur (lui demander le port — ne jamais lancer soi-même) : ouvrir `/tableau-de-bord/entrainement/<sessionId>/resultats` d'une session terminée (compte e2e existant), en émulation mobile, puis muter le DOM pendant le streaming pour simuler un tiers (dans la console : remplacer des text nodes pendant le chargement, ou activer la traduction de page si l'environnement le permet). Vérifier si `$RS` crash de la même façon.
+
+- [ ] **Step A5: Verdict**
+
+Choisir LE chemin : B1 (mismatch réel reproduit/identifié), B2 (mutation tierce confirmée ou fortement probable — ex. replay montrant la page traduite/altérée), B3 (rien de net). En cas de doute entre B2 et B3 → B3 (le spec interdit le filtre sans confirmation).
+
+**Phase B1 — Mismatch réel** (seulement si verdict B1)
+
+- [ ] **Step B1-1: Écrire le test qui échoue** — test de rendu du composant fautif reproduisant le mismatch (la forme exacte dépend du composant identifié ; suivre le pattern des tests existants dans `tests/`, happy-dom). Run: `bun run test -- <fichier>` → FAIL attendu.
+- [ ] **Step B1-2: Fix ciblé** du composant (ex. locale explicite `fr-CA`, extraction de l'horloge au scope module, alignement serveur/client du rendu conditionnel).
+- [ ] **Step B1-3: Tests + gates** — `bun run test -- <fichier>` PASS puis `bun run check`.
+- [ ] **Step B1-4: Commit**
+
+```bash
+git add <fichiers>
+git commit -m "fix: mismatch d'hydratation sur la page résultats d'entraînement (closes #104)"
+```
+
+**Phase B2 — Bruit tiers confirmé** (seulement si verdict B2)
+
+- [ ] **Step B2-1: Filtre `beforeSend` étroit dans `instrumentation-client.ts`**
+
+Ajouter au `Sentry.init` client (double condition message ET frame `$RS` — ne JAMAIS élargir) :
+
+```ts
+  // Un tiers (traduction/extension) qui mute le DOM pendant le streaming fait
+  // crasher le script inline $RS de React avec ce message précis — pas un bug
+  // applicatif. Double condition volontairement étroite : ne jamais l'élargir
+  // sans audit d'hydratation préalable.
+  beforeSend(event, hint) {
+    const error = hint.originalException
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? []
+    if (
+      error instanceof TypeError &&
+      error.message.includes("reading 'parentNode'") &&
+      frames.some((f) => f.function === "$RS")
+    ) {
+      return null
+    }
+    return event
+  },
+```
+
+- [ ] **Step B2-2: Documenter dans `.claude/rules/data-layer.md`** — ajouter une puce à la section Hydration existante : les erreurs `$RS`/`parentNode` d'origine tierce sont filtrées dans `instrumentation-client.ts` ; toute nouvelle erreur d'hydratation doit d'abord être auditée avant d'envisager d'étendre le filtre.
+- [ ] **Step B2-3: Gates** — `bun run check`.
+- [ ] **Step B2-4: Commit + clôture**
+
+```bash
+git add instrumentation-client.ts .claude/rules/data-layer.md
+git commit -m "chore: filtre le crash \$RS causé par la mutation tierce du DOM (closes #104)"
+sentry issue archive NOMAQBANQ-14
+```
+
+**Phase B3 — Non concluant** (seulement si verdict B3)
+
+- [ ] **Step B3-1: Contexte de diagnostic** — dans `instrumentation-client.ts`, ajouter le tag identifié comme discriminant en Phase A. Défaut raisonnable : marqueur de traduction du document au moment de l'erreur :
+
+```ts
+  beforeSend(event) {
+    // Marqueurs de traduction/mutation tierce du document : permettent de trier
+    // les erreurs d'hydratation « vrai bug » vs « DOM altéré par un tiers ».
+    event.tags = {
+      ...event.tags,
+      "document.lang": document.documentElement.lang || "(vide)",
+      "document.translated":
+        document.documentElement.classList.contains("translated-ltr") ||
+        document.documentElement.classList.contains("translated-rtl"),
+    }
+    return event
+  },
+```
+
+- [ ] **Step B3-2: Gates + commit**
+
+```bash
+bun run check
+git add instrumentation-client.ts
+git commit -m "chore: tags de diagnostic pour le crash \$RS de la page résultats (#104)"
+```
+
+- [ ] **Step B3-3: Consigner dans l'issue GitHub** (reste ouverte) :
+
+```bash
+gh issue comment 104 --body "Investigation du 2026-07-13 : <résumé des constats A1-A4>. Non concluant — tags de diagnostic ajoutés (document.lang, document.translated), on statue au prochain événement."
+```
+
+**Clôture Task 3 (tous chemins)**
+
+- [ ] **Step C1: Commenter l'issue #104 avec le verdict et le chemin pris** (B1/B2 : le commit référencé la ferme au merge ; B3 : commentaire du Step B3-3).
+
+---
+
+### Task 4: Finalisation
+
+- [ ] **Step 1: Suite complète + gates**
+
+```bash
+bun run check && bun run test:coverage
+```
+
+Expected: PASS (`bun run test` seul ne mesure pas la couverture — le seuil CI n'est appliqué que par `test:coverage`).
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin fix/sentry-fiabilite
+gh pr create --title "fix: fiabilité Sentry — pool pg, gate d'environnement, crash \$RS résultats (#103 #104 #105)" --body "<résumé des 3 commits + verdict investigation #104>"
+```
+
+Inclure dans le corps de la PR la clé de lecture post-déploiement du résiduel #103 : `pool.on("error")` couvre le cas idle (celui de NOMAQBANQ-Z) ; un client checked-out pendant `db.transaction` reste un chemin d'uncaughtException distinct — si l'issue Sentry se rouvre avec une stack transactionnelle, c'est ce chemin-là, pas un échec du fix.
+
+- [ ] **Step 3: Vérifications post-déploiement (à tracer dans la PR)** — plus d'événements `::1`/localhost dans Sentry ; événements tagués `environment` ; NOMAQBANQ-Z ne se rouvre pas ; NOMAQBANQ-14 selon le chemin (résolue / archivée / en observation).

--- a/docs/superpowers/specs/2026-07-13-sentry-fiabilite-design.md
+++ b/docs/superpowers/specs/2026-07-13-sentry-fiabilite-design.md
@@ -1,0 +1,107 @@
+# Campagne fiabilité Sentry — issues GitHub #103, #104, #105
+
+**Date** : 2026-07-13
+**Contexte** : triage Sentry du 2026-07-13 — backlog vidé (4 issues résolues), 2 vraies issues restantes (NOMAQBANQ-Z, NOMAQBANQ-14) + 1 cause racine de bruit (Sentry actif en dev). Chaque sujet a son issue GitHub : [#103](https://github.com/RinKhimera/NOMAQbanq/issues/103), [#104](https://github.com/RinKhimera/NOMAQbanq/issues/104), [#105](https://github.com/RinKhimera/NOMAQbanq/issues/105).
+
+## Objectif
+
+Éliminer le seul crash fatal récurrent de prod (#103), couper le bruit dev/e2e qui pollue le triage Sentry (#105), et statuer sur le crash d'hydratation de la page résultats d'entraînement (#104) par une investigation encadrée plutôt qu'un filtre à l'aveugle.
+
+## Livraison
+
+- Branche `fix/sentry-fiabilite` depuis `main`, **3 commits ciblés** (un par issue), **une PR**.
+- Ordre d'implémentation : **#105 → #103 → #104** (couper le bruit d'abord, mécanique ensuite, investigation en dernier).
+- Gates : `bun run check` + suite de tests existante. Pas de nouveau test sauf si le fix #104 touche du code applicatif.
+
+---
+
+## 1. #103 — Handler d'erreur sur le Pool pg
+
+**Problème** (Sentry NOMAQBANQ-Z, fatal, 8 événements / 6 users du 2026-06-25 au 2026-07-09) : `db/index.ts` crée le `Pool` pg sans listener `error`. Quand Neon (ou le réseau) coupe une connexion **idle** du pool, `pg` émet `error` sur le pool ; sans listener, Node lève `uncaughtException` → crash de l'instance Fluid Compute.
+
+**Fix** (`db/index.ts`) :
+
+```ts
+pool.on("error", (err) => {
+  console.warn("[pg pool] connexion idle perdue", err.message)
+})
+```
+
+- Le pool retire lui-même le client mort et en recrée un à la prochaine requête : il n'y a rien d'autre à faire que ne pas crasher.
+- `console.warn` n'est visible que dans les **logs Vercel** : sans `consoleLoggingIntegration` (opt-in, jamais activée par défaut), `console.*` ne devient qu'un breadcrumb — pas une entrée Sentry Logs, malgré `enableLogs: true`. Canal assumé et suffisant ; pas d'élargissement des `integrations`.
+- **Pas de `Sentry.captureException`** : une coupure idle gérée est un non-événement ; en faire des events recréerait du bruit (l'inverse de #105).
+- **Résiduel connu (accepté)** : un client **checked-out** (fenêtre `db.transaction`) n'est pas couvert — pg retire le listener du pool à l'acquisition et drizzle n'attache pas de listener `error` au client dédié. Si NOMAQBANQ-Z se rouvre avec une stack transactionnelle, c'est ce chemin résiduel, pas un échec du fix. À rappeler dans la PR comme clé de lecture post-déploiement.
+- **Pas de changement de timeouts** : `idleTimeoutMillis` de pg vaut 10 s par défaut (< les ~5 min du pooler Neon) et `attachDatabasePool` draine déjà à la suspension d'instance. Les événements résiduels (reprise d'instance, reset réseau) sont couverts par le handler. YAGNI.
+
+**Test** : aucun test dédié (config d'infra). Vérification post-déploiement : NOMAQBANQ-Z ne réapparaît pas (Sentry rouvre l'issue automatiquement en cas de récidive).
+
+---
+
+## 2. #105 — Gate d'environnement Sentry
+
+**Problème** : les 3 configs Sentry initialisent le SDK sans gate — tout run `bun dev` ou e2e local (`localhost`, IP `::1`) envoie ses erreurs dans le projet Sentry de prod. 3 des 6 issues du dernier triage étaient ce bruit.
+
+**Décision** : couper le dev local, **garder les previews Vercel** (détection d'erreurs avant merge), distinguer les environnements par tag.
+
+**Fix** — dans `instrumentation-client.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts` (+ une ligne dans `playwright.config.ts`) :
+
+```ts
+Sentry.init({
+  enabled:
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_SENTRY_DISABLED !== "1",
+  // serveur + edge :
+  environment: process.env.VERCEL_ENV ?? "development",
+  // client (VERCEL_ENV absent du bundle navigateur) :
+  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "production",
+  // ... reste inchangé
+})
+```
+
+- `NODE_ENV === "production"` coupe le **mode dev** (local et e2e locaux : `bun dev` = `NODE_ENV=development`) ; les builds preview et production Vercel envoient (les deux ont `NODE_ENV=production`).
+- **Kill-switch `NEXT_PUBLIC_SENTRY_DISABLED`** : le chemin e2e CI déjà présent dans le repo (`playwright.config.ts` : `bun run build && bun run start` avec `NODE_ENV=production` dès que `CI` est posé) échapperait à la gate `NODE_ENV` seule — le DSN étant hardcodé, un futur job e2e CI renverrait le bruit HeadlessChrome en prod. `playwright.config.ts` pose donc `NEXT_PUBLIC_SENTRY_DISABLED: "1"` dans `webServer.env` (inliné au build client par la commande CI, lu au runtime par serveur/edge). La variable est absente des déploiements Vercel → aucun risque d'éteindre la prod, contrairement à une gate composée sur `NEXT_PUBLIC_VERCEL_ENV` qui dépendrait du toggle système-env.
+- `environment` : `production` / `preview` filtrables dans les issues et alertes Sentry.
+- **Côté client**, le fallback est `"production"` (pas `"development"`) : si `NEXT_PUBLIC_VERCEL_ENV` manque dans le bundle, `enabled` garantit déjà qu'on est dans un build prod — mal taguer en `development` un événement de prod serait pire que le fallback optimiste.
+- **Prérequis à vérifier à l'implémentation** : l'option Vercel « Automatically expose System Environment Variables » doit être active pour que `NEXT_PUBLIC_VERCEL_ENV` existe. Vérification par le dashboard (Settings → Environment Variables) ou en lecture seule via `vercel api "/v9/projects/<projet>"` → champ `autoExposeSystemEnvs` (`vercel env ls` ne liste PAS les variables système et ne peut pas répondre). Si l'option est inactive : l'activer (préférence), le fallback couvrant l'intervalle.
+- Le tunnel `/monitoring` (next.config.ts) et les DSN hardcodés ne bougent pas.
+
+**Test** : aucun test dédié. Vérification : `bun run build` passe ; après déploiement, plus aucun événement `::1`/`localhost` dans Sentry ; les événements portent le tag `environment`.
+
+---
+
+## 3. #104 — Crash $RS / hydratation sur la page résultats d'entraînement
+
+**Problème** (Sentry NOMAQBANQ-14, 3 événements / 3 users du 2026-06-29 au 2026-07-13, encore présent sur la release courante) : sur `/tableau-de-bord/entrainement/[sessionId]/resultats`, séquence React error **#418** (mismatch d'hydratation) → `TypeError: Cannot read properties of null (reading 'parentNode')` dans `$RS` (script inline du streaming React) → crash non géré. Chrome Mobile / Android uniquement.
+
+**État de l'exploration préalable** (fait au design) :
+
+- Aucun `toLocaleString`/`Intl`/`new Date()`/`Date.now()`/`Math.random()` dans `components/quiz/results/**` ni dans la page — l'hypothèse « formatage locale-dépendant » (pattern connu du projet, `.claude/rules/data-layer.md`) **ne colle pas** sur ce périmètre.
+- L'utilisateur du dernier événement est à Kinshasa (francophone) — l'hypothèse « Google Translate » n'est **pas automatique** non plus (site déjà en français).
+
+**Phase A — investigation (timeboxée ~30-45 min)** :
+
+1. Visionner le replay Sentry (`b57925147b3a45a082f677685fb780dc`) et les tags des 3 événements (navigateurs, versions, marqueurs de traduction/extension).
+2. Étendre l'audit d'hydratation à **tout l'arbre réellement rendu** par la page (pas seulement les fichiers au nom évocateur) : `SessionResultsHeader`, layout `(dashboard)`, sidebar, et les sous-arbres importés par `SessionResults` — `components/quiz/question-card/` (la 1re question est dépliée par défaut, donc rendue côté serveur), `components/quiz/session/`, `hooks/` — rendu conditionnel `typeof window`, ids non déterministes, contenu dépendant du viewport, attributs différant serveur/client.
+3. Tentative de repro dans un vrai navigateur : émulation mobile + traduction forcée de la page (et/ou extension mutant le DOM).
+
+**Phase B — décision (arbre encodé, un seul des trois chemins)** :
+
+- **B1 · Mismatch réel identifié** → fix ciblé du composant fautif ; test si code applicatif touché ; NOMAQBANQ-14 résolue.
+- **B2 · Mutation du DOM par un tiers confirmée ou fortement probable** → filtre `beforeSend` **étroit** dans `instrumentation-client.ts` : drop uniquement si le message est `Cannot read properties of null (reading 'parentNode')` **et** qu'une frame de la stack est `$RS`. Documenter le pattern dans `.claude/rules/data-layer.md` ; archiver NOMAQBANQ-14 ; fermer #104 en « bruit tiers documenté ».
+- **B3 · Non concluant** → **aucun filtre à l'aveugle**. Ajouter du contexte de diagnostic (tag/contexte Sentry pertinent identifié en phase A, p. ex. marqueur de traduction du document) pour affiner au prochain événement ; consigner l'état dans l'issue GitHub #104, qui reste ouverte.
+
+**Critère de done** : un des trois chemins B est pris et tracé (commit + commentaire d'issue).
+
+---
+
+## Hors périmètre
+
+- Refonte de l'échantillonnage (`tracesSampleRate`, replays) — inchangé.
+- Alerting Sentry (règles, notifications) — inchangé.
+- Tout durcissement générique anti-extensions (meta `notranslate`, etc.) — refusé sauf preuve en B2 que c'est la cause ET qu'un filtre ne suffit pas.
+
+## Risques
+
+- **#105** : si `NEXT_PUBLIC_VERCEL_ENV` n'est pas exposée, les événements client prod/preview seront tous tagués `production` (fallback) jusqu'à activation de l'option — dégradé acceptable, corrigeable sans code.
+- **#104-B2** : un filtre trop large masquerait de vrais bugs — d'où la double condition message + frame `$RS`, et le refus explicite du chemin B2 sans confirmation en phase A.
+- **#103** : les coupures gérées ne sont visibles que dans les logs Vercel — c'est l'état **nominal** (pas un mode dégradé, cf. la note Sentry Logs de la section 1). Réévaluer si des symptômes applicatifs (latence, erreurs de requête) apparaissent. Résiduel « client checked-out en transaction » documenté section 1.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -38,6 +38,23 @@ Sentry.init({
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+
+  // Un tiers (traduction/extension) qui mute le DOM pendant le streaming fait
+  // crasher le script inline $RS de React avec ce message précis — pas un bug
+  // applicatif. Double condition volontairement étroite : ne jamais l'élargir
+  // sans audit d'hydratation préalable.
+  beforeSend(event, hint) {
+    const error = hint.originalException
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? []
+    if (
+      error instanceof TypeError &&
+      error.message.includes("reading 'parentNode'") &&
+      frames.some((f) => f.function === "$RS")
+    ) {
+      return null
+    }
+    return event
+  },
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -6,6 +6,15 @@ import * as Sentry from "@sentry/nextjs"
 Sentry.init({
   dsn: "https://c7c726531f3e9dc07a6488f3bd7ae9b4@o4510410010787842.ingest.us.sentry.io/4510410016227333",
 
+  // Dev local et e2e (y compris le build prod du chemin CI, via le kill-switch)
+  // ne doivent jamais polluer le projet Sentry de prod.
+  enabled:
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_SENTRY_DISABLED !== "1",
+  // VERCEL_ENV n'existe pas dans le bundle navigateur ; fallback "production"
+  // (et pas "development") : `enabled` garantit déjà qu'on est en build prod.
+  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "production",
+
   integrations: [
     Sentry.replayIntegration({
       maskAllText: false,

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,6 +2,7 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs"
+import { isThirdPartyRsCrash } from "@/lib/sentry-filters"
 
 Sentry.init({
   dsn: "https://c7c726531f3e9dc07a6488f3bd7ae9b4@o4510410010787842.ingest.us.sentry.io/4510410016227333",
@@ -39,21 +40,8 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
 
-  // Un tiers (traduction/extension) qui mute le DOM pendant le streaming fait
-  // crasher le script inline $RS de React avec ce message précis — pas un bug
-  // applicatif. Double condition volontairement étroite : ne jamais l'élargir
-  // sans audit d'hydratation préalable.
   beforeSend(event, hint) {
-    const error = hint.originalException
-    const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? []
-    if (
-      error instanceof TypeError &&
-      error.message.includes("reading 'parentNode'") &&
-      frames.some((f) => f.function === "$RS")
-    ) {
-      return null
-    }
-    return event
+    return isThirdPartyRsCrash(event, hint) ? null : event
   },
 })
 

--- a/lib/sentry-filters.ts
+++ b/lib/sentry-filters.ts
@@ -1,0 +1,18 @@
+import type { ErrorEvent, EventHint } from "@sentry/nextjs"
+
+// Un tiers (traduction/extension) qui mute le DOM pendant le streaming fait
+// crasher le script inline $RS de React avec ce message précis — pas un bug
+// applicatif. Double condition volontairement étroite : ne jamais l'élargir
+// sans audit d'hydratation préalable (voir .claude/rules/data-layer.md).
+export function isThirdPartyRsCrash(
+  event: ErrorEvent,
+  hint: EventHint,
+): boolean {
+  const error = hint.originalException
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? []
+  return (
+    error instanceof TypeError &&
+    error.message.includes("reading 'parentNode'") &&
+    frames.some((f) => f.function === "$RS")
+  )
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -113,6 +113,9 @@ export default defineConfig({
     timeout: 120_000,
     env: {
       NODE_ENV: process.env.CI ? "production" : "development",
+      // Le chemin CI tourne en build production : sans ce kill-switch, le DSN
+      // hardcodé enverrait le bruit HeadlessChrome dans le projet Sentry de prod.
+      NEXT_PUBLIC_SENTRY_DISABLED: "1",
     },
   },
 })

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -7,6 +7,13 @@ import * as Sentry from "@sentry/nextjs"
 Sentry.init({
   dsn: "https://c7c726531f3e9dc07a6488f3bd7ae9b4@o4510410010787842.ingest.us.sentry.io/4510410016227333",
 
+  // Dev local et e2e (y compris le build prod du chemin CI, via le kill-switch)
+  // ne doivent jamais polluer le projet Sentry de prod.
+  enabled:
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_SENTRY_DISABLED !== "1",
+  environment: process.env.VERCEL_ENV ?? "development",
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,6 +6,13 @@ import * as Sentry from "@sentry/nextjs"
 Sentry.init({
   dsn: "https://c7c726531f3e9dc07a6488f3bd7ae9b4@o4510410010787842.ingest.us.sentry.io/4510410016227333",
 
+  // Dev local et e2e (y compris le build prod du chemin CI, via le kill-switch)
+  // ne doivent jamais polluer le projet Sentry de prod.
+  enabled:
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_SENTRY_DISABLED !== "1",
+  environment: process.env.VERCEL_ENV ?? "development",
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 

--- a/tests/lib/sentry-filters.test.ts
+++ b/tests/lib/sentry-filters.test.ts
@@ -1,0 +1,54 @@
+import type { ErrorEvent, EventHint } from "@sentry/nextjs"
+import { describe, expect, it } from "vitest"
+import { isThirdPartyRsCrash } from "@/lib/sentry-filters"
+
+const eventWithFrames = (fns: (string | undefined)[]): ErrorEvent =>
+  ({
+    exception: {
+      values: [{ stacktrace: { frames: fns.map((f) => ({ function: f })) } }],
+    },
+  }) as ErrorEvent
+
+const rsError = new TypeError(
+  "Cannot read properties of null (reading 'parentNode')",
+)
+
+describe("isThirdPartyRsCrash", () => {
+  it("droppe le crash $RS canonique (TypeError parentNode + frame $RS)", () => {
+    const event = eventWithFrames(["<anonymous>", "$RS"])
+    const hint: EventHint = { originalException: rsError }
+    expect(isThirdPartyRsCrash(event, hint)).toBe(true)
+  })
+
+  it("laisse passer la même erreur sans frame $RS (code applicatif)", () => {
+    const event = eventWithFrames(["handleClick", "commitRoot"])
+    const hint: EventHint = { originalException: rsError }
+    expect(isThirdPartyRsCrash(event, hint)).toBe(false)
+  })
+
+  it("laisse passer une erreur non-TypeError même avec frame $RS", () => {
+    const event = eventWithFrames(["$RS"])
+    const hint: EventHint = {
+      originalException: new Error(
+        "Cannot read properties of null (reading 'parentNode')",
+      ),
+    }
+    expect(isThirdPartyRsCrash(event, hint)).toBe(false)
+  })
+
+  it("laisse passer une TypeError d'un autre message", () => {
+    const event = eventWithFrames(["$RS"])
+    const hint: EventHint = {
+      originalException: new TypeError(
+        "Cannot read properties of null (reading 'appendChild')",
+      ),
+    }
+    expect(isThirdPartyRsCrash(event, hint)).toBe(false)
+  })
+
+  it("laisse passer un événement sans stacktrace", () => {
+    const event = {} as ErrorEvent
+    const hint: EventHint = { originalException: rsError }
+    expect(isThirdPartyRsCrash(event, hint)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Résumé

Campagne issue du triage Sentry du 2026-07-13 (backlog vidé). Un commit ciblé par issue + deux commits de suivi issus de la revue adversariale d'implémentation (verdict : mergeable). Spec + plan committés (`docs/superpowers/specs/2026-07-13-sentry-fiabilite-design.md`), design ET implémentation passés en revue adversariale.

### #105 — Gate d'environnement Sentry (`chore: gate Sentry hors production…`)
- `enabled: NODE_ENV === "production" && NEXT_PUBLIC_SENTRY_DISABLED !== "1"` dans les 3 configs (client/serveur/edge) : le dev local et les e2e ne polluent plus le projet Sentry de prod. Vérifié dans le SDK installé : `enabled: false` gate toutes les envelopes (errors, traces, replays, logs).
- Kill-switch `NEXT_PUBLIC_SENTRY_DISABLED: "1"` posé dans `webServer.env` de `playwright.config.ts` : couvre le chemin e2e CI qui force `NODE_ENV=production` (Playwright merge `env` avec l'env parent — le serveur local ne perd rien).
- **⚠️ Tag `environment` renommé, pas ajouté** : le SDK taguait déjà `vercel-production` par défaut ; les nouveaux événements porteront `production`/`preview` (via `VERCEL_ENV` / `NEXT_PUBLIC_VERCEL_ENV`). L'historique Sentry sera scindé en deux valeurs — l'unique alerte du projet n'a pas de filtre environnement, rien ne casse, mais les recherches Sentry sur l'historique devront couvrir les deux valeurs. (`autoExposeSystemEnvs: true` vérifié ; le tag client historique prouve que `NEXT_PUBLIC_VERCEL_ENV` est déjà exposée — le fallback `"production"` ne jouera jamais sur Vercel.)

### #103 — Handler d'erreur sur le Pool pg (`fix: ne plus crasher…`)
- `pool.on("error", …)` dans `db/index.ts` : une connexion idle coupée par Neon ne provoque plus d'`uncaughtException` fatale (Sentry NOMAQBANQ-Z, 8 événements / 6 users). Le pool remplace le client mort tout seul ; `console.warn` visible dans les logs Vercel, **avec `err.code`** (57P01, ECONNRESET…) pour discriminer coupure bénigne vs problème émergent (suivi revue).
- **Clé de lecture post-déploiement** : ce handler couvre le cas *idle* (celui de NOMAQBANQ-Z, stack `pg/lib/client.js:199` hors requête). Un client **checked-out** pendant `db.transaction` reste un chemin d'uncaughtException distinct et non couvert (pg retire le listener du pool à l'acquisition) — si l'issue Sentry se rouvre avec une stack transactionnelle, c'est ce résiduel connu, pas un échec du fix. L'événement `error` du pool n'existe que pour les clients idle déjà connectés : le handler ne peut masquer ni un mauvais mot de passe ni un épuisement du pool.

### #104 — Crash $RS page résultats d'entraînement (`chore: filtre le crash $RS…`)
- Investigation (verdict détaillé commenté sur #104) : mutation tierce du DOM fortement probable — un seul appareil touché (même sous-réseau Kinshasa, 2 releases différentes), React #418 avec `args[]=HTML` (mismatch structurel, pas textuel), trois audits d'hydratation du code blancs.
- Filtre `beforeSend` volontairement étroit, prédicat extrait dans `lib/sentry-filters.ts` et **couvert par 5 tests** (suivi revue) : drop uniquement si TypeError `reading 'parentNode'` **ET** frame `$RS`. Vérifié contre l'événement de prod réel ; aucune fonction applicative nommée `$RS` ; le React #418 compagnon n'est pas filtré. Documenté dans `.claude/rules/data-layer.md` avec interdiction d'élargir sans audit. NOMAQBANQ-14 archivée.

## Vérifications post-déploiement
- [ ] Plus aucun événement `::1`/`localhost` dans Sentry
- [ ] Les nouveaux événements portent `environment: production`/`preview` (ancienne valeur : `vercel-production`)
- [ ] NOMAQBANQ-Z ne se rouvre pas (sinon : vérifier si la stack est transactionnelle → résiduel connu ci-dessus)
- [ ] NOMAQBANQ-14 reste archivée (le filtre droppe le pattern $RS)

## Gates
- `bun run check` ✅ · `bun run build` ✅ · `bun run test:coverage` ✅ (82,66 % statements, seuil 80 %) · 5 nouveaux tests `tests/lib/sentry-filters.test.ts` ✅

Closes #103, closes #104, closes #105