### PR TITLE
fix: récupération du merge fantôme PR #96 — #84/#85 stats marketing, #87 doc Stripe, #88 nettoyage

### DIFF
--- a/app/(dashboard)/tableau-de-bord/profil/_components/profile-preferences.tsx
+++ b/app/(dashboard)/tableau-de-bord/profil/_components/profile-preferences.tsx
@@ -5,7 +5,6 @@ import { Monitor } from "lucide-react"
 import { motion, useReducedMotion } from "motion/react"
 import { useTheme } from "next-themes"
 import { useSyncExternalStore } from "react"
-import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { NotificationPreferences } from "@/features/notifications/dal"
 import { cn } from "@/lib/utils"
@@ -21,7 +20,6 @@ const PreferenceItem = ({
   label,
   description,
   children,
-  disabled = false,
   responsive = false,
 }: {
   icon: React.ComponentType<{ className?: string }>
@@ -30,18 +28,12 @@ const PreferenceItem = ({
   label: string
   description: string
   children: React.ReactNode
-  disabled?: boolean
   responsive?: boolean
 }) => {
   // Version responsive avec container queries
   if (responsive) {
     return (
-      <div
-        className={cn(
-          "@container rounded-xl p-4 transition-colors",
-          disabled && "opacity-60",
-        )}
-      >
+      <div className="@container rounded-xl p-4 transition-colors">
         <div className="flex flex-col gap-4 @[420px]:flex-row @[420px]:items-start">
           <div className="flex items-start gap-4 @[420px]:flex-1">
             <div
@@ -73,12 +65,7 @@ const PreferenceItem = ({
 
   // Version standard (non responsive)
   return (
-    <div
-      className={cn(
-        "flex items-start gap-4 rounded-xl p-4 transition-colors",
-        disabled && "opacity-60",
-      )}
-    >
+    <div className="flex items-start gap-4 rounded-xl p-4 transition-colors">
       <div
         className={cn(
           "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl",
@@ -88,17 +75,7 @@ const PreferenceItem = ({
         <Icon className={cn("h-5 w-5", iconColorClass)} />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <p className="font-medium text-gray-900 dark:text-white">{label}</p>
-          {disabled && (
-            <Badge
-              variant="secondary"
-              className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500 dark:bg-gray-800"
-            >
-              Bientôt
-            </Badge>
-          )}
-        </div>
+        <p className="font-medium text-gray-900 dark:text-white">{label}</p>
         <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
           {description}
         </p>

--- a/app/(marketing)/_components/home-landing.tsx
+++ b/app/(marketing)/_components/home-landing.tsx
@@ -21,6 +21,7 @@ import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { MARKETING_CLAIMS } from "@/constants"
 import { useMarketingStats } from "@/hooks/useMarketingStats"
 
 export default function HomeLanding() {
@@ -209,7 +210,8 @@ export default function HomeLanding() {
                     </div>
                     <div>
                       <p className="font-semibold text-gray-900 dark:text-white">
-                        85% de réussite
+                        {stats?.successRate ?? MARKETING_CLAIMS.successRate} de
+                        réussite
                       </p>
                       <p className="text-sm text-gray-600 dark:text-gray-400">
                         Taux de succès
@@ -222,7 +224,7 @@ export default function HomeLanding() {
                   <div className="flex items-center space-x-2">
                     <Star className="h-5 w-5 fill-current text-yellow-500" />
                     <span className="text-sm font-semibold text-gray-900 dark:text-white">
-                      4.9/5
+                      {MARKETING_CLAIMS.rating}
                     </span>
                   </div>
                 </div>

--- a/app/(marketing)/a-propos/_components/a-propos-page-client.tsx
+++ b/app/(marketing)/a-propos/_components/a-propos-page-client.tsx
@@ -2,6 +2,8 @@
 
 import { Award, CircleCheckBig } from "lucide-react"
 import Image from "next/image"
+import { MARKETING_CLAIMS } from "@/constants"
+import { useMarketingStats } from "@/hooks/useMarketingStats"
 import AboutCTA from "./about-cta"
 import AboutHeader from "./about-header"
 import AboutMissions from "./about-missions"
@@ -10,6 +12,7 @@ import AboutStory from "./about-story"
 import AboutTestimonials from "./about-testimonials"
 
 export default function AProposPageClient() {
+  const { stats } = useMarketingStats()
   return (
     <div className="theme-bg">
       <div className="mx-auto max-w-7xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
@@ -55,7 +58,8 @@ export default function AProposPageClient() {
                 </div>
                 <div>
                   <p className="font-semibold text-gray-900 dark:text-white">
-                    85% de réussite
+                    {stats?.successRate ?? MARKETING_CLAIMS.successRate} de
+                    réussite
                   </p>
                   <p className="text-sm text-gray-600 dark:text-gray-400">
                     Taux de succès

--- a/app/(marketing)/a-propos/_components/about-story.tsx
+++ b/app/(marketing)/a-propos/_components/about-story.tsx
@@ -2,6 +2,7 @@
 
 import { Heart, Star } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
+import { MARKETING_CLAIMS } from "@/constants"
 import { useMarketingStats } from "@/hooks/useMarketingStats"
 
 export default function AboutStory() {
@@ -30,8 +31,9 @@ export default function AboutStory() {
           </p>
           <p>
             Aujourd&apos;hui, nous accompagnons des centaines de candidats vers
-            la réussite, avec un taux de succès de {stats?.successRate ?? "85%"}{" "}
-            parmi nos utilisateurs actifs.
+            la réussite, avec un taux de succès de{" "}
+            {stats?.successRate ?? MARKETING_CLAIMS.successRate} parmi nos
+            utilisateurs actifs.
           </p>
         </div>
 

--- a/app/(marketing)/a-propos/page.tsx
+++ b/app/(marketing)/a-propos/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from "next"
+import { MARKETING_CLAIMS } from "@/constants"
 import AProposPageClient from "./_components/a-propos-page-client"
 
 export const metadata: Metadata = {
   title: "À propos",
-  description:
-    "Découvrez NOMAQbanq : notre mission, notre équipe et notre engagement envers la communauté médicale francophone. 85% de taux de réussite, des milliers de candidats accompagnés.",
+  description: `Découvrez NOMAQbanq : notre mission, notre équipe et notre engagement envers la communauté médicale francophone. ${MARKETING_CLAIMS.successRate} de taux de réussite, des milliers de candidats accompagnés.`,
   alternates: {
     canonical: "https://nomaqbanq.ca/a-propos",
     languages: {
@@ -13,8 +13,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "À propos de NOMAQbanq",
-    description:
-      "Notre mission : accompagner les médecins francophones vers la réussite à l'EACMC. 85% de taux de réussite, des milliers de candidats satisfaits.",
+    description: `Notre mission : accompagner les médecins francophones vers la réussite à l'EACMC. ${MARKETING_CLAIMS.successRate} de taux de réussite, des milliers de candidats satisfaits.`,
     images: [
       {
         url: "/images/home-image.jpg",

--- a/app/(marketing)/tarifs/_components/pricing-header.tsx
+++ b/app/(marketing)/tarifs/_components/pricing-header.tsx
@@ -4,6 +4,7 @@ import { Award, CircleCheckBig, Sparkles, Star, Users } from "lucide-react"
 import { motion } from "motion/react"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { MARKETING_CLAIMS } from "@/constants"
 import { useMarketingStats } from "@/hooks/useMarketingStats"
 
 export const PricingHeader = () => {
@@ -134,7 +135,7 @@ export const PricingHeader = () => {
               ))}
             </div>
             <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-              4.9/5
+              {MARKETING_CLAIMS.rating}
             </span>
           </motion.div>
         </div>

--- a/constants/index.tsx
+++ b/constants/index.tsx
@@ -129,3 +129,13 @@ export const FOOTER_LEGAL_LINKS = [
   { name: "Conditions d'utilisation", href: "/conditions" },
   { name: "Cookies", href: "/cookies" },
 ] as const
+
+/**
+ * Claims marketing ÉDITORIAUX (non calculés). `successRate` sert de repli quand
+ * le vrai taux (features/marketing/dal.ts) n'est pas publiable (volume ou
+ * plancher). `rating` reste 100 % éditorial : aucun système d'avis en base.
+ */
+export const MARKETING_CLAIMS = {
+  successRate: "85%",
+  rating: "4.9/5",
+} as const

--- a/docs/STRIPE_FRONTEND_SPEC.md
+++ b/docs/STRIPE_FRONTEND_SPEC.md
@@ -15,7 +15,8 @@
 3. Le client est redirigé vers `checkoutUrl` (page Stripe hébergée).
 4. Paiement sur Stripe → redirection vers `successPath?session_id={CHECKOUT_SESSION_ID}`.
 5. En parallèle, Stripe POST le webhook `app/api/stripe/webhook/route.ts`
-   (signature vérifiée) → sur `checkout.session.completed` + `payment_status: "paid"`,
+   (signature vérifiée) → sur `checkout.session.completed` + `payment_status`
+   `"paid"` ou `"no_payment_required"` (promo 100 %, #92),
    appelle `completeStripeTransaction` (features/payments/stripe.ts).
 6. `completeStripeTransaction` (idempotent via `stripeEventId`) passe la
    transaction à `completed`, persiste le montant/devise réellement facturés, et

--- a/docs/STRIPE_FRONTEND_SPEC.md
+++ b/docs/STRIPE_FRONTEND_SPEC.md
@@ -1,603 +1,78 @@
-# Spécification Frontend - Intégration Stripe NOMAQbanq
+# Paiements Stripe — architecture actuelle (Drizzle / Better Auth)
 
-## Résumé
+> Stack backend : Drizzle/Neon + Better Auth (voir `AGENTS.md` et
+> `.claude/rules/data-layer.md`). Ce document décrit le flux de paiement **tel
+> qu'il existe** — toutes les pages listées sont déjà implémentées.
 
-Le backend Stripe est entièrement implémenté. Ce document décrit les fonctions Convex disponibles et comment les utiliser côté frontend pour implémenter les pages de paiement.
-
----
-
-## Configuration requise
-
-### Variables d'environnement (.env.local)
-
-```bash
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_... # ou pk_live_...
-```
-
-### Installation (déjà fait)
-
-```bash
-npm install stripe @stripe/stripe-js
-```
-
----
-
-## Architecture des paiements
-
-### Produits disponibles
-
-| Code                    | Nom                         | Prix    | Durée     | Type d'accès |
-| ----------------------- | --------------------------- | ------- | --------- | ------------ |
-| `exam_access`           | Accès Examens - 1 mois      | 50 CAD  | 30 jours  | exam         |
-| `training_access`       | Accès Entraînement - 1 mois | 50 CAD  | 30 jours  | training     |
-| `exam_access_promo`     | Accès Examens - 6 mois      | 200 CAD | 180 jours | exam         |
-| `training_access_promo` | Accès Entraînement - 6 mois | 200 CAD | 180 jours | training     |
-
-### Flux de paiement Stripe
+## Flux de paiement
 
 ```
-1. User clique "Acheter"
-2. Frontend appelle createCheckoutSession(productCode, successUrl, cancelUrl)
-3. Backend crée session Stripe + transaction "pending"
-4. Frontend redirige vers checkoutUrl (page Stripe hosted)
-5. User paie sur Stripe
-6. Stripe redirige vers successUrl?session_id=xxx
-7. Webhook Stripe → completeStripeTransaction → userAccess créé/mis à jour
-8. Frontend affiche page de succès
+1. L'utilisateur clique « Acheter » (page /tarifs ou paywall).
+2. Server Action `createStripeCheckout({ productCode, successPath, cancelPath })`
+   (features/payments/actions.ts) : garde `requireSession`, crée la session
+   Stripe Checkout (mode "payment", customer_email, metadata userId/productId/…)
+   ET insère une transaction `status: "pending"`.
+3. Le client est redirigé vers `checkoutUrl` (page Stripe hébergée).
+4. Paiement sur Stripe → redirection vers `successPath?session_id={CHECKOUT_SESSION_ID}`.
+5. En parallèle, Stripe POST le webhook `app/api/stripe/webhook/route.ts`
+   (signature vérifiée) → sur `checkout.session.completed` + `payment_status: "paid"`,
+   appelle `completeStripeTransaction` (features/payments/stripe.ts).
+6. `completeStripeTransaction` (idempotent via `stripeEventId`) passe la
+   transaction à `completed`, persiste le montant/devise réellement facturés, et
+   crée/prolonge la ligne `userAccess` (cumul du temps d'accès).
+7. La page de succès (`/tableau-de-bord/paiement/succes`) appelle
+   `verifyStripeCheckout(sessionId)` pour AFFICHER le statut — elle ne crédite
+   PAS l'accès (c'est le webhook qui fait foi). Anti-IDOR : la session est
+   refusée si `metadata.userId` ≠ utilisateur courant.
 ```
 
-### Cumul du temps
-
-Si un utilisateur a déjà un accès actif et achète à nouveau :
-
-- Le nouveau temps est **ajouté** à l'expiration existante
-- Exemple : 15 jours restants + 30 jours achetés = 45 jours total
-
----
-
-## Fonctions Convex disponibles
-
-### Queries - Accès utilisateur
-
-#### `payments.hasExamAccess`
-
-Vérifie si l'utilisateur a un accès actif aux examens.
-
-```typescript
-import { useQuery } from "convex/react"
-import { api } from "@/convex/_generated/api"
-
-const hasAccess = useQuery(api.payments.hasExamAccess)
-// Returns: boolean
-```
-
-#### `payments.hasTrainingAccess`
-
-Vérifie si l'utilisateur a un accès actif à l'entraînement.
-
-```typescript
-const hasAccess = useQuery(api.payments.hasTrainingAccess)
-// Returns: boolean
-```
-
-#### `payments.getMyAccessStatus`
-
-Récupère le statut complet des accès de l'utilisateur.
-
-```typescript
-const accessStatus = useQuery(api.payments.getMyAccessStatus)
-// Returns:
-// {
-//   examAccess: { expiresAt: number, daysRemaining: number } | null,
-//   trainingAccess: { expiresAt: number, daysRemaining: number } | null
-// }
-```
-
-### Queries - Produits
-
-#### `payments.getAvailableProducts`
-
-Liste tous les produits actifs disponibles à l'achat.
-
-```typescript
-const products = useQuery(api.payments.getAvailableProducts)
-// Returns: Array<{
-//   _id: Id<"products">,
-//   code: "exam_access" | "training_access" | "exam_access_promo" | "training_access_promo",
-//   name: string,
-//   description: string,
-//   priceCAD: number,      // En cents (5000 = 50$)
-//   durationDays: number,
-//   accessType: "exam" | "training",
-//   stripeProductId: string,
-//   stripePriceId: string,
-//   isActive: boolean
-// }>
-```
-
-### Queries - Transactions utilisateur
-
-#### `payments.getMyTransactions`
-
-Historique des transactions de l'utilisateur connecté (paginé).
-
-```typescript
-import { usePaginatedQuery } from "convex/react"
-
-const { results, status, loadMore } = usePaginatedQuery(
-  api.payments.getMyTransactions,
-  {},
-  { initialNumItems: 10 },
-)
-// Returns paginated:
-// {
-//   _id: Id<"transactions">,
-//   type: "stripe" | "manual",
-//   status: "pending" | "completed" | "failed" | "refunded",
-//   amountPaid: number,
-//   currency: string,
-//   accessType: "exam" | "training",
-//   durationDays: number,
-//   createdAt: number,
-//   completedAt?: number,
-//   product: { name: string, ... } | null
-// }
-```
-
-### Actions Stripe
-
-#### `stripe.createCheckoutSession`
-
-Crée une session de paiement Stripe et retourne l'URL de redirection.
-
-```typescript
-import { useAction } from "convex/react"
-import { api } from "@/convex/_generated/api"
-
-const createCheckout = useAction(api.stripe.createCheckoutSession)
-
-// Usage
-const handleBuy = async (productCode: string) => {
-  try {
-    const { checkoutUrl, sessionId } = await createCheckout({
-      productCode: productCode as
-        | "exam_access"
-        | "training_access"
-        | "exam_access_promo"
-        | "training_access_promo",
-      successUrl: `${window.location.origin}/payment/success`,
-      cancelUrl: `${window.location.origin}/pricing`,
-    })
-
-    if (checkoutUrl) {
-      window.location.href = checkoutUrl
-    }
-  } catch (error) {
-    console.error("Erreur lors de la création du checkout:", error)
-  }
-}
-```
-
-#### `stripe.verifyCheckoutSession`
-
-Vérifie le statut d'une session après retour de Stripe (page de succès).
-
-```typescript
-const verifySession = useAction(api.stripe.verifyCheckoutSession)
-
-// Usage (dans la page de succès)
-const sessionId = searchParams.get("session_id")
-const result = await verifySession({ sessionId })
-// Returns:
-// {
-//   success: boolean,
-//   status: string,
-//   customerEmail: string,
-//   metadata: object,
-//   amountTotal: number,
-//   currency: string
-// }
-```
-
-#### `stripe.createCustomerPortalSession`
-
-Crée une session pour le portail client Stripe (gestion des factures).
-
-```typescript
-const createPortal = useAction(api.stripe.createCustomerPortalSession)
-
-const handleManageBilling = async () => {
-  const { portalUrl } = await createPortal({
-    returnUrl: `${window.location.origin}/account`,
-  })
-  window.location.href = portalUrl
-}
-```
-
----
-
-## Queries Admin
-
-#### `payments.getAllTransactions`
-
-Toutes les transactions avec filtres (admin seulement).
-
-```typescript
-const { results, status, loadMore } = usePaginatedQuery(
-  api.payments.getAllTransactions,
-  {
-    type: "stripe", // Optionnel: "stripe" | "manual"
-    status: "completed", // Optionnel: "pending" | "completed" | "failed" | "refunded"
-    userId: userId, // Optionnel: Id<"users">
-  },
-  { initialNumItems: 20 },
-)
-// Returns enriched transactions with user and product details
-```
-
-#### `payments.getTransactionStats`
-
-Statistiques pour le dashboard admin.
-
-```typescript
-const stats = useQuery(api.payments.getTransactionStats)
-// Returns:
-// {
-//   totalRevenue: number,        // En cents
-//   totalTransactions: number,
-//   recentRevenue: number,       // 30 derniers jours
-//   recentTransactions: number,
-//   stripeTransactions: number,
-//   manualTransactions: number
-// }
-```
-
-#### `payments.getUserAccessStatus`
-
-Statut d'accès d'un utilisateur spécifique (admin).
-
-```typescript
-const userAccess = useQuery(api.payments.getUserAccessStatus, { userId })
-// Returns same format as getMyAccessStatus
-```
-
-### Mutations Admin
-
-#### `payments.recordManualPayment`
-
-Enregistre un paiement manuel (cash, Interac, etc.).
-
-```typescript
-const recordPayment = useMutation(api.payments.recordManualPayment)
-
-await recordPayment({
-  userId: userId, // Id<"users">
-  productCode: "exam_access", // ProductCode
-  amountPaid: 5000, // En cents
-  currency: "CAD",
-  paymentMethod: "interac", // "cash" | "interac" | "virement" | etc.
-  notes: "Paiement reçu le 15 janvier", // Optionnel
-})
-```
-
-#### `payments.upsertProduct`
-
-Crée ou met à jour un produit (admin, nécessite auth).
-
-```typescript
-const upsertProduct = useMutation(api.payments.upsertProduct)
-
-await upsertProduct({
-  code: "exam_access",
-  name: "Accès Examens - 1 mois",
-  description: "...",
-  priceCAD: 5000,
-  durationDays: 30,
-  accessType: "exam",
-  stripeProductId: "prod_xxx",
-  stripePriceId: "price_xxx",
-  isActive: true,
-})
-```
-
----
-
-## Pages à implémenter
-
-### 1. Page Pricing (`/pricing` ou `/tarifs`)
-
-**Objectif** : Afficher les produits et permettre l'achat.
-
-**Fonctions utilisées** :
-
-- `useQuery(api.payments.getAvailableProducts)` - Liste des produits
-- `useQuery(api.payments.getMyAccessStatus)` - Accès actuels (pour afficher "Déjà actif")
-- `useAction(api.stripe.createCheckoutSession)` - Lancer le paiement
-
-**UI suggérée** :
-
-- Grille de cartes produits
-- Badge "Actif jusqu'au XX" si l'utilisateur a déjà l'accès
-- Bouton "Acheter" ou "Prolonger" selon le statut
-- Afficher le prix formaté (priceCAD / 100 + " $")
-
-### 2. Page Success (`/payment/success`)
-
-**Objectif** : Confirmer le paiement après retour de Stripe.
-
-**Fonctions utilisées** :
-
-- `useAction(api.stripe.verifyCheckoutSession)` - Vérifier le paiement
-- `useQuery(api.payments.getMyAccessStatus)` - Afficher le nouvel accès
-
-**UI suggérée** :
-
-- État de chargement pendant la vérification
-- Message de succès avec détails (produit, montant)
-- Lien vers le dashboard ou les examens/training
-- Gestion de l'erreur si session invalide
-
-**Code exemple** :
-
-```typescript
-"use client"
-
-import { useSearchParams } from "next/navigation"
-import { useAction, useQuery } from "convex/react"
-import { api } from "@/convex/_generated/api"
-import { useEffect, useState } from "react"
-
-export default function PaymentSuccessPage() {
-  const searchParams = useSearchParams()
-  const sessionId = searchParams.get("session_id")
-
-  const verifySession = useAction(api.stripe.verifyCheckoutSession)
-  const accessStatus = useQuery(api.payments.getMyAccessStatus)
-
-  const [verificationResult, setVerificationResult] = useState<any>(null)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    if (sessionId) {
-      verifySession({ sessionId })
-        .then(setVerificationResult)
-        .finally(() => setIsLoading(false))
-    }
-  }, [sessionId])
-
-  if (isLoading) return <LoadingSpinner />
-
-  if (!verificationResult?.success) {
-    return <ErrorMessage />
-  }
-
-  return <SuccessMessage accessStatus={accessStatus} />
-}
-```
-
-### 3. Page Account/Billing (`/account` ou `/compte`)
-
-**Objectif** : Voir ses accès et gérer la facturation.
-
-**Fonctions utilisées** :
-
-- `useQuery(api.payments.getMyAccessStatus)` - Statut des accès
-- `usePaginatedQuery(api.payments.getMyTransactions)` - Historique
-- `useAction(api.stripe.createCustomerPortalSession)` - Portail Stripe
-
-**UI suggérée** :
-
-- Section "Mes accès" avec dates d'expiration
-- Bouton "Prolonger" si accès actif mais bientôt expiré
-- Historique des transactions en tableau
-- Bouton "Gérer mes factures" → Customer Portal
-
-### 4. Admin - Transactions (`/admin/transactions`)
-
-**Objectif** : Voir toutes les transactions et enregistrer des paiements manuels.
-
-**Fonctions utilisées** :
-
-- `usePaginatedQuery(api.payments.getAllTransactions)` - Liste
-- `useQuery(api.payments.getTransactionStats)` - Stats
-- `useMutation(api.payments.recordManualPayment)` - Paiement manuel
-
-**UI suggérée** :
-
-- Cards avec stats (revenus, transactions)
-- Filtres (type, status, utilisateur)
-- Tableau des transactions
-- Modal "Enregistrer paiement manuel"
-
-### 5. Admin - User Detail (`/admin/users/[id]`)
-
-**Ajout** : Section accès de l'utilisateur.
-
-**Fonctions utilisées** :
-
-- `useQuery(api.payments.getUserAccessStatus, { userId })` - Accès
-- `useMutation(api.payments.recordManualPayment)` - Ajouter accès
-
----
-
-## Composants suggérés
-
-### AccessBadge
-
-Affiche le statut d'accès avec couleur.
-
-```typescript
-type AccessBadgeProps = {
-  accessType: "exam" | "training"
-  expiresAt: number | null
-  daysRemaining: number | null
-}
-
-function AccessBadge({ accessType, expiresAt, daysRemaining }: AccessBadgeProps) {
-  if (!expiresAt) {
-    return <Badge variant="secondary">Inactif</Badge>
-  }
-
-  if (daysRemaining && daysRemaining <= 7) {
-    return <Badge variant="warning">Expire dans {daysRemaining}j</Badge>
-  }
-
-  return <Badge variant="success">Actif - {daysRemaining}j restants</Badge>
-}
-```
-
-### PricingCard
-
-Carte produit pour la page pricing.
-
-```typescript
-type PricingCardProps = {
-  product: Product
-  currentAccess: AccessStatus | null
-  onBuy: (code: string) => void
-  isLoading: boolean
-}
-```
-
-### TransactionRow
-
-Ligne de transaction pour les tableaux.
-
----
-
-## Gestion des accès dans l'app
-
-### Protéger les routes
-
-Les vérifications d'accès sont déjà faites côté backend dans :
-
-- `exams.startExam` - Vérifie `userAccess` pour "exam"
-- `questions.getLearningBankQuestions` - Vérifie `userAccess` pour "training"
-
-Côté frontend, afficher un message approprié :
-
-```typescript
-// Dans la page d'examen
-const hasExamAccess = useQuery(api.payments.hasExamAccess)
-
-if (hasExamAccess === false) {
-  return <UpgradePrompt type="exam" />
-}
-
-// Dans la page training
-const hasTrainingAccess = useQuery(api.payments.hasTrainingAccess)
-
-if (hasTrainingAccess === false) {
-  return <UpgradePrompt type="training" />
-}
-```
-
-### Composant UpgradePrompt
-
-```typescript
-function UpgradePrompt({ type }: { type: "exam" | "training" }) {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Accès requis</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p>
-          {type === "exam"
-            ? "Un abonnement est requis pour accéder aux examens simulés."
-            : "Un abonnement est requis pour accéder à la banque d'entraînement."}
-        </p>
-        <Link href="/pricing">
-          <Button>Voir les tarifs</Button>
-        </Link>
-      </CardContent>
-    </Card>
-  )
-}
-```
-
----
-
-## Helpers utiles
-
-### Formatage du prix
-
-```typescript
-export function formatPrice(cents: number, currency = "CAD"): string {
-  return new Intl.NumberFormat("fr-CA", {
-    style: "currency",
-    currency,
-  }).format(cents / 100)
-}
-
-// Usage: formatPrice(5000) → "50,00 $"
-```
-
-### Formatage de la date d'expiration
-
-```typescript
-import { format, formatDistanceToNow } from "date-fns"
-import { fr } from "date-fns/locale"
-
-export function formatExpiration(timestamp: number): string {
-  return format(new Date(timestamp), "d MMMM yyyy", { locale: fr })
-}
-
-export function formatTimeRemaining(timestamp: number): string {
-  return formatDistanceToNow(new Date(timestamp), {
-    locale: fr,
-    addSuffix: true,
-  })
-}
-
-// Usage:
-// formatExpiration(1234567890000) → "15 février 2039"
-// formatTimeRemaining(futureTimestamp) → "dans 25 jours"
-```
-
----
-
-## Types TypeScript
-
-```typescript
-// Types pour le frontend
-export type ProductCode =
-  | "exam_access"
-  | "training_access"
-  | "exam_access_promo"
-  | "training_access_promo"
-
-export type AccessType = "exam" | "training"
-
-export type TransactionStatus = "pending" | "completed" | "failed" | "refunded"
-
-export type TransactionType = "stripe" | "manual"
-
-export interface AccessInfo {
-  expiresAt: number
-  daysRemaining: number
-}
-
-export interface MyAccessStatus {
-  examAccess: AccessInfo | null
-  trainingAccess: AccessInfo | null
-}
-```
-
----
-
-## Notes importantes
-
-1. **Webhook** : Le webhook Stripe est configuré sur `/stripe` (convex/http.ts). L'accès est activé automatiquement après paiement réussi.
-
-2. **Admins** : Les utilisateurs avec `role === "admin"` ont toujours accès aux examens et training, pas besoin de payer.
-
-3. **Cumul** : Le temps est cumulé si l'utilisateur a déjà un accès actif.
-
-4. **Idempotence** : Les webhooks sont idempotents (pas de double-activation si Stripe renvoie l'événement).
-
-5. **Devise** : Les prix sont stockés en **cents CAD**. Stripe gère la conversion XAF via Adaptive Pricing.
-
-6. **Test** : Utiliser les cartes de test Stripe :
-   - Succès : `4242 4242 4242 4242`
-   - Refus : `4000 0000 0000 0002`
+Le crédit d'accès est **toujours** fait par le webhook, jamais par la page de
+succès (résistant à un utilisateur qui ne revient pas sur `successPath`).
+
+## Modules
+
+| Module                            | Rôle                                                                                                                                                                                                                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `features/payments/actions.ts`    | Server Actions : `createStripeCheckout`, `verifyStripeCheckout`, `createCustomerPortal` ; paiements manuels admin (`recordManualPayment`, `updateManualTransaction`, `deleteManualTransaction`) ; loaders (`loadUserAccessStatus`, `loadAdminTransactions`, `loadTransactionStats`…). |
+| `features/payments/stripe.ts`     | Fulfillment serveur : `completeStripeTransaction` (crédit d'accès idempotent), `failStripeTransaction` (session expirée).                                                                                                                                                             |
+| `features/payments/dal.ts`        | Lectures `server-only` : `getAccessStatus`, `hasAccess`, `getAvailableProducts`, `getMyTransactions`, `getAllTransactions`, `getTransactionStats`, `getRevenueByDay`, `getExpiringAccess`.                                                                                            |
+| `app/api/stripe/webhook/route.ts` | Endpoint webhook (`runtime = "nodejs"`, signature vérifiée).                                                                                                                                                                                                                          |
+| `lib/stripe.ts`                   | `getStripe()`, `getStripeWebhookSecret()` (SDK + secrets).                                                                                                                                                                                                                            |
+
+## Produits
+
+Enum `product_code` (`db/schema/enums.ts`) : `exam_access`, `training_access`,
+`exam_access_promo`, `training_access_promo`. Les produits (prix, durée,
+`stripePriceId`, `isCombo`…) vivent dans la table `products`, seedée en base — un
+produit `isCombo` octroie exam **et** training. Aucun code produit n'est en dur
+côté client : la grille lit `getAvailableProducts`.
+
+## Pages (déjà implémentées)
+
+| Page                                    | Fichier                                                                                         |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Tarifs / achat                          | `app/(marketing)/tarifs/page.tsx` (+ `_components/pricing-grid.tsx`)                            |
+| Succès paiement                         | `app/(dashboard)/tableau-de-bord/paiement/succes/` (+ `_components/payment-success-client.tsx`) |
+| Mes abonnements / portail               | `app/(dashboard)/tableau-de-bord/abonnements/`                                                  |
+| Admin transactions + paiement manuel    | `app/(admin)/admin/transactions/` (+ `components/shared/payments/manual-payment-modal.tsx`)     |
+| Section accès (fiche utilisateur admin) | `app/(admin)/admin/utilisateurs/[id]/`                                                          |
+| Paywall entraînement                    | `app/(dashboard)/tableau-de-bord/entrainement/_components/training-paywall.tsx`                 |
+
+## Invariants à connaître
+
+- **Webhook** : endpoint `/api/stripe/webhook` (pointer le dashboard Stripe
+  dessus + définir `STRIPE_WEBHOOK_SECRET`). Réponses : `400` signature
+  invalide (jamais rejoué), `500` erreur inattendue → Stripe **réessaie** (ne
+  jamais avaler une erreur transitoire en 200), `200` traité ou ignoré.
+- **Idempotence** : `completeStripeTransaction` est gardé sur `stripeEventId` —
+  pas de double-activation si Stripe renvoie l'événement.
+- **Cumul du temps** : un achat alors qu'un accès est actif **prolonge**
+  l'expiration (15 j restants + 30 j = 45 j).
+- **Montant/devise** : stockés en **centièmes** (`amountPaid` en cents CAD). Le
+  webhook persiste `amount_total`/`currency` réels de Stripe (promo, Adaptive
+  Pricing) ; XAF est **zéro-décimal chez Stripe** → converti ×100 au fulfillment
+  (cf. correctif #79/#80).
+- **Accès admin** : `role === "admin"` bypasse `hasAccess` — pas de paiement
+  requis pour examens/entraînement.
+- **Cartes de test Stripe** : succès `4242 4242 4242 4242` · refus
+  `4000 0000 0000 0002`.

--- a/docs/STRIPE_FRONTEND_SPEC.md
+++ b/docs/STRIPE_FRONTEND_SPEC.md
@@ -19,7 +19,8 @@
    appelle `completeStripeTransaction` (features/payments/stripe.ts).
 6. `completeStripeTransaction` (idempotent via `stripeEventId`) passe la
    transaction à `completed`, persiste le montant/devise réellement facturés, et
-   crée/prolonge la ligne `userAccess` (cumul du temps d'accès).
+   crée/prolonge la ligne `userAccess` (cumul du temps pour un accès simple ;
+   fenêtre fraîche pour un combo — voir Invariants).
 7. La page de succès (`/tableau-de-bord/paiement/succes`) appelle
    `verifyStripeCheckout(sessionId)` pour AFFICHER le statut — elle ne crédite
    PAS l'accès (c'est le webhook qui fait foi). Anti-IDOR : la session est
@@ -42,21 +43,24 @@ succès (résistant à un utilisateur qui ne revient pas sur `successPath`).
 ## Produits
 
 Enum `product_code` (`db/schema/enums.ts`) : `exam_access`, `training_access`,
-`exam_access_promo`, `training_access_promo`. Les produits (prix, durée,
-`stripePriceId`, `isCombo`…) vivent dans la table `products`, seedée en base — un
-produit `isCombo` octroie exam **et** training. Aucun code produit n'est en dur
-côté client : la grille lit `getAvailableProducts`.
+`exam_access_promo`, `training_access_promo`, `premium_access`. Les produits
+(prix, durée, `stripePriceId`, `isCombo`…) vivent dans la table `products`,
+seedée en base — un produit `isCombo` (`premium_access`) octroie exam **et**
+training. Les prix/durées/labels ne sont PAS en dur côté client (la grille lit
+`getAvailableProducts`) ; en revanche quelques codes le sont pour la mise en
+page : `pricing-grid.tsx` isole `premium_access` (carte combo mise en avant) et
+la modale de paiement manuel a `exam_access` par défaut.
 
 ## Pages (déjà implémentées)
 
-| Page                                    | Fichier                                                                                         |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Tarifs / achat                          | `app/(marketing)/tarifs/page.tsx` (+ `_components/pricing-grid.tsx`)                            |
-| Succès paiement                         | `app/(dashboard)/tableau-de-bord/paiement/succes/` (+ `_components/payment-success-client.tsx`) |
-| Mes abonnements / portail               | `app/(dashboard)/tableau-de-bord/abonnements/`                                                  |
-| Admin transactions + paiement manuel    | `app/(admin)/admin/transactions/` (+ `components/shared/payments/manual-payment-modal.tsx`)     |
-| Section accès (fiche utilisateur admin) | `app/(admin)/admin/utilisateurs/[id]/`                                                          |
-| Paywall entraînement                    | `app/(dashboard)/tableau-de-bord/entrainement/_components/training-paywall.tsx`                 |
+| Page                                    | Fichier                                                                                                                                        |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tarifs / achat                          | `app/(marketing)/tarifs/page.tsx` (+ `_components/pricing-grid.tsx`)                                                                           |
+| Succès paiement                         | `app/(dashboard)/tableau-de-bord/paiement/succes/page.tsx` (rend `PaymentSuccessContent` de `paiement/_components/payment-success-client.tsx`) |
+| Mes abonnements / portail               | `app/(dashboard)/tableau-de-bord/abonnements/`                                                                                                 |
+| Admin transactions + paiement manuel    | `app/(admin)/admin/transactions/` (+ `components/shared/payments/manual-payment-modal.tsx`)                                                    |
+| Section accès (fiche utilisateur admin) | `app/(admin)/admin/utilisateurs/[id]/`                                                                                                         |
+| Paywall entraînement                    | `app/(dashboard)/tableau-de-bord/entrainement/_components/training-paywall.tsx`                                                                |
 
 ## Invariants à connaître
 
@@ -66,8 +70,10 @@ côté client : la grille lit `getAvailableProducts`.
   jamais avaler une erreur transitoire en 200), `200` traité ou ignoré.
 - **Idempotence** : `completeStripeTransaction` est gardé sur `stripeEventId` —
   pas de double-activation si Stripe renvoie l'événement.
-- **Cumul du temps** : un achat alors qu'un accès est actif **prolonge**
-  l'expiration (15 j restants + 30 j = 45 j).
+- **Cumul du temps** : un achat d'accès simple alors qu'un accès du même type
+  est actif **prolonge** l'expiration (15 j restants + 30 j = 45 j). **Exception
+  combo** (`isCombo`/`premium_access`, `features/payments/stripe.ts`) : la
+  fenêtre est posée à `now + durée` (pas de cumul avec l'existant).
 - **Montant/devise** : stockés en **centièmes** (`amountPaid` en cents CAD). Le
   webhook persiste `amount_total`/`currency` réels de Stripe (promo, Adaptive
   Pricing) ; XAF est **zéro-décimal chez Stripe** → converti ×100 au fulfillment

--- a/docs/superpowers/plans/2026-07-10-taux-reussite-marketing.md
+++ b/docs/superpowers/plans/2026-07-10-taux-reussite-marketing.md
@@ -188,6 +188,7 @@ import { getMarketingStats } from "@/features/marketing/dal"
 import {
   MIN_COMPLETED_PARTICIPATIONS,
   SUCCESS_SCORE_THRESHOLD,
+  resolveSuccessRate,
 } from "@/features/marketing/lib"
 import { createId } from "@/lib/ids"
 
@@ -266,22 +267,16 @@ describe("getMarketingStats — successRate calculé", () => {
     expect(stats).not.toHaveProperty("rating")
   })
 
-  it("publie un taux calculé quand volume ≥ seuil et taux ≥ plancher", async () => {
-    // N participations 100 % réussies s'ajoutent à la baseline. Le total dépasse
-    // le seuil de volume ; le taux global reste ≥ 70 % TANT que la baseline de la
-    // branche de test ne contient pas une majorité d'échecs. Assertion robuste :
-    // le taux publié est un « NN% » cohérent avec l'agrégat réel (pas l'éditorial
-    // par défaut si le calcul s'applique).
+  it("câble l'agrégat SQL sur resolveSuccessRate (oracle exact, baseline develop quelconque)", async () => {
+    // La branche de test est clonée de develop (scripts/neon-api.ts), donc la
+    // baseline n'est JAMAIS vide : l'oracle recalcule l'agrégat indépendamment
+    // et exige l'égalité avec la bascule — exact quelle que soit la baseline
+    // (revue design 2026-07-12, constat #1 : l'ancien if/else était tautologique
+    // dans sa branche else).
     const agg = await baselineAgg()
-    const rate = Math.round((agg.passed / agg.completed) * 100)
     const stats = await getMarketingStats()
-    // Le total franchit le seuil (N ≥ 50) : si le taux réel ≥ 70, on l'affiche.
-    if (rate >= 70) {
-      expect(stats.successRate).toBe(`${rate}%`)
-    } else {
-      // Baseline très défavorable (improbable sur branche fraîche) → éditorial.
-      expect(stats.successRate).toMatch(/%$/)
-    }
+    expect(stats.successRate).toBe(resolveSuccessRate(agg))
+    // Nos N insertions garantissent le franchissement du seuil de volume.
     expect(agg.completed).toBeGreaterThanOrEqual(MIN_COMPLETED_PARTICIPATIONS)
   })
 })
@@ -290,7 +285,10 @@ describe("getMarketingStats — successRate calculé", () => {
 - [ ] **Step 2: Vérifier le rouge**
 
 Run: `bun run test:integration`
-Expected: FAIL — `stats` a encore `rating` (« ne renvoie plus rating » échoue) et `successRate` vaut `"85%"` en dur (le second test échoue si le taux calculé ≠ 85 %). Le reste de la suite reste vert.
+Expected: FAIL — le RED **déterministe** est le test `rating` (« ne renvoie plus
+rating » échoue tant que le champ existe). Le test d'oracle exact échoue AUSSI
+dès que `resolveSuccessRate(agg) ≠ "85%"` (taux réel ≥ 70 % différent de 85) —
+mais ne compte pas comme seul témoin du rouge. Le reste de la suite reste vert.
 
 (Coût : ~90-120 s par run Neon. 1 RED + 1 GREEN suffisent.)
 
@@ -307,7 +305,7 @@ import { SUCCESS_SCORE_THRESHOLD, resolveSuccessRate } from "./lib"
 
 (l'import drizzle `isNull, sql` existe déjà.)
 
-Retirer `successRate` et `rating` du type :
+Retirer `rating` du type (`successRate` RESTE, il devient calculé) :
 
 ```ts
 export type MarketingStats = {
@@ -324,6 +322,9 @@ export type MarketingStats = {
 Après le `count(*)` users, ajouter l'agrégat participations :
 
 ```ts
+// Pas de jointure user : les participations de comptes soft-deleted COMPTENT
+// (un passage d'examen réel reste un point de donnée du taux — on mesure des
+// passages, pas des comptes actifs ; décision revue design 2026-07-12).
 const [participationAgg] = await db
   .select({
     completed:
@@ -456,12 +457,14 @@ description: `Notre mission : accompagner les médecins francophones vers la ré
 
 ```bash
 grep -rn "85%" app features
-grep -rn "4\.9" app features
+grep -rn "4\.9/5" app features
 ```
 
-Expected : ne matchent plus que la définition de `MARKETING_CLAIMS` (dans
-`constants/`, hors `app`/`features` — donc idéalement **zéro** match dans
-`app`/`features`). Un reliquat `85%`/`4.9` en dur = à corriger.
+Expected : **zéro** match dans `app`/`features` (la constante vit dans
+`constants/`, hors périmètre). Motif `4\.9/5` et NON `4\.9` : les paths SVG du
+logo Google dans `app/(auth)` contiennent « 14.97 » qui matche `4\.9` — ne PAS
+« corriger » ces SVG (revue design 2026-07-12, constat #2). Un reliquat
+`85%`/`4.9/5` en dur = à corriger.
 
 Run: `bun run check && bun run test`
 Expected: PASS partout.

--- a/docs/superpowers/plans/2026-07-10-taux-reussite-marketing.md
+++ b/docs/superpowers/plans/2026-07-10-taux-reussite-marketing.md
@@ -1,0 +1,505 @@
+# Taux de réussite marketing honnête et centralisé (#84 + #85) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sortir les claims éditoriaux (`85%`, `4.9/5`) du DAL et du JSX vers une constante unique, puis rendre `successRate` réellement calculé sur les participations d'examens (seuil de volume + plancher de publication).
+
+**Architecture:** Une constante `MARKETING_CLAIMS` (`constants/index.tsx`) comme source éditoriale unique. Une fonction pure `resolveSuccessRate` (`features/marketing/lib.ts`, unit-testable) décide entre taux calculé et repli éditorial. `getMarketingStats` ajoute UNE requête agrégée (`count(*) filter`) et applique `resolveSuccessRate` ; `rating` sort du type `MarketingStats`. Tous les affichages lisent la constante ou `stats.successRate`.
+
+**Tech Stack:** Drizzle/Neon (agrégat SQL), React (Server Components + hook client), Vitest (unit happy-dom + intégration Neon éphémère).
+
+**Spec:** `docs/superpowers/specs/2026-07-10-taux-reussite-marketing-design.md`
+
+**Rappels projet :** commits conventionnels SANS attribution Claude ; `bun run test` (JAMAIS `bun test`) ; ne jamais lancer `bun dev` soi-même. **On EMPILE sur la branche existante `fix/91-quiz-public-answer-key` (PR #96) — PAS de nouvelle branche.** Ordre imposé par les issues : #84 (centralisation) AVANT #85 (calcul), sinon conflits.
+
+---
+
+### Task 1: Constante éditoriale `MARKETING_CLAIMS` (#84)
+
+**Files:**
+
+- Modify: `constants/index.tsx` (append)
+
+- [ ] **Step 1: Ajouter la constante**
+
+À la fin de `constants/index.tsx` :
+
+```ts
+/**
+ * Claims marketing ÉDITORIAUX (non calculés). `successRate` sert de repli quand
+ * le vrai taux (features/marketing/dal.ts) n'est pas publiable (volume ou
+ * plancher). `rating` reste 100 % éditorial : aucun système d'avis en base.
+ */
+export const MARKETING_CLAIMS = {
+  successRate: "85%",
+  rating: "4.9/5",
+} as const
+```
+
+- [ ] **Step 2: Vérifier la compile**
+
+Run: `bun run check`
+Expected: PASS (constante non encore consommée — pas d'erreur unused sur un export).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add constants/index.tsx
+git commit -m "feat: constante MARKETING_CLAIMS (claims editoriaux centralises) (#84)"
+```
+
+---
+
+### Task 2: `resolveSuccessRate` + seuils (unit, RED → GREEN) (#85)
+
+**Files:**
+
+- Create: `tests/marketing/success-rate.test.ts`
+- Create: `features/marketing/lib.ts`
+
+- [ ] **Step 1: Écrire le test unitaire (rouge)**
+
+`features/marketing/lib.ts` ne touche pas `db` → testable en happy-dom sans mock DB. On importe la vraie constante pour ne pas figer une copie.
+
+```ts
+import { describe, expect, it } from "vitest"
+import { MARKETING_CLAIMS } from "@/constants"
+import {
+  MIN_COMPLETED_PARTICIPATIONS,
+  MIN_PUBLISHABLE_SUCCESS_RATE,
+  SUCCESS_SCORE_THRESHOLD,
+  resolveSuccessRate,
+} from "@/features/marketing/lib"
+
+const EDITORIAL = MARKETING_CLAIMS.successRate
+
+describe("resolveSuccessRate", () => {
+  it("retombe sur l'éditorial sous le seuil de volume", () => {
+    expect(resolveSuccessRate({ completed: 49, passed: 49 })).toBe(EDITORIAL)
+  })
+
+  it("retombe sur l'éditorial à 0 participation (pas de division par zéro)", () => {
+    expect(resolveSuccessRate({ completed: 0, passed: 0 })).toBe(EDITORIAL)
+  })
+
+  it("publie le taux calculé au seuil exact de volume si ≥ plancher", () => {
+    // 50 terminées, 40 réussies → 80 % ≥ 70 % → publié.
+    expect(resolveSuccessRate({ completed: 50, passed: 40 })).toBe("80%")
+  })
+
+  it("retombe sur l'éditorial quand le taux est sous le plancher de publication", () => {
+    // 100 terminées, 42 réussies → 42 % < 70 % → éditorial.
+    expect(resolveSuccessRate({ completed: 100, passed: 42 })).toBe(EDITORIAL)
+  })
+
+  it("publie exactement au plancher (70 %) mais pas juste en dessous (69 %)", () => {
+    expect(resolveSuccessRate({ completed: 100, passed: 70 })).toBe("70%")
+    expect(resolveSuccessRate({ completed: 100, passed: 69 })).toBe(EDITORIAL)
+  })
+
+  it("arrondit le taux (Math.round)", () => {
+    // 60 terminées, 47 réussies → 78,33 % → 78 %.
+    expect(resolveSuccessRate({ completed: 60, passed: 47 })).toBe("78%")
+  })
+
+  it("expose des seuils cohérents avec la spec", () => {
+    expect(SUCCESS_SCORE_THRESHOLD).toBe(60)
+    expect(MIN_COMPLETED_PARTICIPATIONS).toBe(50)
+    expect(MIN_PUBLISHABLE_SUCCESS_RATE).toBe(70)
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test -- success-rate`
+Expected: FAIL — module `@/features/marketing/lib` introuvable.
+
+- [ ] **Step 3: Écrire le module**
+
+```ts
+import { MARKETING_CLAIMS } from "@/constants"
+
+// Score (%) minimal d'une participation « réussie ».
+export const SUCCESS_SCORE_THRESHOLD = 60
+// Volume minimal de participations terminées pour publier un taux calculé.
+export const MIN_COMPLETED_PARTICIPATIONS = 50
+// Plancher marketing : sous ce taux, on garde le claim éditorial (page de vente).
+export const MIN_PUBLISHABLE_SUCCESS_RATE = 70
+
+/**
+ * Décide de la valeur affichée : le taux calculé arrondi, OU le claim éditorial
+ * si le volume est insuffisant OU si le taux est sous le plancher de publication.
+ */
+export const resolveSuccessRate = ({
+  completed,
+  passed,
+}: {
+  completed: number
+  passed: number
+}): string => {
+  if (completed < MIN_COMPLETED_PARTICIPATIONS) {
+    return MARKETING_CLAIMS.successRate
+  }
+  const rate = Math.round((passed / completed) * 100)
+  if (rate < MIN_PUBLISHABLE_SUCCESS_RATE) {
+    return MARKETING_CLAIMS.successRate
+  }
+  return `${rate}%`
+}
+```
+
+- [ ] **Step 4: Vérifier le vert + gates**
+
+Run: `bun run test -- success-rate` puis `bun run check`
+Expected: PASS (7 tests) ; check PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/marketing/success-rate.test.ts features/marketing/lib.ts
+git commit -m "feat: resolveSuccessRate + seuils (bascule calcul/editorial) (#85)"
+```
+
+---
+
+### Task 3: DAL — agrégat + calcul, `rating` retiré (intégration, RED → GREEN) (#85 + #84)
+
+**Files:**
+
+- Create: `tests/integration/marketing-dal.test.ts`
+- Modify: `features/marketing/dal.ts`
+- Modify: `tests/hooks/useMarketingStats.test.tsx` (mock sans `rating`)
+
+- [ ] **Step 1: Écrire le test d'intégration (rouge)**
+
+`exam_participations` est partagée entre fichiers de test → **delta-vs-baseline** :
+lire la baseline agrégée, insérer des participations connues (1 examen + N users
+distincts, contrainte `UNIQUE(examId, userId)`), assert le delta. `getMarketingStats`
+est `cache()`-isé (React) → mocker `react` `cache` en passthrough comme les autres
+tests DAL.
+
+```ts
+import { eq, inArray, sql } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { examParticipations, exams, user } from "@/db/schema"
+import { getMarketingStats } from "@/features/marketing/dal"
+import {
+  MIN_COMPLETED_PARTICIPATIONS,
+  SUCCESS_SCORE_THRESHOLD,
+} from "@/features/marketing/lib"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+const suffix = createId().slice(0, 8)
+const examId = createId()
+const creatorId = createId()
+// Assez de participations pour franchir le seuil de volume à coup sûr, toutes
+// réussies (score ≥ seuil) → delta 100 % réussite ; combiné à la baseline, le
+// total dépasse MIN_COMPLETED_PARTICIPATIONS.
+const N = MIN_COMPLETED_PARTICIPATIONS + 10
+const userIds = Array.from({ length: N }, () => createId())
+
+const baselineAgg = async () => {
+  const [row] = await db
+    .select({
+      completed:
+        sql<number>`count(*) filter (where status in ('completed','auto_submitted'))`.mapWith(
+          Number,
+        ),
+      passed:
+        sql<number>`count(*) filter (where status in ('completed','auto_submitted') and score >= ${SUCCESS_SCORE_THRESHOLD})`.mapWith(
+          Number,
+        ),
+    })
+    .from(examParticipations)
+  return row ?? { completed: 0, passed: 0 }
+}
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: creatorId,
+    name: "Créateur Marketing",
+    email: `mktg-${suffix}@test.invalid`,
+    emailVerified: true,
+  })
+  await db.insert(exams).values({
+    id: examId,
+    title: `Examen marketing ${suffix}`,
+    startDate: new Date(Date.now() - 48 * 60 * 60 * 1000),
+    endDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    completionTime: 3600,
+    createdBy: creatorId,
+  })
+  await db.insert(user).values(
+    userIds.map((id, i) => ({
+      id,
+      name: `Participant ${i}`,
+      email: `mktg-p-${i}-${suffix}@test.invalid`,
+      emailVerified: true,
+    })),
+  )
+  await db.insert(examParticipations).values(
+    userIds.map((uid) => ({
+      examId,
+      userId: uid,
+      status: "completed" as const,
+      score: 90, // ≥ SUCCESS_SCORE_THRESHOLD → réussite
+      completedAt: new Date(),
+    })),
+  )
+})
+
+afterAll(async () => {
+  await db.delete(exams).where(eq(exams.id, examId)) // cascade participations
+  await db.delete(user).where(inArray(user.id, [creatorId, ...userIds]))
+})
+
+describe("getMarketingStats — successRate calculé", () => {
+  it("ne renvoie plus le champ rating", async () => {
+    const stats = await getMarketingStats()
+    expect(stats).not.toHaveProperty("rating")
+  })
+
+  it("publie un taux calculé quand volume ≥ seuil et taux ≥ plancher", async () => {
+    // N participations 100 % réussies s'ajoutent à la baseline. Le total dépasse
+    // le seuil de volume ; le taux global reste ≥ 70 % TANT que la baseline de la
+    // branche de test ne contient pas une majorité d'échecs. Assertion robuste :
+    // le taux publié est un « NN% » cohérent avec l'agrégat réel (pas l'éditorial
+    // par défaut si le calcul s'applique).
+    const agg = await baselineAgg()
+    const rate = Math.round((agg.passed / agg.completed) * 100)
+    const stats = await getMarketingStats()
+    // Le total franchit le seuil (N ≥ 50) : si le taux réel ≥ 70, on l'affiche.
+    if (rate >= 70) {
+      expect(stats.successRate).toBe(`${rate}%`)
+    } else {
+      // Baseline très défavorable (improbable sur branche fraîche) → éditorial.
+      expect(stats.successRate).toMatch(/%$/)
+    }
+    expect(agg.completed).toBeGreaterThanOrEqual(MIN_COMPLETED_PARTICIPATIONS)
+  })
+})
+```
+
+- [ ] **Step 2: Vérifier le rouge**
+
+Run: `bun run test:integration`
+Expected: FAIL — `stats` a encore `rating` (« ne renvoie plus rating » échoue) et `successRate` vaut `"85%"` en dur (le second test échoue si le taux calculé ≠ 85 %). Le reste de la suite reste vert.
+
+(Coût : ~90-120 s par run Neon. 1 RED + 1 GREEN suffisent.)
+
+- [ ] **Step 3: Modifier le DAL**
+
+Dans `features/marketing/dal.ts` :
+
+Imports — ajouter `examParticipations` et le lib :
+
+```ts
+import { examParticipations, questions, user } from "@/db/schema"
+import { SUCCESS_SCORE_THRESHOLD, resolveSuccessRate } from "./lib"
+```
+
+(l'import drizzle `isNull, sql` existe déjà.)
+
+Retirer `successRate` et `rating` du type :
+
+```ts
+export type MarketingStats = {
+  totalQuestions: string
+  totalUsers: string
+  totalDomains: number
+  successRate: string
+  topDomains: { domain: string; count: number }[]
+}
+```
+
+(`successRate` RESTE — il devient calculé ; seul `rating` disparaît.)
+
+Après le `count(*)` users, ajouter l'agrégat participations :
+
+```ts
+const [participationAgg] = await db
+  .select({
+    completed:
+      sql<number>`count(*) filter (where ${examParticipations.status} in ('completed','auto_submitted'))`.mapWith(
+        Number,
+      ),
+    passed:
+      sql<number>`count(*) filter (where ${examParticipations.status} in ('completed','auto_submitted') and ${examParticipations.score} >= ${SUCCESS_SCORE_THRESHOLD})`.mapWith(
+        Number,
+      ),
+  })
+  .from(examParticipations)
+```
+
+Remplacer le `return` :
+
+```ts
+return {
+  totalQuestions: formatMarketingStat(totalQuestions),
+  totalUsers: formatMarketingStat(users?.n ?? 0),
+  totalDomains: domainRows.length,
+  successRate: resolveSuccessRate({
+    completed: participationAgg?.completed ?? 0,
+    passed: participationAgg?.passed ?? 0,
+  }),
+  topDomains: domainRows.slice(0, 10).map((r) => ({
+    domain: r.domain,
+    count: r.count,
+  })),
+}
+```
+
+- [ ] **Step 4: Mettre à jour le mock du hook**
+
+Dans `tests/hooks/useMarketingStats.test.tsx`, retirer `rating: "4.9/5",` de `mockStats` (l.19). Vérifier qu'aucun autre test ne construit un `MarketingStats` complet :
+
+Run: `grep -rn "rating:" tests/`
+Expected: plus aucune ligne (hors ce fichier, déjà corrigé).
+
+- [ ] **Step 5: Vérifier le vert + gates**
+
+Run: `bun run test:integration` puis `bun run check && bun run test`
+Expected: PASS partout.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/marketing/dal.ts tests/integration/marketing-dal.test.ts tests/hooks/useMarketingStats.test.tsx
+git commit -m "feat: successRate calcule sur les participations + retrait de rating du DAL (#85)"
+```
+
+---
+
+### Task 4: Points d'affichage lisent la source centralisée (#84)
+
+**Files:**
+
+- Modify: `app/(marketing)/tarifs/_components/pricing-header.tsx`
+- Modify: `app/(marketing)/a-propos/_components/about-story.tsx`
+- Modify: `app/(marketing)/a-propos/_components/a-propos-page-client.tsx`
+- Modify: `app/(marketing)/_components/home-landing.tsx`
+- Modify: `app/(marketing)/a-propos/page.tsx`
+
+Aucun changement visuel : mêmes textes, mêmes accents.
+
+- [ ] **Step 1: `pricing-header.tsx` — `4.9/5` → constante**
+
+Ajouter l'import : `import { MARKETING_CLAIMS } from "@/constants"`.
+Remplacer le littéral `4.9/5` (l.137) par `{MARKETING_CLAIMS.rating}`.
+(`successRate` y est déjà via `marketingStats?.successRate` — inchangé.)
+
+- [ ] **Step 2: `about-story.tsx` — repli → constante**
+
+Ajouter l'import `MARKETING_CLAIMS`. Remplacer (l.33) :
+
+```tsx
+la réussite, avec un taux de succès de {stats?.successRate ?? "85%"}{" "}
+```
+
+par :
+
+```tsx
+la réussite, avec un taux de succès de{" "}
+{stats?.successRate ?? MARKETING_CLAIMS.successRate}{" "}
+```
+
+- [ ] **Step 3: `a-propos-page-client.tsx` — brancher le hook**
+
+Le composant est `"use client"` mais ne consomme pas encore les stats. Ajouter :
+
+```ts
+import { MARKETING_CLAIMS } from "@/constants"
+import { useMarketingStats } from "@/hooks/useMarketingStats"
+```
+
+Dans le corps du composant, récupérer les stats :
+
+```ts
+const { stats } = useMarketingStats()
+```
+
+Remplacer le littéral `85% de réussite` (l.58) par :
+
+```tsx
+{stats?.successRate ?? MARKETING_CLAIMS.successRate} de réussite
+```
+
+- [ ] **Step 4: `home-landing.tsx` — littéraux → source**
+
+Ajouter l'import `MARKETING_CLAIMS` (le composant consomme déjà `useMarketingStats`, `stats` est en scope).
+Remplacer `85% de réussite` (l.212) par `{stats?.successRate ?? MARKETING_CLAIMS.successRate} de réussite`.
+Remplacer `4.9/5` (l.225) par `{MARKETING_CLAIMS.rating}`.
+
+- [ ] **Step 5: `a-propos/page.tsx` — metadata SEO → constante**
+
+Ajouter l'import `MARKETING_CLAIMS`. Les `metadata` étant un objet statique
+exporté, interpoler la constante dans les deux descriptions (l.7 et l.17) :
+
+```ts
+description: `Découvrez NOMAQbanq : notre mission, notre équipe et notre engagement envers la communauté médicale francophone. ${MARKETING_CLAIMS.successRate} de taux de réussite, des milliers de candidats accompagnés.`,
+```
+
+et
+
+```ts
+description: `Notre mission : accompagner les médecins francophones vers la réussite à l'EACMC. ${MARKETING_CLAIMS.successRate} de taux de réussite, des milliers de candidats satisfaits.`,
+```
+
+- [ ] **Step 6: Vérifier les critères d'acceptation grep + gates**
+
+```bash
+grep -rn "85%" app features
+grep -rn "4\.9" app features
+```
+
+Expected : ne matchent plus que la définition de `MARKETING_CLAIMS` (dans
+`constants/`, hors `app`/`features` — donc idéalement **zéro** match dans
+`app`/`features`). Un reliquat `85%`/`4.9` en dur = à corriger.
+
+Run: `bun run check && bun run test`
+Expected: PASS partout.
+
+- [ ] **Step 7: Vérification navigateur (par l'utilisateur)**
+
+Demander à l'utilisateur : `bun dev` → `/`, `/tarifs`, `/a-propos` → les
+chiffres s'affichent identiques (taux = éditorial `85%` tant que < 50
+participations réussies en dev, `4.9/5` partout). NE PAS lancer `bun dev` soi-même.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "app/(marketing)"
+git commit -m "refactor: les affichages marketing lisent MARKETING_CLAIMS / stats.successRate (#84)"
+```
+
+---
+
+### Task 5: Gates finaux
+
+- [ ] **Step 1: Suite complète**
+
+Run: `bun run check && bun run test && bun run test:integration`
+Expected: PASS partout.
+
+- [ ] **Step 2: Formater + committer la spec/plan si retouchés**
+
+```bash
+bunx prettier --write docs/superpowers/specs/2026-07-10-taux-reussite-marketing-design.md docs/superpowers/plans/2026-07-10-taux-reussite-marketing.md
+git add docs/superpowers
+git commit -m "docs: spec + plan taux de reussite marketing (#84 #85)"
+```
+
+---
+
+## Hors scope (rappel spec)
+
+Vrai système d'avis pour `rating` (pas de table), `4.9/5` du carrousel de
+témoignages (données fictives par témoignage), tout changement visuel. Ne rien
+implémenter de tout ça.

--- a/docs/superpowers/specs/2026-07-10-taux-reussite-marketing-design.md
+++ b/docs/superpowers/specs/2026-07-10-taux-reussite-marketing-design.md
@@ -1,7 +1,11 @@
 # Spec — Taux de réussite marketing honnête et centralisé (#84 + #85)
 
 **Date** : 2026-07-10
-**Statut** : validé (brainstorming) — en attente de revue adversariale design
+**Statut** : validé (brainstorming) ; revue adversariale design du 2026-07-12
+triée — oracle du test d'intégration rendu exact (`toBe(resolveSuccessRate(agg))`,
+la branche Neon de test est clonée de `develop`, jamais « fraîche »), critère
+grep affiné (`4\.9/5`), sémantique du dénominateur tranchée (les participations
+de comptes soft-deleted comptent)
 **Issues** : #84 (centralisation éditoriale, `good first issue`) + #85 (vrai calcul,
 dépend de #84). Sous-issues de l'epic #78. Traitées ensemble (une seule spec /
 un seul plan) car #85 réconcilie le type que #84 rend honnête.
@@ -112,6 +116,14 @@ const [participationAgg] = await db
 
 `successRate: resolveSuccessRate({ completed: participationAgg?.completed ?? 0, passed: participationAgg?.passed ?? 0 })`.
 
+**Dénominateur — comptes supprimés (revue 2026-07-12, constat #3)** : l'agrégat
+ne joint PAS `user` et compte donc aussi les participations de comptes
+soft-deleted, contrairement à `totalUsers` (qui exclut `deletedAt`). **Assumé et
+documenté dans le code** : un passage d'examen réel reste un point de donnée du
+taux de réussite même si le compte a été supprimé ensuite — le taux mesure des
+passages, pas des comptes actifs. Bonus : l'agrégat reste UNE requête sans
+jointure (critère #85).
+
 ## 4. Points d'affichage
 
 | Fichier / ligne                                    | Aujourd'hui                             | Après                                                                                                                                                                |
@@ -148,12 +160,15 @@ constante.
   participation (pas de division par zéro). Assertions sur la constante réelle
   `MARKETING_CLAIMS.successRate`.
 - **Intégration** (`tests/integration/marketing-dal.test.ts`, branche Neon) —
-  l'agrégat SQL en **delta-vs-baseline** (table `exam_participations` partagée
-  entre fichiers : lire la baseline `completed`/`passed`, insérer des
-  participations connues via un examen + N users dédiés — contrainte `UNIQUE(examId,
-userId)` oblige des users distincts —, assert le delta ; cleanup FK exams→users).
-  Vérifie que `getMarketingStats().successRate` reflète le calcul quand le total
-  (baseline + insérées) dépasse 50 et le plancher, sinon l'éditorial.
+  la branche de test est clonée de `develop` (`scripts/neon-api.ts`), donc la
+  baseline `exam_participations` n'est JAMAIS vide ni « fraîche » : l'oracle
+  doit être **exact et indépendant de la baseline** (revue 2026-07-12, #1) :
+  insérer des participations connues (1 examen + N users distincts — contrainte
+  `UNIQUE(examId, userId)`), re-lire l'agrégat réel, puis
+  `expect(getMarketingStats().successRate).toBe(resolveSuccessRate(agg))` +
+  `expect(agg.completed).toBeGreaterThanOrEqual(MIN_COMPLETED_PARTICIPATIONS)`.
+  Ça prouve le câblage SQL→bascule (la logique de bascule elle-même est couverte
+  en unit). Cleanup FK exams→users.
 - **MAJ** `tests/hooks/useMarketingStats.test.tsx` : le mock `MarketingStats`
   perd `rating`.
 
@@ -175,8 +190,10 @@ userId)` oblige des users distincts —, assert le delta ; cleanup FK exams→us
 
 ## Critères d'acceptation (issues #84 + #85)
 
-- [ ] `grep -rn "85%" app features` et `grep -rn "4.9" app features` ne matchent
-      plus que la constante centralisée et ses usages importés.
+- [ ] `grep -rn "85%" app features` et `grep -rn "4\.9/5" app features` ne
+      matchent plus rien (la constante vit dans `constants/`, hors périmètre du
+      grep). Motif `4\.9/5` et non `4\.9` : des paths SVG dans `app/(auth)`
+      contiennent « 14.97 » (revue 2026-07-12, #2).
 - [ ] `MarketingStats` ne contient plus `rating` ; `successRate` est calculé ou
       repli éditorial documenté (le type ne ment plus).
 - [ ] Le taux affiché vient du calcul SQL quand ≥ 50 participations terminées ET

--- a/docs/superpowers/specs/2026-07-10-taux-reussite-marketing-design.md
+++ b/docs/superpowers/specs/2026-07-10-taux-reussite-marketing-design.md
@@ -1,0 +1,187 @@
+# Spec — Taux de réussite marketing honnête et centralisé (#84 + #85)
+
+**Date** : 2026-07-10
+**Statut** : validé (brainstorming) — en attente de revue adversariale design
+**Issues** : #84 (centralisation éditoriale, `good first issue`) + #85 (vrai calcul,
+dépend de #84). Sous-issues de l'epic #78. Traitées ensemble (une seule spec /
+un seul plan) car #85 réconcilie le type que #84 rend honnête.
+
+## Contexte
+
+`features/marketing/dal.ts` renvoie `successRate: "85%"` et `rating: "4.9/5"` en
+dur, à côté de `totalQuestions`/`totalUsers`/`totalDomains` réellement calculés
+en SQL — le type `MarketingStats` ment (il présente de l'éditorial comme du
+calculé). Les mêmes valeurs sont AUSSI codées en dur dans le JSX (home-landing,
+a-propos, tarifs) et dans les metadata SEO de `a-propos/page.tsx`.
+
+## Portée
+
+- **#84** : sortir l'éditorial du DAL, le centraliser dans `constants/index.tsx`,
+  faire lire cette source par tous les points d'affichage.
+- **#85** : rendre `successRate` réellement calculé à partir des participations
+  d'examens terminées, avec seuil de volume ET plancher de publication.
+
+**Hors scope** : vrai système d'avis pour `rating` (aucune table d'avis en base —
+reste éditorial) ; tout changement visuel ; le `4.9/5` du carrousel de
+témoignages (`components/marketing/testimonials-carousel.tsx` : `rating` par
+témoignage fictif, sans rapport avec le claim global).
+
+## Décisions de design (tranchées en brainstorming)
+
+- **Plancher de publication** : le taux calculé n'est affiché que s'il est
+  **≥ 70 %** ; sinon on retombe sur le claim éditorial. La page tarifs est une
+  page de vente — afficher « 42 % de réussite » serait un autogoal. Ne dégrade
+  rien vs aujourd'hui (le 85 % actuel est déjà 100 % éditorial).
+- **Seuils** : réussite = `score ≥ 60` ; crédibilité = **≥ 50** participations
+  terminées ; « terminé » = statut `completed` **OU** `auto_submitted` (convention
+  du repo : un examen auto-soumis à l'expiration est un vrai passage).
+
+## 1. Constante éditoriale (#84)
+
+Dans `constants/index.tsx` :
+
+```ts
+/**
+ * Claims marketing ÉDITORIAUX (non calculés). `successRate` sert de repli quand
+ * le vrai taux (features/marketing/dal.ts) n'est pas publiable (volume ou
+ * plancher). `rating` reste 100 % éditorial : aucun système d'avis en base.
+ */
+export const MARKETING_CLAIMS = {
+  successRate: "85%",
+  rating: "4.9/5",
+} as const
+```
+
+## 2. Type `MarketingStats` (#84 + #85)
+
+- **Retire `rating`** (aucun consommateur via le DAL — les « 4.9/5 » affichés
+  sont du JSX en dur qui lira `MARKETING_CLAIMS.rating`). Pas de migration.
+- **Garde `successRate`**, désormais honnête : soit `"NN%"` calculé, soit le
+  claim éditorial. Le type ne ment plus (tout ce qu'il expose est soit calculé,
+  soit explicitement un repli documenté — pas « faux calcul »).
+
+## 3. Calcul du taux (#85)
+
+### Fonction pure de bascule — `features/marketing/lib.ts`
+
+Testable sans DB (unit) :
+
+```ts
+export const SUCCESS_SCORE_THRESHOLD = 60 // score (%) d'une participation réussie
+export const MIN_COMPLETED_PARTICIPATIONS = 50 // volume minimal pour publier un calcul
+export const MIN_PUBLISHABLE_SUCCESS_RATE = 70 // plancher marketing (page de vente)
+
+/**
+ * Décide de la valeur affichée : le taux calculé arrondi, OU le claim éditorial
+ * si le volume est insuffisant ou si le taux est sous le plancher de publication.
+ */
+export const resolveSuccessRate = ({
+  completed,
+  passed,
+}: {
+  completed: number
+  passed: number
+}): string => {
+  if (completed < MIN_COMPLETED_PARTICIPATIONS)
+    return MARKETING_CLAIMS.successRate
+  const rate = Math.round((passed / completed) * 100)
+  if (rate < MIN_PUBLISHABLE_SUCCESS_RATE) return MARKETING_CLAIMS.successRate
+  return `${rate}%`
+}
+```
+
+### Agrégat SQL — dans `getMarketingStats`
+
+Une seule requête agrégée supplémentaire (règle « Reads bornés » : `count(*)
+filter (where …)`, jamais de lecture de lignes) :
+
+```ts
+const [participationAgg] = await db
+  .select({
+    completed:
+      sql<number>`count(*) filter (where ${examParticipations.status} in ('completed','auto_submitted'))`.mapWith(
+        Number,
+      ),
+    passed:
+      sql<number>`count(*) filter (where ${examParticipations.status} in ('completed','auto_submitted') and ${examParticipations.score} >= ${SUCCESS_SCORE_THRESHOLD})`.mapWith(
+        Number,
+      ),
+  })
+  .from(examParticipations)
+```
+
+`successRate: resolveSuccessRate({ completed: participationAgg?.completed ?? 0, passed: participationAgg?.passed ?? 0 })`.
+
+## 4. Points d'affichage
+
+| Fichier / ligne                                    | Aujourd'hui                             | Après                                                                                                                                                                |
+| -------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `features/marketing/dal.ts`                        | `successRate: "85%"`, `rating: "4.9/5"` | `successRate` calculé ; `rating` **supprimé** du type/retour                                                                                                         |
+| `tarifs/_components/pricing-header.tsx:20`         | `marketingStats?.successRate`           | inchangé (déjà via stats)                                                                                                                                            |
+| `tarifs/_components/pricing-header.tsx:137`        | `4.9/5` en dur                          | `MARKETING_CLAIMS.rating`                                                                                                                                            |
+| `a-propos/_components/about-story.tsx:33`          | `stats?.successRate ?? "85%"`           | `stats?.successRate ?? MARKETING_CLAIMS.successRate`                                                                                                                 |
+| `a-propos/_components/a-propos-page-client.tsx:58` | `85% de réussite` en dur                | brancher `useMarketingStats` (composant déjà `"use client"`) → `{stats?.successRate ?? MARKETING_CLAIMS.successRate}` (cohérence avec `about-story` de la même page) |
+| `_components/home-landing.tsx:212`                 | `85% de réussite` en dur                | `{stats?.successRate ?? MARKETING_CLAIMS.successRate}` (le composant consomme déjà `useMarketingStats`)                                                              |
+| `_components/home-landing.tsx:225`                 | `4.9/5` en dur                          | `MARKETING_CLAIMS.rating`                                                                                                                                            |
+| `a-propos/page.tsx:7,17` (metadata SEO)            | `85% de taux…` en dur                   | `MARKETING_CLAIMS.successRate` interpolé                                                                                                                             |
+
+**Exception assumée — metadata SEO** : `a-propos/page.tsx` est un Server
+Component qui exporte `metadata` statique ; on n'y fera **pas** de requête DB
+pour un chiffre de description. Il lit `MARKETING_CLAIMS.successRate` (l'éditorial),
+qui peut diverger du taux calculé affiché dans le corps de page. Assumé : une
+description SEO n'est pas un contrat de chiffre, et centraliser via la constante
+supprime déjà la duplication littérale (critère d'acceptation #84).
+
+**Décision de branchement** `a-propos-page-client.tsx` / `home-landing.tsx` : si
+le composant consomme déjà `useMarketingStats`, afficher `stats.successRate`
+(vrai taux) ; sinon lire `MARKETING_CLAIMS.successRate` (constante) plutôt que
+d'ajouter un fetch — à trancher fichier par fichier au plan selon l'existant. Le
+critère #84 (« un seul endroit à changer ») est satisfait dans les deux cas : la
+valeur vient soit du DAL (calcul + repli constante), soit directement de la
+constante.
+
+## 5. Tests
+
+- **Unit** (`tests/marketing/success-rate.test.ts`, happy-dom) — `resolveSuccessRate` :
+  sous-volume (49 → éditorial) ; au seuil exact (50, taux ≥ 70 → calculé) ;
+  plancher (69 % → éditorial, 70 % → calculé) ; arrondi (`Math.round`) ; 0
+  participation (pas de division par zéro). Assertions sur la constante réelle
+  `MARKETING_CLAIMS.successRate`.
+- **Intégration** (`tests/integration/marketing-dal.test.ts`, branche Neon) —
+  l'agrégat SQL en **delta-vs-baseline** (table `exam_participations` partagée
+  entre fichiers : lire la baseline `completed`/`passed`, insérer des
+  participations connues via un examen + N users dédiés — contrainte `UNIQUE(examId,
+userId)` oblige des users distincts —, assert le delta ; cleanup FK exams→users).
+  Vérifie que `getMarketingStats().successRate` reflète le calcul quand le total
+  (baseline + insérées) dépasse 50 et le plancher, sinon l'éditorial.
+- **MAJ** `tests/hooks/useMarketingStats.test.tsx` : le mock `MarketingStats`
+  perd `rating`.
+
+## Fichiers touchés
+
+| Fichier                                                         | Changement                                                                     |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `constants/index.tsx`                                           | + `MARKETING_CLAIMS`                                                           |
+| `features/marketing/lib.ts`                                     | nouveau — seuils + `resolveSuccessRate`                                        |
+| `features/marketing/dal.ts`                                     | agrégat participations + `resolveSuccessRate` ; `rating` retiré du type/retour |
+| `app/(marketing)/tarifs/_components/pricing-header.tsx`         | `4.9/5` → constante                                                            |
+| `app/(marketing)/a-propos/_components/about-story.tsx`          | repli → constante                                                              |
+| `app/(marketing)/a-propos/_components/a-propos-page-client.tsx` | `85%` en dur → stats/constante                                                 |
+| `app/(marketing)/_components/home-landing.tsx`                  | `85%`/`4.9/5` en dur → stats/constante                                         |
+| `app/(marketing)/a-propos/page.tsx`                             | metadata SEO → `MARKETING_CLAIMS.successRate`                                  |
+| `tests/marketing/success-rate.test.ts`                          | nouveau (unit)                                                                 |
+| `tests/integration/marketing-dal.test.ts`                       | nouveau (intégration)                                                          |
+| `tests/hooks/useMarketingStats.test.tsx`                        | mock sans `rating`                                                             |
+
+## Critères d'acceptation (issues #84 + #85)
+
+- [ ] `grep -rn "85%" app features` et `grep -rn "4.9" app features` ne matchent
+      plus que la constante centralisée et ses usages importés.
+- [ ] `MarketingStats` ne contient plus `rating` ; `successRate` est calculé ou
+      repli éditorial documenté (le type ne ment plus).
+- [ ] Le taux affiché vient du calcul SQL quand ≥ 50 participations terminées ET
+      taux ≥ 70 %, sinon de la constante éditoriale.
+- [ ] Une seule requête agrégée (`count(*) filter`), pas de lecture de lignes.
+- [ ] Seuils (60, 50, 70) = constantes nommées et documentées.
+- [ ] Aucun changement visuel ; texte FR avec accents.
+- [ ] `bun run check`, `bun run test`, `bun run test:integration` passent.

--- a/docs/superpowers/specs/2026-07-13-recuperation-merge-fantome-design.md
+++ b/docs/superpowers/specs/2026-07-13-recuperation-merge-fantome-design.md
@@ -1,0 +1,89 @@
+# Récupération du merge fantôme PR #96 + campagne de clôture des issues
+
+Date : 2026-07-13 · Branche : `fix/recuperation-merge-fantome`
+
+## Constat
+
+Le squash `c7638a2` (PR #96) annonçait « Closes #84 #85 #87 #88 #91 » mais ne
+contient **que** le travail #91 (21 fichiers : quiz-token, rate-limit, docs #91).
+La PR a été mergée depuis un état obsolète de la branche distante ; GitHub a
+fermé les 4 autres issues sans que leur code n'atteigne `main`.
+
+Preuves :
+
+- `features/marketing/dal.ts:56-57` porte encore `successRate: "85%"` /
+  `rating: "4.9/5"` dans `main` ;
+- `git show c7638a2 --numstat` : aucun fichier `features/marketing/**`,
+  `constants/index.tsx`, `docs/STRIPE_FRONTEND_SPEC.md` ni
+  `profile-preferences.tsx`.
+
+Les commits perdus vivent uniquement sur la branche locale
+`fix/91-quiz-public-answer-key` (à conserver jusqu'à la fin de la récupération).
+
+## Campagne B — récupération (cette branche)
+
+Cherry-pick des 10 commits perdus, dans l'ordre chronologique d'origine :
+
+| #   | SHA     | Objet                                                               |
+| --- | ------- | ------------------------------------------------------------------- |
+| 1   | 8d34117 | docs : spec + plan taux de réussite marketing (#84 #85)             |
+| 2   | 942156c | #88 : retrait du scaffolding mort de `profile-preferences`          |
+| 3   | 60b0484 | #87 : réécriture `docs/STRIPE_FRONTEND_SPEC.md`                     |
+| 4   | 4126f27 | docs : triage revue design #84/#85                                  |
+| 5   | 977f8c6 | #84 : constante `MARKETING_CLAIMS` (`constants/index.tsx`)          |
+| 6   | fc611cd | #85 : `resolveSuccessRate` + seuils (`features/marketing/lib.ts`)   |
+| 7   | c8438e3 | #91 : fix du test flaky « jeton falsifié »                          |
+| 8   | c139516 | #85 : successRate calculé sur les participations, `rating` hors DAL |
+| 9   | 2a0982e | #84 : les affichages marketing lisent `MARKETING_CLAIMS`            |
+| 10  | 4b5b194 | #87 : corrections doc post-revue                                    |
+
+Conflits attendus : mineurs, sur les composants marketing touchés depuis par
+`96f6987` (fallbacks stats) et les évolutions de `hooks/useMarketingStats.ts`
+(PR #97/#100/#107). Résolution en faveur de l'intention combinée (fallbacks de
+main + claims centralisés de la branche).
+
+Ce code a déjà été revu (revue d'implémentation groupée : « OUI mergeable,
+0 bloquant ») — pas de nouvelle revue du contenu, seulement des résolutions de
+conflits.
+
+Gates : `bun run check`, `bun run test`, coverage ≥ 80 %, `bun run
+test:integration`.
+
+Critères d'acceptation (reprennent l'épic #78) :
+
+- [ ] `grep -rn "85%\|4\.9/5"` ne retourne plus rien hors `MARKETING_CLAIMS`
+      (source unique) et docs historiques ;
+- [ ] `features/marketing/dal.ts` ne retourne plus de constante déguisée en
+      métrique (`rating` hors du type, `successRate` calculé au-delà du seuil) ;
+- [ ] les gates passent.
+
+## Campagne A — Stripe (branche suivante, après B)
+
+1. **#92** : le webhook accepte `payment_status ∈ {"paid", "no_payment_required"}`
+   au fulfillment (promo 100 %) ; test d'intégration `amountTotal: 0` →
+   transaction `completed`, `amountPaid = 0`, accès accordé ; idempotence
+   inchangée.
+2. **#81** : script one-off `scripts/` de lecture seule (clé live limitée
+   existante `nomaqbanq-prod-app`, fournie localement le moment venu ; lecture
+   DB prod via branche Neon éphémère) ; rapport chiffré posté sur l'issue ;
+   décision backfill documentée → fermeture de l'épic #76.
+
+Outillage : Stripe CLI profil `nomaqbanq` (mode test) + `stripe listen` pour la
+vérification vraie-vie de #92.
+
+## Toute fin — purge Convex (dans la dernière PR)
+
+- Supprimer `.claude/skills/convex-*` (6 dossiers) et
+  `scripts/import-from-convex.ts` ;
+- purger les mentions Convex de `.claude/CLAUDE-GUIDELINES.md`,
+  `.claude/rules/data-layer.md`, `.claude/settings.local.json`, `AGENTS.md` et
+  des commentaires de `features/marketing/dal.ts`, `lib/upload-rate-limit.ts`,
+  `app/api/e2e/route.ts` ;
+- les docs historiques (`docs/superpowers/**`, handoffs) sont conservées telles
+  quelles (archives).
+
+## PR
+
+Aucun push avant la toute fin (demande explicite). Deux PR : campagne B, puis
+campagne A (qui embarque la purge Convex). Les épics #78 et #76 se ferment
+après merge, avec un commentaire de traçabilité expliquant le merge fantôme.

--- a/features/marketing/dal.ts
+++ b/features/marketing/dal.ts
@@ -2,14 +2,14 @@ import { isNull, sql } from "drizzle-orm"
 import { cache } from "react"
 import "server-only"
 import { db } from "@/db"
-import { questions, user } from "@/db/schema"
+import { examParticipations, questions, user } from "@/db/schema"
+import { SUCCESS_SCORE_THRESHOLD, resolveSuccessRate } from "./lib"
 
 export type MarketingStats = {
   totalQuestions: string
   totalUsers: string
   totalDomains: number
   successRate: string
-  rating: string
   topDomains: { domain: string; count: number }[]
 }
 
@@ -49,12 +49,31 @@ export const getMarketingStats = cache(async (): Promise<MarketingStats> => {
     // Exclut les comptes supprimés (cohérent avec questions + getAdminStats).
     .where(isNull(user.deletedAt))
 
+  // Taux de réussite réel sur les participations terminées. Pas de jointure
+  // user : les participations de comptes soft-deleted COMPTENT (un passage
+  // d'examen réel reste un point de donnée du taux — on mesure des passages, pas
+  // des comptes actifs ; décision revue design 2026-07-12).
+  const [participationAgg] = await db
+    .select({
+      completed:
+        sql<number>`count(*) filter (where ${examParticipations.status} in ('completed','auto_submitted'))`.mapWith(
+          Number,
+        ),
+      passed:
+        sql<number>`count(*) filter (where ${examParticipations.status} in ('completed','auto_submitted') and ${examParticipations.score} >= ${SUCCESS_SCORE_THRESHOLD})`.mapWith(
+          Number,
+        ),
+    })
+    .from(examParticipations)
+
   return {
     totalQuestions: formatMarketingStat(totalQuestions),
     totalUsers: formatMarketingStat(users?.n ?? 0),
     totalDomains: domainRows.length,
-    successRate: "85%",
-    rating: "4.9/5",
+    successRate: resolveSuccessRate({
+      completed: participationAgg?.completed ?? 0,
+      passed: participationAgg?.passed ?? 0,
+    }),
     topDomains: domainRows.slice(0, 10).map((r) => ({
       domain: r.domain,
       count: r.count,

--- a/features/marketing/lib.ts
+++ b/features/marketing/lib.ts
@@ -1,0 +1,29 @@
+import { MARKETING_CLAIMS } from "@/constants"
+
+// Score (%) minimal d'une participation « réussie ».
+export const SUCCESS_SCORE_THRESHOLD = 60
+// Volume minimal de participations terminées pour publier un taux calculé.
+export const MIN_COMPLETED_PARTICIPATIONS = 50
+// Plancher marketing : sous ce taux, on garde le claim éditorial (page de vente).
+export const MIN_PUBLISHABLE_SUCCESS_RATE = 70
+
+/**
+ * Décide de la valeur affichée : le taux calculé arrondi, OU le claim éditorial
+ * si le volume est insuffisant OU si le taux est sous le plancher de publication.
+ */
+export const resolveSuccessRate = ({
+  completed,
+  passed,
+}: {
+  completed: number
+  passed: number
+}): string => {
+  if (completed < MIN_COMPLETED_PARTICIPATIONS) {
+    return MARKETING_CLAIMS.successRate
+  }
+  const rate = Math.round((passed / completed) * 100)
+  if (rate < MIN_PUBLISHABLE_SUCCESS_RATE) {
+    return MARKETING_CLAIMS.successRate
+  }
+  return `${rate}%`
+}

--- a/tests/hooks/useMarketingStats.test.tsx
+++ b/tests/hooks/useMarketingStats.test.tsx
@@ -16,7 +16,6 @@ const mockStats: MarketingStats = {
   totalUsers: "200+",
   totalDomains: 12,
   successRate: "85%",
-  rating: "4.9/5",
   topDomains: [
     { domain: "Cardiologie", count: 500 },
     { domain: "Neurologie", count: 300 },

--- a/tests/integration/marketing-dal.test.ts
+++ b/tests/integration/marketing-dal.test.ts
@@ -1,0 +1,97 @@
+import { eq, inArray, sql } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { examParticipations, exams, user } from "@/db/schema"
+import { getMarketingStats } from "@/features/marketing/dal"
+import {
+  MIN_COMPLETED_PARTICIPATIONS,
+  SUCCESS_SCORE_THRESHOLD,
+  resolveSuccessRate,
+} from "@/features/marketing/lib"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+const suffix = createId().slice(0, 8)
+const examId = createId()
+const creatorId = createId()
+// Assez de participations pour franchir le seuil de volume à coup sûr.
+const N = MIN_COMPLETED_PARTICIPATIONS + 10
+const userIds = Array.from({ length: N }, () => createId())
+
+const baselineAgg = async () => {
+  const [row] = await db
+    .select({
+      completed:
+        sql<number>`count(*) filter (where status in ('completed','auto_submitted'))`.mapWith(
+          Number,
+        ),
+      passed:
+        sql<number>`count(*) filter (where status in ('completed','auto_submitted') and score >= ${SUCCESS_SCORE_THRESHOLD})`.mapWith(
+          Number,
+        ),
+    })
+    .from(examParticipations)
+  return row ?? { completed: 0, passed: 0 }
+}
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: creatorId,
+    name: "Créateur Marketing",
+    email: `mktg-${suffix}@test.invalid`,
+    emailVerified: true,
+  })
+  await db.insert(exams).values({
+    id: examId,
+    title: `Examen marketing ${suffix}`,
+    startDate: new Date(Date.now() - 48 * 60 * 60 * 1000),
+    endDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    completionTime: 3600,
+    createdBy: creatorId,
+  })
+  await db.insert(user).values(
+    userIds.map((id, i) => ({
+      id,
+      name: `Participant ${i}`,
+      email: `mktg-p-${i}-${suffix}@test.invalid`,
+      emailVerified: true,
+    })),
+  )
+  await db.insert(examParticipations).values(
+    userIds.map((uid) => ({
+      examId,
+      userId: uid,
+      status: "completed" as const,
+      score: 90, // ≥ SUCCESS_SCORE_THRESHOLD → réussite
+      completedAt: new Date(),
+    })),
+  )
+})
+
+afterAll(async () => {
+  await db.delete(exams).where(eq(exams.id, examId)) // cascade participations
+  await db.delete(user).where(inArray(user.id, [creatorId, ...userIds]))
+})
+
+describe("getMarketingStats — successRate calculé", () => {
+  it("ne renvoie plus le champ rating", async () => {
+    const stats = await getMarketingStats()
+    expect(stats).not.toHaveProperty("rating")
+  })
+
+  it("câble l'agrégat SQL sur resolveSuccessRate (oracle exact, baseline develop quelconque)", async () => {
+    // La branche de test est clonée de develop (scripts/neon-api.ts), donc la
+    // baseline n'est JAMAIS vide : l'oracle recalcule l'agrégat réel et exige
+    // l'égalité avec la bascule — exact quelle que soit la baseline (revue design
+    // 2026-07-12, #1 : l'ancien if/else était tautologique dans sa branche else).
+    const agg = await baselineAgg()
+    const stats = await getMarketingStats()
+    expect(stats.successRate).toBe(resolveSuccessRate(agg))
+    // Nos N insertions garantissent le franchissement du seuil de volume.
+    expect(agg.completed).toBeGreaterThanOrEqual(MIN_COMPLETED_PARTICIPATIONS)
+  })
+})

--- a/tests/integration/questions-quiz-dal.test.ts
+++ b/tests/integration/questions-quiz-dal.test.ts
@@ -258,9 +258,12 @@ describe("scoreQuizAnswers (action publique)", () => {
   it("refuse un jeton falsifié ou malformé", async () => {
     withIp(`ip-${createId()}`)
     const valid = signQuizToken([qImg])
-    const tampered = valid.endsWith("A")
-      ? `${valid.slice(0, -1)}B`
-      : `${valid.slice(0, -1)}A`
+    // Altère le PAYLOAD (1er segment) : c'est l'entrée string du HMAC, donc tout
+    // changement casse la signature de façon déterministe. Altérer la SIGNATURE
+    // serait flaky — flipper son dernier char base64url ne change que des bits de
+    // padding et peut décoder aux mêmes octets → jeton accepté par hasard.
+    const [payloadB64, sigB64] = valid.split(".")
+    const tampered = `${payloadB64[0] === "a" ? "b" : "a"}${payloadB64.slice(1)}.${sigB64}`
     for (const bad of [tampered, "abc"]) {
       const result = await scoreQuizAnswers({
         token: bad,

--- a/tests/marketing/success-rate.test.ts
+++ b/tests/marketing/success-rate.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { MARKETING_CLAIMS } from "@/constants"
+import {
+  MIN_COMPLETED_PARTICIPATIONS,
+  MIN_PUBLISHABLE_SUCCESS_RATE,
+  SUCCESS_SCORE_THRESHOLD,
+  resolveSuccessRate,
+} from "@/features/marketing/lib"
+
+const EDITORIAL = MARKETING_CLAIMS.successRate
+
+describe("resolveSuccessRate", () => {
+  it("retombe sur l'éditorial sous le seuil de volume", () => {
+    expect(resolveSuccessRate({ completed: 49, passed: 49 })).toBe(EDITORIAL)
+  })
+
+  it("retombe sur l'éditorial à 0 participation (pas de division par zéro)", () => {
+    expect(resolveSuccessRate({ completed: 0, passed: 0 })).toBe(EDITORIAL)
+  })
+
+  it("publie le taux calculé au seuil exact de volume si ≥ plancher", () => {
+    // 50 terminées, 40 réussies → 80 % ≥ 70 % → publié.
+    expect(resolveSuccessRate({ completed: 50, passed: 40 })).toBe("80%")
+  })
+
+  it("retombe sur l'éditorial quand le taux est sous le plancher de publication", () => {
+    // 100 terminées, 42 réussies → 42 % < 70 % → éditorial.
+    expect(resolveSuccessRate({ completed: 100, passed: 42 })).toBe(EDITORIAL)
+  })
+
+  it("publie exactement au plancher (70 %) mais pas juste en dessous (69 %)", () => {
+    expect(resolveSuccessRate({ completed: 100, passed: 70 })).toBe("70%")
+    expect(resolveSuccessRate({ completed: 100, passed: 69 })).toBe(EDITORIAL)
+  })
+
+  it("arrondit le taux (Math.round)", () => {
+    // 60 terminées, 47 réussies → 78,33 % → 78 %.
+    expect(resolveSuccessRate({ completed: 60, passed: 47 })).toBe("78%")
+  })
+
+  it("expose des seuils cohérents avec la spec", () => {
+    expect(SUCCESS_SCORE_THRESHOLD).toBe(60)
+    expect(MIN_COMPLETED_PARTICIPATIONS).toBe(50)
+    expect(MIN_PUBLISHABLE_SUCCESS_RATE).toBe(70)
+  })
+})

--- a/tests/questions/quiz-token.test.ts
+++ b/tests/questions/quiz-token.test.ts
@@ -43,10 +43,11 @@ describe("signQuizToken / verifyQuizToken", () => {
   })
 
   it("refuse une signature altérée", () => {
-    const token = signQuizToken(["q-a"])
-    const flipped = token.endsWith("A")
-      ? `${token.slice(0, -1)}B`
-      : `${token.slice(0, -1)}A`
+    const [payloadB64, sigB64] = signQuizToken(["q-a"]).split(".")
+    // Altère le PREMIER char de la signature (bits de poids fort, jamais du
+    // padding) → décode à des octets différents de façon déterministe. Flipper le
+    // DERNIER char serait flaky (2 bits de padding sur un HMAC de 32 octets).
+    const flipped = `${payloadB64}.${sigB64[0] === "a" ? "b" : "a"}${sigB64.slice(1)}`
     expect(verifyQuizToken(flipped)).toBeNull()
   })
 


### PR DESCRIPTION
Closes #78.

## Contexte : merge fantôme

La PR #96 (squash `c7638a2`) annonçait « Closes #84 #85 #87 #88 #91 » mais a été mergée depuis un état obsolète de la branche distante : **seul le travail #91 a atterri dans main**. GitHub a fermé les 4 autres issues sans que leur code n'existe sur main (preuve : `features/marketing/dal.ts` portait encore `successRate: "85%"` en dur). Les issues #84/#85/#87/#88 restent closes — cette PR fait atterrir leur code réel.

## Contenu

Cherry-pick des 10 commits perdus (code déjà passé en revue adversariale à l'époque, verdict « OUI mergeable, 0 bloquant »), appliqués **sans conflit** sur un main à jour :

- **#84** : constante `MARKETING_CLAIMS` (`constants/index.tsx`) = source unique des claims éditoriaux ; les 5 affichages marketing la lisent.
- **#85** : `resolveSuccessRate` + seuils (`features/marketing/lib.ts`) — le taux de réussite est calculé sur les vraies participations d'examens dès que le volume suffit ; `rating` sort du DAL (le type ne ment plus).
- **#87** : `docs/STRIPE_FRONTEND_SPEC.md` réécrit pour l'architecture Drizzle/Better Auth (+ correctif post-revue : le webhook honore aussi `no_payment_required`).
- **#88** : retrait du scaffolding mort « Bientôt »/`disabled` de `profile-preferences`.
- Fix du test flaky #91 (jeton falsifié déterministe).

## Critères de l'épic #78 vérifiés

- `grep 85%|4.9/5` : plus aucune valeur en dur hors `MARKETING_CLAIMS` (metadata SEO comprises).
- Le DAL ne retourne plus de constante déguisée en métrique.

## Gates

`bun run check` ✅ · 928 tests frontend ✅ · coverage 82,7 % ✅ · 270 tests d'intégration ✅ (incluant `marketing-dal.test.ts`, oracle exact sur branche Neon éphémère). Revue adversariale post-récupération : OUI, 0 constat sur cette branche.

⚠️ **Ordre de merge : cette PR d'abord**, puis #109 (la purge Convex de l'autre PR suppose la réécriture de `STRIPE_FRONTEND_SPEC.md` faite ici).
