### PR TITLE
Milestone sécurité : observabilité erreurs (C1) + intégrité examens (C2) + filet tests & CI (C3)

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -30,6 +30,16 @@ storagePath,order}` pour rester assignable aux composants partagés
 
 - `"use server"` → guard → `zod.safeParse` (early `fail(message)`) → écriture →
   `revalidatePath`.
+- **Catch fallback = `captureServerError`** (`lib/observability.ts`) : tag
+  statique + `{ userId }` si en scope — JAMAIS de payload (PII). Réservé aux
+  exceptions inattendues : les erreurs métier mappées (zod, TIME_UP,
+  ACCESS_EXPIRED, 23505 username, `resource_missing` Stripe, `APIError` Better
+  Auth…) `return fail(...)` SANS capture (sinon on recrée le bruit filtré en
+  #105). Codes pg : `getPgErrorCode`/`isPgUniqueViolation` (`lib/db-errors.ts`)
+  — ne JAMAIS tester `error.code` en surface (Drizzle enveloppe dans `cause` ;
+  branche morte, bug updateProfile). Les route handlers qui catchent puis
+  répondent 500 (webhook Stripe) DOIVENT capturer eux-mêmes : `onRequestError`
+  ne voit jamais une erreur catchée.
 - **Concurrence par utilisateur** : `db.transaction` + `SELECT … .for("update")`
   (verrou de ligne) englobant check + insert. Postgres (READ COMMITTED) ne
   sérialise pas les checks applicatifs — sans le verrou, deux requêtes

--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -43,7 +43,21 @@ storagePath,order}` pour rester assignable aux composants partagés
 - **Concurrence par utilisateur** : `db.transaction` + `SELECT … .for("update")`
   (verrou de ligne) englobant check + insert. Postgres (READ COMMITTED) ne
   sérialise pas les checks applicatifs — sans le verrou, deux requêtes
-  concurrentes passent toutes deux le check.
+  concurrentes passent toutes deux le check. Un `EXISTS (…)` dans le `WHERE`
+  d'un UPDATE NE suffit PAS contre une transaction concurrente en vol : il lit
+  la dernière version committée et ne se met pas en file derrière un `FOR UPDATE`
+  détenu (ex. `saveExamAnswer` vs `finalizeExam` sur la même participation →
+  verrou de ligne, pas EXISTS).
+- **Passation d'examen — invariante d'accès** : le contenu des questions n'est
+  livré/écrit que pour une participation `in_progress` (créée par `startExam`,
+  seul à vérifier fenêtre+accès+audience). La page evaluation ne met les
+  questions dans le payload RSC qu'en `in_progress` (le client `router.refresh()`
+  après `startExam`) ; `getExamWithQuestions` re-garde `hasAccess("exam")` pour
+  `subscribers` (défense en profondeur — un `null` sur la page détail rend la
+  carte paywall, PAS un 404). Budget-temps anti-triche gardé À L'ÉCRITURE
+  (`saveExamAnswer` refuse au-delà de `startedAt + completionTime + grâce`), pas
+  seulement à la finalisation (`isAutoSubmit` vient du client). `updateExam` et
+  `startExam` prennent un `FOR UPDATE` commun sur la ligne `exams`.
 - **Narrowing TS** : renvoyer la valeur DEPUIS le callback de transaction
   (`const r = await db.transaction(async tx => { … return v })`), PAS via un
   `let` capturé dans la closure — TS ne le narrow pas après un garde `if (!r)`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,37 @@ jobs:
       # C'est désormais le seul garde-fou de couverture : plus d'upload tiers.
       - name: Tests with coverage
         run: bun run test:coverage
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Cache Bun install
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Orchestrateur : crée une branche Neon jetable (test-*), migre, lance le
+      # projet vitest `integration`, détruit la branche. Seuls secrets requis :
+      # NEON_API_KEY + NEON_PROJECT_ID (l'URL DB vient de la branche créée ;
+      # l'env applicatif vient de tests/helpers/test-env.ts).
+      - name: Integration tests (ephemeral Neon branch)
+        run: bun run test:integration
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}

--- a/app/(admin)/error.tsx
+++ b/app/(admin)/error.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as Sentry from "@sentry/nextjs"
 import { ArrowLeft, RefreshCw, Settings } from "lucide-react"
 import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
@@ -13,7 +14,9 @@ export default function AdminError({
   reset: () => void
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
+    // Doublon SSR voulu : crash serveur = event onRequestError (vraie stack)
+    // + cet event digest ; crash client = cet event seul. Ne pas retirer.
+    Sentry.captureException(error)
     console.error("Admin Panel Error:", error)
   }, [error])
 

--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as Sentry from "@sentry/nextjs"
 import { ArrowLeft, RefreshCw, User } from "lucide-react"
 import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
@@ -13,7 +14,9 @@ export default function DashboardError({
   reset: () => void
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
+    // Doublon SSR voulu : crash serveur = event onRequestError (vraie stack)
+    // + cet event digest ; crash client = cet event seul. Ne pas retirer.
+    Sentry.captureException(error)
     console.error("Dashboard Error:", error)
   }, [error])
 

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { ShieldAlert, TriangleAlert } from "lucide-react"
+import { Loader2, ShieldAlert, TriangleAlert } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useState } from "react"
+import { useState, useTransition } from "react"
 import { toast } from "sonner"
 import { QuizRunner } from "@/components/quiz/runner/quiz-runner"
 import type {
@@ -62,6 +62,7 @@ export function EvaluationClient({
   initialAnswersRaw,
 }: EvaluationClientProps) {
   const router = useRouter()
+  const [isStarting, startTransition] = useTransition()
 
   // serverStartTime: null = pas encore démarré, number = démarré
   const resuming = isInProgress(initialSession)
@@ -201,25 +202,28 @@ export function EvaluationClient({
       : undefined,
   }
 
-  // Démarrage de l'examen
-  const handleStartExam = async () => {
-    try {
-      const result = await startExam({ examId })
-      if (!result.success) {
-        toast.error(result.error)
+  // Démarrage de l'examen. La page ne met les questions dans le payload RSC
+  // qu'en in_progress : on ne démonte le dialog (bouton « Démarrage… » entre
+  // temps) qu'une fois le router.refresh() appliqué, dans la même transition,
+  // pour ne jamais monter le runner à vide avec le chrono lancé.
+  const handleStartExam = () => {
+    startTransition(async () => {
+      try {
+        const result = await startExam({ examId })
+        if (!result.success) {
+          toast.error(result.error)
+          router.push("/tableau-de-bord/examen-blanc")
+          return
+        }
+        setServerStartTime(result.startedAt ?? null)
+        toast.success("Examen démarré - Bonne chance !")
+        router.refresh()
+        setShowWarningDialog(false)
+      } catch {
+        toast.error("Erreur lors du démarrage de l'examen")
         router.push("/tableau-de-bord/examen-blanc")
-        return
       }
-      setServerStartTime(result.startedAt ?? null)
-      setShowWarningDialog(false)
-      toast.success("Examen démarré - Bonne chance !")
-      // La page ne livre les questions qu'en in_progress : re-fetch le Server
-      // Component pour les recevoir (l'état client est préservé au travers).
-      router.refresh()
-    } catch {
-      toast.error("Erreur lors du démarrage de l'examen")
-      router.push("/tableau-de-bord/examen-blanc")
-    }
+    })
   }
 
   // Dialogue d'avertissement avant démarrage
@@ -309,19 +313,41 @@ export function EvaluationClient({
             <DialogFooter className="gap-2">
               <Button
                 variant="outline"
+                disabled={isStarting}
                 onClick={() => router.push("/tableau-de-bord/examen-blanc")}
               >
                 Annuler
               </Button>
               <Button
                 onClick={handleStartExam}
+                disabled={isStarting}
                 className="bg-linear-to-r from-green-600 to-emerald-600 font-semibold text-white hover:from-green-700 hover:to-emerald-700"
               >
-                Je comprends - Commencer l&apos;examen
+                {isStarting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Démarrage…
+                  </>
+                ) : (
+                  "Je comprends - Commencer l'examen"
+                )}
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
+      </div>
+    )
+  }
+
+  // Fenêtre transitoire entre startExam et l'arrivée des questions via refresh :
+  // ne jamais monter le runner à vide (chrono lancé sur un examen sans question).
+  if (totalQuestions === 0) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-linear-to-br from-gray-50 via-white to-blue-50/30 dark:from-gray-900 dark:via-gray-900 dark:to-blue-900/10">
+        <div className="text-muted-foreground flex items-center gap-3">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          Chargement de l&apos;examen…
+        </div>
       </div>
     )
   }

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx
@@ -213,6 +213,9 @@ export function EvaluationClient({
       setServerStartTime(result.startedAt ?? null)
       setShowWarningDialog(false)
       toast.success("Examen démarré - Bonne chance !")
+      // La page ne livre les questions qu'en in_progress : re-fetch le Server
+      // Component pour les recevoir (l'état client est préservé au travers).
+      router.refresh()
     } catch {
       toast.error("Erreur lors du démarrage de l'examen")
       router.push("/tableau-de-bord/examen-blanc")

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/page.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from "next/navigation"
+import { redirect } from "next/navigation"
 import {
   getExamAnswersForParticipation,
   getExamSession,
@@ -12,18 +12,27 @@ export default async function EvaluationPage({
   params: Promise<{ examId: string }>
 }) {
   const { examId } = await params
-  const data = await getExamWithQuestions(examId)
-  if (!data) notFound()
 
-  const [session, initialAnswersRaw] = await Promise.all([
-    getExamSession(examId),
-    getExamAnswersForParticipation(examId),
-  ])
+  const session = await getExamSession(examId)
 
-  // Session déjà soumise → redirection serveur (évite les effets de bord dans le rendu client).
+  // Déjà soumis → résumé (UX conservée, évite un examen re-jouable).
   if (session?.status === "completed" || session?.status === "auto_submitted") {
     redirect(`/tableau-de-bord/examen-blanc/${examId}/soumis`)
   }
+
+  const data = await getExamWithQuestions(examId)
+  // Non-abonné (DAL → null) : renvoyé vers la carte paywall de la page détail.
+  if (!data) redirect(`/tableau-de-bord/examen-blanc/${examId}`)
+
+  // Invariante anti-fuite : les questions ne partent dans le payload RSC que pour
+  // une participation in_progress (créée par startExam, seul à vérifier
+  // fenêtre+accès+audience). Sans participation → écran de démarrage sans
+  // questions ; le client fait router.refresh() après startExam pour les
+  // recevoir. Ferme subscribers, restricted ET le pré-fetch pré-fenêtre.
+  const inProgress = session?.status === "in_progress"
+  const initialAnswersRaw = inProgress
+    ? await getExamAnswersForParticipation(examId)
+    : []
 
   return (
     <EvaluationClient
@@ -34,7 +43,7 @@ export default async function EvaluationPage({
         enablePause: data.exam.enablePause,
         pauseDurationMinutes: data.exam.pauseDurationMinutes,
       }}
-      questions={data.questions}
+      questions={inProgress ? data.questions : []}
       initialSession={session}
       initialAnswersRaw={initialAnswersRaw}
     />

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/page.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/page.tsx
@@ -15,17 +15,67 @@ import { StudentExamDetailsClient } from "./_components/student-exam-details-cli
 // Hors composant : isole l'horloge (impure) du corps de rendu.
 const isExamClosed = (endDateMs: number) => endDateMs < Date.now()
 
+// Carte « Accès non autorisé » : paywall (pas d'accès exam) ou résultats non
+// encore ouverts. Rendue aussi quand le DAL renvoie null pour un non-abonné
+// (préserve le tunnel d'achat au lieu d'un 404 sec).
+function ExamAccessDeniedCard({
+  resultsNotReady = false,
+}: {
+  readonly resultsNotReady?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-4 p-4 md:gap-6 lg:p-6">
+      <div className="flex items-center gap-3 md:gap-4">
+        <Button
+          className="hover:text-blue-700 dark:hover:text-white"
+          variant="outline"
+          size="sm"
+          asChild
+        >
+          <Link href="/tableau-de-bord/examen-blanc">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Retour
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center py-12">
+          <h3 className="font-display mb-2 text-lg font-semibold">
+            Accès non autorisé
+          </h3>
+          <p className="text-muted-foreground mb-4 max-w-md text-center">
+            {resultsNotReady
+              ? "Les résultats de cet examen ne sont pas encore disponibles."
+              : "Vous devez avoir un accès exam actif pour accéder à cet examen."}
+          </p>
+          <Button asChild>
+            <Link href="/tableau-de-bord/examen-blanc">Retour aux examens</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
 export default async function MockExamDetailsPage({
   params,
 }: {
   params: Promise<{ examId: string }>
 }) {
   const { examId } = await params
-  const data = await getExamWithQuestions(examId)
-  if (!data) notFound()
-
   const session = await getCurrentSession()
   const isAdmin = session?.user?.role === "admin"
+
+  const data = await getExamWithQuestions(examId)
+  if (!data) {
+    // Non-admin + null = pas d'accès (ou examen confidentiel) → carte paywall,
+    // pas un 404 sec (préserve le tunnel d'achat). Admin ne voit null que si
+    // l'examen n'existe pas.
+    if (isAdmin) notFound()
+    return <ExamAccessDeniedCard />
+  }
+
   const isClosed = isExamClosed(data.exam.endDate)
   // Examen restreint : `getExamWithQuestions` a déjà autorisé l'accès (membre de
   // l'audience ou participation) — la sélection octroie l'accès, l'abonnement
@@ -36,41 +86,7 @@ export default async function MockExamDetailsPage({
 
   // Non-admins : accès aux détails uniquement si l'examen est fermé ET accès actif.
   if (!isAdmin && (!isClosed || !examAccess)) {
-    return (
-      <div className="flex flex-col gap-4 p-4 md:gap-6 lg:p-6">
-        <div className="flex items-center gap-3 md:gap-4">
-          <Button
-            className="hover:text-blue-700 dark:hover:text-white"
-            variant="outline"
-            size="sm"
-            asChild
-          >
-            <Link href="/tableau-de-bord/examen-blanc">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Retour
-            </Link>
-          </Button>
-        </div>
-
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-12">
-            <h3 className="font-display mb-2 text-lg font-semibold">
-              Accès non autorisé
-            </h3>
-            <p className="text-muted-foreground mb-4 max-w-md text-center">
-              {!examAccess
-                ? "Vous devez avoir un accès exam actif pour accéder à cet examen."
-                : "Les résultats de cet examen ne sont pas encore disponibles."}
-            </p>
-            <Button asChild>
-              <Link href="/tableau-de-bord/examen-blanc">
-                Retour aux examens
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    )
+    return <ExamAccessDeniedCard resultsNotReady={examAccess} />
   }
 
   const [leaderboard, examSession] = await Promise.all([

--- a/app/api/cron/close-expired/route.ts
+++ b/app/api/cron/close-expired/route.ts
@@ -3,6 +3,7 @@ import { sendPendingNotifications } from "@/features/notifications/cron"
 import { closeExpiredTrainingSessions } from "@/features/training/cron"
 import { anonymizeExpiredDeletedAccounts } from "@/features/users/cron"
 import { env } from "@/lib/env/server"
+import { captureServerError } from "@/lib/observability"
 import { cleanupQuizRateLimits } from "@/lib/quiz-rate-limit"
 
 // Accès DB → runtime Node.
@@ -51,6 +52,7 @@ export async function GET(request: Request) {
   let failed = false
   const run = async <T>(
     label: string,
+    tag: string,
     task: () => Promise<T>,
     empty: T,
   ): Promise<T> => {
@@ -58,37 +60,43 @@ export async function GET(request: Request) {
       return await task()
     } catch (error) {
       failed = true
-      console.error(`[cron close-expired] ${label} en échec`, error)
+      captureServerError(tag, error, { detail: label })
       return empty
     }
   }
 
   const examParticipations = await run(
     "clôture examens",
+    "[cron:exams]",
     closeExpiredExamParticipations,
     { closedCount: 0 },
   )
   const trainingSessions = await run(
     "clôture entraînements",
+    "[cron:trainings]",
     closeExpiredTrainingSessions,
     { closedCount: 0 },
   )
   const anonymizedAccounts = await run(
     "anonymisation",
+    "[cron:anonymize]",
     anonymizeExpiredDeletedAccounts,
     { anonymizedCount: 0 },
   )
   const quizRateLimitCleanup = await run(
     "purge rate-limit quiz",
+    "[cron:quiz-rl]",
     cleanupQuizRateLimits,
     { deletedCount: 0 },
   )
 
   // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
-  const notifications = await run("notifications", sendPendingNotifications, {
-    examResultsSent: 0,
-    accessRemindersSent: 0,
-  })
+  const notifications = await run(
+    "notifications",
+    "[cron:notifications]",
+    sendPendingNotifications,
+    { examResultsSent: 0, accessRemindersSent: 0 },
+  )
 
   if (failed) return new Response("Cron handler error", { status: 500 })
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -3,6 +3,7 @@ import {
   completeStripeTransaction,
   failStripeTransaction,
 } from "@/features/payments/stripe"
+import { captureServerError } from "@/lib/observability"
 import { getStripe, getStripeWebhookSecret } from "@/lib/stripe"
 
 // Le SDK Stripe nécessite le runtime Node (pas Edge).
@@ -36,7 +37,7 @@ export async function POST(request: Request) {
     stripe = getStripe()
     webhookSecret = getStripeWebhookSecret()
   } catch (error) {
-    console.error("[stripe webhook] configuration manquante", error)
+    captureServerError("[stripe:webhook]", error, { detail: "configuration" })
     return new Response("Server configuration error", { status: 500 })
   }
 
@@ -75,9 +76,12 @@ export async function POST(request: Request) {
             currency: checkoutSession.currency,
           })
           if (result.status === "not_found") {
-            console.error(
-              "[stripe webhook] aucune transaction pour la session",
-              checkoutSession.id,
+            // Transaction fantôme (payé sans pending en base) : anomalie réelle,
+            // mais 200 conservé — rejouer l'événement ne la fera pas apparaître.
+            captureServerError(
+              "[stripe:webhook]",
+              new Error("aucune transaction pour la session Stripe"),
+              { detail: `session ${checkoutSession.id}` },
             )
           }
         }
@@ -108,7 +112,10 @@ export async function POST(request: Request) {
         break
     }
   } catch (error) {
-    console.error("[stripe webhook] erreur de traitement", event.type, error)
+    // `onRequestError` ne voit jamais cette erreur (catchée puis convertie en
+    // Response 500) : la capture explicite est la SEULE trace Sentry du
+    // fulfillment. Le 500 → retry Stripe est le contrat, ne pas y toucher.
+    captureServerError("[stripe:webhook]", error, { detail: event.type })
     return new Response("Webhook handler error", { status: 500 })
   }
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as Sentry from "@sentry/nextjs"
 import { House, RefreshCw, TriangleAlert } from "lucide-react"
 import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
@@ -13,7 +14,9 @@ export default function Error({
   reset: () => void
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
+    // Doublon SSR voulu : crash serveur = event onRequestError (vraie stack)
+    // + cet event digest ; crash client = cet event seul. Ne pas retirer.
+    Sentry.captureException(error)
     console.error("Application Error:", error)
   }, [error])
 

--- a/docs/superpowers/handoffs/2026-07-14-milestone-c1-c2-c3-progress.md
+++ b/docs/superpowers/handoffs/2026-07-14-milestone-c1-c2-c3-progress.md
@@ -1,0 +1,107 @@
+# Handoff — Milestone C1+C2+C3 (audit 2026-07-13)
+
+- **Date** : 2026-07-14
+- **Contexte** : audit complet du repo (6 agents) → campagnes. Ce milestone = les
+  3 premières (socle sécurité/observabilité/tests). Revue d'implémentation + e2e
+  faits UNE fois, groupés, à la fin des trois (décision utilisateur).
+- **Stack de branches (RIEN poussé)** : `main` ← `c1-observabilite` ←
+  `c2-integrite-examens` ← `c3-tests-ci` (HEAD). 21 commits au-dessus de `main`.
+
+## État : les 3 campagnes IMPLÉMENTÉES, gates verts
+
+Chaque campagne a eu : brainstorm → spec → plan → **revue adversariale de
+DESIGN** (session fraîche, triée à la source) → implémentation inline
+(executing-plans, TDD, commits par task) → checkpoint gates. Specs/plans sous
+`docs/superpowers/{specs,plans}/2026-07-14-*`. Rapports de revue jetables
+supprimés.
+
+### C1 — Observabilité & erreurs (`c1-observabilite`, 9 commits)
+
+`lib/observability.ts` (`captureServerError` : `server-only`, Sentry prod-only,
+tag statique + userId, ZÉRO PII) + `lib/db-errors.ts`
+(`getPgErrorCode`/`isPgUniqueViolation` — corrige bug 23505 `updateProfile` sous
+course). Remplace 26 `logDev` + 9 blocs `NODE_ENV`. Filtres métier :
+`resource_missing` (verifyStripeCheckout), `APIError` Better Auth
+(setAccountPassword, catch était nu). Boundaries → Sentry. Crons tags par tâche +
+anonymisation RGPD. **Webhook Stripe capturé** (constat 🔴 revue : `onRequestError`
+ne voit pas une erreur catchée+répondue 500). Convention dans
+`.claude/rules/data-layer.md`.
+
+### C2 — Intégrité & sécurité examens (`c2-integrite-examens`, 6 commits)
+
+- **Fuite contenu** : la page evaluation est le GUICHET d'entrée (appelle
+  `startExam`) → on ne gate PAS l'accès mais on **conditionne la livraison des
+  questions** à une participation `in_progress` (`questions=[]` sinon) +
+  `router.refresh()` client après `startExam`. Garde DAL `hasAccess` subscribers.
+  Page détail : `null` → carte paywall (`ExamAccessDeniedCard`), pas 404.
+- **Budget-temps** gardé À L'ÉCRITURE (`saveExamAnswer`, pas seulement finalize
+  qui saute `TIME_UP` sur `isAutoSubmit` client).
+- **Race save/finalize** : transaction + `FOR UPDATE` participation (un `EXISTS`
+  ne suffit pas sous READ COMMITTED — constat revue).
+- **Race updateExam/startExam** : `FOR UPDATE` commun sur la ligne `exams`.
+- **Cap** `MAX_EXAM_QUESTIONS` sur `loadExamQuestionExplanations`.
+
+### C3 — Filet tests & CI (`c3-tests-ci`, 6 commits)
+
+Job CI `integration` (réutilise `scripts/test-integration.ts`). Tests :
+`createStripeCheckout` (transaction pending, assertions INDÉPENDANTES du produit
+résolu car `products.code` non unique + develop a déjà un exam_access), contrat
+HTTP webhook (400/200/filtre/dispatch, `beforeEach(vi.clearAllMocks())`),
+`verifyStripeCheckout` IDOR + happy. **Course de fulfillment = 2 tx DISTINCTES →
+cumul 180j prouve le verrou** (2 tx identiques ne prouvent rien : unicité via
+`onConflictDoUpdate`, pas le verrou — constat 🔴 revue).
+
+## Gates (dernier checkpoint sur `c3-tests-ci`)
+
+`bun run check` exit 0 · `bun run test` **957** (frontend) · `bun run
+test:integration` **279** (30 fichiers, branche Neon éphémère). Verts.
+
+## Secrets CI ✅ posés (2026-07-14)
+
+`NEON_API_KEY` + `NEON_PROJECT_ID` ajoutés en secrets GitHub
+`RinKhimera/NOMAQbanq` via `gh secret set` (valeurs lues de `.env.local`, jamais
+affichées). Le job CI `integration` verdira au 1er run (push/PR).
+
+## Revue d'implémentation ✅ FAITE + triée (2026-07-14)
+
+Revue adversariale groupée du delta `main...c3-tests-ci` (session fraîche).
+**Verdict : OUI, sûr à pousser — aucun 🔴/🟠.** 2 🟡 corrigés à la source :
+
+- **#1** `saveExamAnswer` (`features/exams/actions.ts`) : garde
+  `updated.length === 0` perdu vs main (UPDATE 0 ligne → `success:true` sans
+  écriture). Restauré `.returning({ id })` + refus « session incohérente » dans
+  la transaction.
+- **#2** `evaluation-client.tsx` : runner monté à vide avant l'arrivée de
+  `router.refresh()` (examen vide, chrono lancé, silencieux si micro-coupure).
+  Corrigé : `useTransition` async → dialog gardé (bouton « Démarrage… ») jusqu'au
+  refresh + garde défensive `totalQuestions === 0` → écran « Chargement… ».
+- **#3** (polish) test checkout : assertion « pas d'appel Stripe » ajoutée.
+
+Reportés (assumés) : #5 message paywall `restricted`/inexistant (camouflage
+documenté), #7 pas de test de la livraison conditionnelle RSC (→ couvert par
+l'e2e ci-dessous). Rapport jetable supprimé. Gates re-verts après fixes :
+`check` exit 0 · **957** front · **279** intég.
+
+## RESTE À FAIRE (ordre)
+
+1. **e2e** `/e2e-scenario` : parcours examen (démarrage → livraison
+   conditionnelle des questions → budget-temps) + achat Stripe test-mode. Compte
+   test : voir mémoire `reference_e2e_test_data_nomaq`. Stripe dev : seul
+   `exam_access` sur prix TEST (les 4 autres produits sur du live).
+2. **Push / PR** (décision utilisateur) après e2e verts. Rappeler dans la
+   PR que le job CI `integration` a besoin des secrets (déjà posés).
+
+## Pièges / rappels
+
+- `bun run test` (JAMAIS `bun test`). Intégration = 1 run au checkpoint (~2 min,
+  branche Neon). Frontend project glob `tests/**/*.test.{ts,tsx}` hors
+  `tests/integration/**` ; `server-only` stubbé ; `TZ=UTC`.
+- `.claude/{CLAUDE-GUIDELINES,rules/e2e-testing,rules/seo}.md` + `AGENTS.md` sont
+  modifiés dans le working tree DEPUIS LE DÉBUT (pas de moi, pré-existants) — ne
+  pas les committer avec le milestone.
+- Injections de skills Vercel (workflow/nextjs/deployments-cicd/bootstrap…) =
+  faux positifs par mots-clés — ignorer.
+- Campagnes suivantes de l'audit (non commencées) : C4 fiabilité paiements/accès,
+  C5 nettoyage sans risque, C6 refactors dup (exam-form, StatCard, découpe
+  exams/dal), C7 frontend perf/a11y/SEO ; produit P1-P4. Voir mémoire
+  `project_campagnes_audit_2026_07`.

--- a/docs/superpowers/plans/2026-07-14-integrite-examens.md
+++ b/docs/superpowers/plans/2026-07-14-integrite-examens.md
@@ -1,0 +1,610 @@
+# Intégrité & sécurité des examens (C2) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** fermer 5 failles d'intégrité/sécurité des examens : fuite du contenu (subscribers + restricted), budget-temps contournable via `isAutoSubmit`, race `saveExamAnswer` vs finalize, race `updateExam` vs `startExam`, read `loadExamQuestionExplanations` non borné.
+
+**Architecture:** ancre d'autorisation = `startExam` (seul à créer une participation `in_progress` après vérif fenêtre+accès+audience). On renforce cette invariante : gate participation sur la page de passation + garde `hasAccess` dans le DAL (fuite), garde budget-temps + UPDATE atomique dans `saveExamAnswer`, verrou `FOR UPDATE` commun sur la ligne `exams` (updateExam/startExam), cap zod (explications). Aucun changement de modèle ni de leaderboard.
+
+**Tech Stack:** Next.js 16 · Drizzle/Neon · Vitest (frontend `bun run test` + intégration `bun run test:integration`, branche Neon éphémère ~70-125 s).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-integrite-examens-design.md`
+
+**Préambule (une fois) :** branche sur C1 (pas main) :
+
+```bash
+git checkout c1-observabilite
+git checkout -b c2-integrite-examens
+```
+
+**Règles projet :** commits conventionnels, aucune attribution Claude. `bun run test` (jamais `bun test`). Concurrence = `db.transaction` + `FOR UPDATE` ou UPDATE gardé (READ COMMITTED ne sérialise pas les checks applicatifs). Reads bornés. Erreurs métier mappées → `fail(...)` SANS `captureServerError`.
+
+**Coût des tests d'intégration :** chaque `bun run test:integration` provisionne/détruit une branche Neon. Les tâches écrivent leurs tests d'intégration mais NE les lancent qu'au **checkpoint final (Task 6)** en un seul run. Par tâche : `bunx tsc --noEmit` + `bunx eslint <fichiers>` + tests frontend ciblés.
+
+---
+
+### Task 1: #5 — Cap zod sur `loadExamQuestionExplanations`
+
+**Files:**
+
+- Modify: `features/exams/schemas.ts` (nouveau schéma), `features/exams/actions.ts:56-61` (`loadExamQuestionExplanations`)
+- Test: `tests/features/exam-explanations-cap.test.ts` (nouveau, frontend)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/features/exam-explanations-cap.test.ts
+import { describe, expect, it } from "vitest"
+import { MAX_EXAM_QUESTIONS } from "@/features/exams/schemas"
+import { loadExamQuestionExplanationsSchema } from "@/features/exams/schemas"
+
+describe("loadExamQuestionExplanationsSchema", () => {
+  it("accepte 1 à MAX_EXAM_QUESTIONS ids", () => {
+    expect(loadExamQuestionExplanationsSchema.safeParse(["a"]).success).toBe(
+      true,
+    )
+    expect(
+      loadExamQuestionExplanationsSchema.safeParse(
+        Array(MAX_EXAM_QUESTIONS).fill("a"),
+      ).success,
+    ).toBe(true)
+  })
+  it("refuse 0 id et > MAX_EXAM_QUESTIONS ids", () => {
+    expect(loadExamQuestionExplanationsSchema.safeParse([]).success).toBe(false)
+    expect(
+      loadExamQuestionExplanationsSchema.safeParse(
+        Array(MAX_EXAM_QUESTIONS + 1).fill("a"),
+      ).success,
+    ).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test tests/features/exam-explanations-cap.test.ts`
+Expected: FAIL — `loadExamQuestionExplanationsSchema` n'existe pas.
+
+- [ ] **Step 3: Add schema**
+
+Dans `features/exams/schemas.ts` (après les autres schémas) — cap =
+`MAX_EXAM_QUESTIONS` (constante existante `:6`, = 500), PAS 100 : « Tout déplier »
+en résultats (`session-results.tsx:232`) envoie tous les ids d'un examen en UN
+appel ; un cap < taille réelle (≤500 schéma / ≤230 formulaire) → `[]` silencieux
+→ explications définitivement vides.
+
+```ts
+export const loadExamQuestionExplanationsSchema = z
+  .array(z.string())
+  .min(1)
+  .max(MAX_EXAM_QUESTIONS)
+```
+
+- [ ] **Step 4: Guard the action**
+
+Dans `features/exams/actions.ts`, `loadExamQuestionExplanations` :
+
+```ts
+export const loadExamQuestionExplanations = async (
+  questionIds: string[],
+): Promise<QuestionExplanationView[]> => {
+  await requireSession()
+  const parsed = loadExamQuestionExplanationsSchema.safeParse(questionIds)
+  if (!parsed.success) return []
+  return getExamQuestionExplanations(parsed.data)
+}
+```
+
+Ajouter `loadExamQuestionExplanationsSchema` à l'import depuis `./schemas`.
+
+- [ ] **Step 5: Run test + lint**
+
+Run: `bun run test tests/features/exam-explanations-cap.test.ts` → PASS
+Run: `bunx tsc --noEmit && bunx eslint features/exams/actions.ts features/exams/schemas.ts` → 0 erreur
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/exams/schemas.ts features/exams/actions.ts tests/features/exam-explanations-cap.test.ts
+git commit -m "fix(exams): borne l'entrée de loadExamQuestionExplanations (cap MAX_EXAM_QUESTIONS)"
+```
+
+---
+
+### Task 2: #1 — Fuite du contenu d'examen (livraison conditionnelle + garde DAL + paywall)
+
+⚠️ **La page evaluation est le GUICHET d'entrée** (revue constat A) : la liste y
+navigue SANS participation (`examen-blanc-client.tsx:447`) et c'est le dialog
+« Règles » de cette page qui appelle `startExam` (`evaluation-client.tsx:205`).
+Un gate `notFound` sur l'absence de participation casserait tout démarrage. On
+conditionne la **livraison des questions**, pas l'accès à la page.
+
+**Files:**
+
+- Modify: `features/exams/dal.ts` (`getExamWithQuestions`, branche subscribers), `app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/page.tsx`, `app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx`, `app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/page.tsx` (paywall, constat E)
+- Test: `tests/integration/exam-audience.test.ts` (étendre)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Ajouter à `tests/integration/exam-audience.test.ts` (réutiliser les helpers de seed du fichier — examens subscribers + user sans accès) :
+
+```ts
+describe("getExamWithQuestions — anti-fuite subscribers (C2)", () => {
+  it("renvoie null pour un utilisateur SANS accès exam actif", async () => {
+    // seed : exam subscribers + user sans userAccess 'exam'
+    // (adapter aux helpers existants du fichier)
+    const view = await getExamWithQuestions(subscribersExamId)
+    expect(view).toBeNull()
+  })
+  it("renvoie les questions pour un abonné avec accès actif", async () => {
+    const view = await getExamWithQuestions(subscribersExamId)
+    expect(view?.questions.length).toBeGreaterThan(0)
+  })
+})
+```
+
+Note exécutant : le DAL lit la session via `getCurrentSession` (mockée dans le harnais d'intégration comme les autres tests du fichier — repérer le pattern `mockSession`/`setTestUser` déjà utilisé). Le `hasAccess("exam")` lit `userAccess` : seeder/ne pas seeder la ligne selon le cas.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun run test:integration exam-audience` (au checkpoint final ; ici, revue de code du diff attendu). Le 1er test doit échouer AVANT le fix (subscribers sans accès reçoit actuellement les questions).
+
+- [ ] **Step 3: DAL — garde subscribers**
+
+Dans `features/exams/dal.ts`, `getExamWithQuestions`, la garde d'audience (après le `if (!isAdmin && exam.audienceType === "restricted") { … }`) : ajouter la branche subscribers.
+
+```ts
+if (!isAdmin && exam.audienceType === "subscribers") {
+  // Symétrique startExam/saveExamAnswer : l'abonnement actif EST l'autorisation
+  // pour un examen subscribers. Anti-fuite du texte des questions à un
+  // utilisateur sans entitlement (la fenêtre de dates est gardée par les
+  // appelants : page evaluation via participation in_progress, page détail via
+  // isClosed).
+  if (!(await hasAccess("exam"))) return null
+}
+```
+
+Import : `import { hasAccess } from "../payments/dal"` (vérifier qu'il n'est pas déjà importé dans dal.ts ; sinon l'ajouter).
+
+- [ ] **Step 4: Page evaluation — livraison conditionnelle des questions**
+
+Réécrire `evaluation/page.tsx` : la page reste accessible sans participation
+(guichet d'entrée), mais ne livre les questions QUE si `in_progress`. État
+actuel : elle fetch `getExamWithQuestions` PUIS `Promise.all([getExamSession,
+getExamAnswersForParticipation])` et redirige seulement si completed. Nouvelle
+version :
+
+```tsx
+export default async function EvaluationPage({
+  params,
+}: {
+  params: Promise<{ examId: string }>
+}) {
+  const { examId } = await params
+
+  const session = await getExamSession(examId)
+
+  // Déjà soumis → résumé (UX conservée, évite un examen re-jouable).
+  if (session?.status === "completed" || session?.status === "auto_submitted") {
+    redirect(`/tableau-de-bord/examen-blanc/${examId}/soumis`)
+  }
+
+  const data = await getExamWithQuestions(examId)
+  // Non-abonné (DAL → null) : renvoyé vers la carte paywall de la page détail.
+  if (!data) redirect(`/tableau-de-bord/examen-blanc/${examId}`)
+
+  // Invariante anti-fuite : les questions ne partent dans le payload RSC que
+  // pour une participation in_progress (créée par startExam, seul à vérifier
+  // fenêtre+accès+audience). Sans participation → écran de démarrage sans
+  // questions ; le client fait router.refresh() après startExam pour les
+  // recevoir. Ferme subscribers, restricted ET le pré-fetch pré-fenêtre.
+  const inProgress = session?.status === "in_progress"
+  const initialAnswersRaw = inProgress
+    ? await getExamAnswersForParticipation(examId)
+    : []
+
+  return (
+    <EvaluationClient
+      examId={examId}
+      exam={{
+        title: data.exam.title,
+        completionTime: data.exam.completionTime,
+        enablePause: data.exam.enablePause,
+        pauseDurationMinutes: data.exam.pauseDurationMinutes,
+      }}
+      questions={inProgress ? data.questions : []}
+      initialSession={session}
+      initialAnswersRaw={initialAnswersRaw}
+    />
+  )
+}
+```
+
+(Trade-off assumé : on fetch `getExamWithQuestions` même hors `in_progress` pour
+récupérer les métadonnées de l'écran de démarrage — coût serveur existant, mais
+les questions ne partent PLUS dans le payload. Un lecteur de méta léger serait
+une optimisation future, hors scope.)
+
+- [ ] **Step 5: Client — `router.refresh()` après `startExam`**
+
+Dans `evaluation-client.tsx`, `handleStartExam` (après `startExam` réussi) :
+aujourd'hui il fait `setServerStartTime` + `setShowWarningDialog(false)` mais la
+page ne renvoyait pas de questions au 1er rendu (elles y étaient déjà). Puisque
+la page ne les livre plus qu'en `in_progress`, ajouter `router.refresh()` pour
+que le Server Component les relivre (l'état client — `serverStartTime`, dialog
+fermé — est préservé au travers du refresh) :
+
+```tsx
+setServerStartTime(result.startedAt ?? null)
+setShowWarningDialog(false)
+toast.success("Examen démarré - Bonne chance !")
+router.refresh()
+```
+
+- [ ] **Step 6: Page détail — paywall au lieu de 404 (constat E)**
+
+Dans `[examId]/page.tsx`, la garde DAL renvoyant `null` pour un non-abonné, un
+`notFound()` sec régresse le tunnel d'achat. Récupérer la session AVANT le check
+null, et pour un non-admin rendre la carte paywall existante quand `data` est
+`null` (ne PAS `notFound`). État actuel : `const data = await
+getExamWithQuestions(examId); if (!data) notFound()` PUIS `const session = await
+getCurrentSession()`. Réordonner :
+
+```tsx
+const session = await getCurrentSession()
+const isAdmin = session?.user?.role === "admin"
+
+const data = await getExamWithQuestions(examId)
+if (!data) {
+  // Non-admin + null = pas d'accès (ou examen confidentiel) → carte paywall,
+  // pas un 404 sec (préserve le tunnel d'achat). Admin ne voit null que si
+  // l'examen n'existe pas.
+  if (isAdmin) notFound()
+  return <ExamAccessDeniedCard />
+}
+```
+
+Extraire le JSX de la carte « Accès non autorisé » actuelle (lignes ~39-73) en
+un petit composant local `ExamAccessDeniedCard` (ou l'inliner dans le `return`
+ci-dessus), réutilisé par le bloc de garde existant `if (!isAdmin && (!isClosed
+|| !examAccess))`. Le message générique « Vous devez avoir un accès exam actif »
+convient au cas dominant (non-abonné d'un examen subscribers).
+
+- [ ] **Step 7: Lint + commit**
+
+Run: `bunx tsc --noEmit && bunx eslint features/exams/dal.ts "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/page.tsx" "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx" "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/page.tsx"` → 0 erreur
+
+```bash
+git add features/exams/dal.ts "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/page.tsx" "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/evaluation/_components/evaluation-client.tsx" "app/(dashboard)/tableau-de-bord/examen-blanc/[examId]/page.tsx" tests/integration/exam-audience.test.ts
+git commit -m "fix(exams): ferme la fuite du contenu d'examen (livraison conditionnelle + garde hasAccess + paywall préservé)"
+```
+
+---
+
+### Task 3: #2 + #3 — `saveExamAnswer` : budget-temps + transaction anti-race
+
+**Files:**
+
+- Modify: `features/exams/actions.ts` (`saveExamAnswer`)
+- Test: `tests/integration/exam-runner.test.ts` (étendre)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Ajouter à `tests/integration/exam-runner.test.ts` (réutiliser le seed d'examen + participation in_progress du fichier). Tests DÉTERMINISTES (pas d'assertion d'ordre sur `Promise.all`, flaky — constat D) :
+
+```ts
+it("saveExamAnswer refuse une réponse au-delà du budget-temps (TIME_UP) et ne la persiste pas", async () => {
+  // seed participation in_progress avec startedAt reculé au-delà de
+  // completionTime + SAVE_GRACE (ex. startedAt = now - (completionTime*1000 + 60_000))
+  const res = await saveExamAnswer({ examId, questionId, selectedAnswer: "A" })
+  expect(res).toEqual({ success: false, error: "Temps écoulé." })
+  // la réponse reste nulle en base (relire examAnswers)
+  const [row] = await db
+    .select({ selectedAnswer: examAnswers.selectedAnswer })
+    .from(examAnswers)
+    .where(
+      and(
+        eq(examAnswers.participationId, participationId),
+        eq(examAnswers.questionId, questionId),
+      ),
+    )
+  expect(row?.selectedAnswer).toBeNull()
+})
+
+it("attaque #2 bout-en-bout : réponse hors-temps refusée puis finalize isAutoSubmit tardif → score ne l'inclut pas", async () => {
+  // startedAt reculé au-delà du budget ; participation in_progress
+  const save = await saveExamAnswer({ examId, questionId, selectedAnswer correctAnswer })
+  expect(save.success).toBe(false) // TIME_UP
+  const fin = await finalizeExam({ examId, isAutoSubmit: true })
+  expect(fin.success).toBe(true)
+  // la réponse hors-temps n'a jamais été comptée
+  expect(fin.correctAnswers).toBe(0)
+})
+
+it("race déterministe : finalize PUIS save → save refusé (session plus active)", async () => {
+  const fin = await finalizeExam({ examId, isAutoSubmit: false })
+  expect(fin.success).toBe(true)
+  // sous le verrou participation, save re-lit un statut terminal → refus propre
+  const save = await saveExamAnswer({ examId, questionId, selectedAnswer: "A" })
+  expect(save).toEqual({
+    success: false,
+    error: "Cette session d'examen n'est plus active.",
+  })
+})
+```
+
+Note exécutant : adapter les noms de champs de retour de `finalizeExam` (`correctAnswers`/`score`) à la signature réelle (`actions.ts:845` renvoie `{ score, correctAnswers, totalQuestions }`). Corriger la coquille `selectedAnswer correctAnswer` → `selectedAnswer: correctAnswer` (la bonne réponse, pour prouver qu'elle N'est PAS comptée).
+
+- [ ] **Step 2: Constante + étendre le SELECT exam (hors transaction)**
+
+Constante en tête de fichier (près de `SECONDS_PER_QUESTION`/`resolvePause` ;
+NB `MAX_PAUSE_MINUTES` est importé de `schemas.ts`, pas défini ici) :
+
+```ts
+const SAVE_GRACE_MS = 10_000
+```
+
+Étendre le SELECT exam de `saveExamAnswer` avec `completionTime` :
+
+```ts
+const [exam] = await db
+  .select({
+    startDate: exams.startDate,
+    endDate: exams.endDate,
+    audienceType: exams.audienceType,
+    completionTime: exams.completionTime,
+  })
+  .from(exams)
+  .where(eq(exams.id, examId))
+  .limit(1)
+```
+
+(`pauseDurationMinutes` inutile : la pause ACTIVE interdit déjà l'écriture — cf.
+Step 3 — donc le budget n'a besoin que du cumul figé `totalPauseDurationMs`.)
+
+- [ ] **Step 3: Transaction + verrou participation (race #3) englobant budget + écriture**
+
+Une sous-requête `EXISTS` ne sérialise PAS contre un `finalizeExam` en vol
+(READ COMMITTED — constat C). Fermeture complète : verrou de ligne sur la
+participation (idiome AGENTS.md), même ligne que `finalizeExam:777`. Réécrire le
+bloc de `saveExamAnswer` depuis le SELECT participation actuel (`:620`) jusqu'au
+`return { success: true }` (`:666`). La lecture immuable de la question
+(appartenance + bonne réponse) reste HORS transaction ; le SELECT participation,
+la garde statut/pause, le budget-temps et l'UPDATE passent DANS la transaction.
+
+```ts
+// Question immuable (appartenance + bonne réponse) : hors transaction.
+const [q] = await db
+  .select({ correctAnswer: questions.correctAnswer })
+  .from(examQuestions)
+  .innerJoin(questions, eq(questions.id, examQuestions.questionId))
+  .where(
+    and(
+      eq(examQuestions.examId, examId),
+      eq(examQuestions.questionId, questionId),
+    ),
+  )
+  .limit(1)
+if (!q) return fail("Cette question ne fait pas partie de l'examen.")
+const isCorrect = q.correctAnswer === selectedAnswer
+
+// Verrou participation englobant check-statut + budget + écriture : sérialise
+// avec finalizeExam (qui verrouille la même ligne) → aucune écriture après le
+// score (race #3). Budget-temps gardé À L'ÉCRITURE — anti-triche : finalize
+// saute TIME_UP quand isAutoSubmit=true (flag client). Narrowing : renvoyer
+// la valeur DEPUIS le callback (pas de let capturé — AGENTS.md).
+const outcome = await db.transaction(async (tx) => {
+  const [p] = await tx
+    .select({
+      id: examParticipations.id,
+      status: examParticipations.status,
+      startedAt: examParticipations.startedAt,
+      totalPauseDurationMs: examParticipations.totalPauseDurationMs,
+      pauseStartedAt: examParticipations.pauseStartedAt,
+    })
+    .from(examParticipations)
+    .where(
+      and(
+        eq(examParticipations.examId, examId),
+        eq(examParticipations.userId, userId),
+      ),
+    )
+    .for("update")
+    .limit(1)
+  if (!p) return { ok: false as const, msg: "Participation introuvable." }
+  if (p.status !== "in_progress")
+    return {
+      ok: false as const,
+      msg: "Cette session d'examen n'est plus active.",
+    }
+  if (p.pauseStartedAt)
+    return {
+      ok: false as const,
+      msg: "Réponse impossible pendant la pause.",
+    }
+
+  // Pause ACTIVE déjà exclue → pauseMs = cumul figé uniquement (pas de
+  // branche pauseStartedAt : elle serait morte ici — constat H).
+  if (!isAdmin && p.startedAt) {
+    const pauseMs = p.totalPauseDurationMs ?? 0
+    const elapsed = now - p.startedAt.getTime() - pauseMs
+    if (elapsed > exam.completionTime * 1000 + SAVE_GRACE_MS)
+      return { ok: false as const, msg: "Temps écoulé." }
+  }
+
+  await tx
+    .update(examAnswers)
+    .set({ selectedAnswer, isCorrect })
+    .where(
+      and(
+        eq(examAnswers.participationId, p.id),
+        eq(examAnswers.questionId, questionId),
+      ),
+    )
+  return { ok: true as const }
+})
+
+if (!outcome.ok) return fail(outcome.msg)
+return { success: true } // never return isCorrect (anti-cheat)
+```
+
+(L'UPDATE n'a plus besoin de garde `EXISTS` : sous le verrou, le statut
+`in_progress` est déjà re-vérifié et ne peut pas changer avant le commit. La
+ligne `examAnswers` existe — pré-créée par `startExam` — donc pas de
+`updated.length === 0` à gérer.)
+
+- [ ] **Step 4: Lint + commit**
+
+Run: `bunx tsc --noEmit && bunx eslint features/exams/actions.ts` → 0 erreur
+Run: `bun run test` (frontend, non-régression) → PASS
+
+```bash
+git add features/exams/actions.ts tests/integration/exam-runner.test.ts
+git commit -m "fix(exams): budget-temps serveur à l'écriture + transaction anti-race sur saveExamAnswer"
+```
+
+---
+
+### Task 4: #4 — Verrou commun `updateExam` / `startExam`
+
+**Files:**
+
+- Modify: `features/exams/actions.ts` (`updateExam`, `startExam`)
+- Test: `tests/integration/exams.test.ts` (étendre : race)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Ajouter à `tests/integration/exams.test.ts` :
+
+```ts
+it("updateExam et startExam concurrents ne produisent pas de participation sur un set remplacé", async () => {
+  // seed exam SANS participation, avec set Q1..Qn ; nouveau set Q1'..Qm'
+  const [upd, start] = await Promise.all([
+    updateExam({ id: examId /* … nouveau questionIds … */ }),
+    startExam({ examId }),
+  ])
+  // invariant : si start a créé une participation, ses examAnswers correspondent
+  // AU set effectivement servi (pas un mélange ancien/nouveau).
+  // Vérifier : les questionId de examAnswers == set courant de examQuestions.
+})
+```
+
+- [ ] **Step 2: `startExam` — verrou sur la ligne exams**
+
+Dans la transaction de `startExam`, AJOUTER un `FOR UPDATE` sur la ligne exams. Aujourd'hui le SELECT exam (`actions.ts` ~443) n'a pas de verrou ; le remplacer :
+
+```ts
+const [exam] = await tx
+  .select({
+    startDate: exams.startDate,
+    endDate: exams.endDate,
+    audienceType: exams.audienceType,
+  })
+  .from(exams)
+  .where(eq(exams.id, examId))
+  .for("update")
+  .limit(1)
+```
+
+(Le verrou `FOR UPDATE user` existant reste — ordre déterministe : exams après user ; garder cet ordre identique dans updateExam pour éviter tout deadlock croisé. updateExam ne verrouille pas `user`, donc pas de cycle.)
+
+- [ ] **Step 3: `updateExam` — verrou sur la ligne exams**
+
+Le SELECT exam en tête de transaction (`actions.ts:211`) : ajouter `.for("update")` :
+
+```ts
+const [exam] = await tx
+  .select({ id: exams.id })
+  .from(exams)
+  .where(eq(exams.id, id))
+  .for("update")
+  .limit(1)
+if (!exam) throw new Error("NOT_FOUND")
+```
+
+- [ ] **Step 4: Lint + commit**
+
+Run: `bunx tsc --noEmit && bunx eslint features/exams/actions.ts` → 0 erreur
+
+```bash
+git add features/exams/actions.ts tests/integration/exams.test.ts
+git commit -m "fix(exams): verrou FOR UPDATE commun sur la ligne examen (updateExam vs startExam)"
+```
+
+---
+
+### Task 5: Documentation du pattern
+
+**Files:**
+
+- Modify: `.claude/rules/e2e-testing.md` OU `.claude/rules/data-layer.md` (selon le scope — la garde participation/budget est backend → `data-layer.md`)
+
+- [ ] **Step 1: Documenter l'invariante**
+
+Ajouter à `.claude/rules/data-layer.md` (section Server Actions ou une note examens) :
+
+```markdown
+- **Passation d'examen — invariante d'accès** : le contenu des questions n'est
+  rendu/écrit que pour une participation `in_progress` (créée par `startExam`,
+  seul à vérifier fenêtre+accès+audience). La page evaluation gate sur
+  `in_progress` ; `getExamWithQuestions` re-garde `hasAccess("exam")` pour
+  `subscribers` (défense en profondeur). Budget-temps anti-triche gardé À
+  L'ÉCRITURE (`saveExamAnswer` refuse au-delà de `startedAt + completionTime +
+grâce`), pas seulement à la finalisation (`isAutoSubmit` vient du client).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/rules/data-layer.md
+git commit -m "docs(exams): invariante passation (participation in_progress + budget à l'écriture)"
+```
+
+---
+
+### Task 6: Checkpoint final — intégration + gates complets
+
+- [ ] **Step 1: Formater les docs de campagne**
+
+```bash
+bunx prettier --write docs/superpowers/specs/2026-07-14-integrite-examens-design.md docs/superpowers/plans/2026-07-14-integrite-examens.md
+```
+
+- [ ] **Step 2: `bun run check`**
+
+Run: `bun run check`
+Expected: exit 0 (prettier + tsc + eslint).
+
+- [ ] **Step 3: Suite frontend**
+
+Run: `bun run test`
+Expected: PASS (aucune régression).
+
+- [ ] **Step 4: Intégration (un seul run — branche Neon)**
+
+Run: `bun run test:integration`
+Expected: PASS. Cibler surtout `exam-audience`, `exam-runner`, `exams`,
+`passation-anti-cheat`. En cas d'échec des tests anti-triche existants dû à la
+nouvelle garde `hasAccess` subscribers : vérifier que le seed du test donne bien
+un `userAccess` 'exam' actif à l'utilisateur non-admin (sinon le DAL renvoie
+`null` — comportement voulu, adapter le seed du test, PAS le code).
+
+- [ ] **Step 5: Statut spec + commit final**
+
+Passer le statut du spec à « implémenté » :
+
+```bash
+git add docs/superpowers/specs/2026-07-14-integrite-examens-design.md docs/superpowers/plans/2026-07-14-integrite-examens.md
+git commit -m "docs(exams): spec/plan C2 + statut implémenté"
+```
+
+---
+
+## Critères de done (rappel spec)
+
+1. Utilisateur sans participation `in_progress` → page evaluation `notFound` ; DAL subscribers sans accès → `null`.
+2. Réponse au-delà du budget-temps refusée et non persistée (quel que soit `isAutoSubmit`).
+3. Réponse concurrente à une finalisation refusée (UPDATE gardé).
+4. `updateExam`/`startExam` concurrents → participation cohérente avec le set servi.
+5. `loadExamQuestionExplanations` borné à 100 ids.
+6. `bun run check` + `bun run test` + `bun run test:integration` verts.

--- a/docs/superpowers/plans/2026-07-14-observabilite-erreurs.md
+++ b/docs/superpowers/plans/2026-07-14-observabilite-erreurs.md
@@ -1,0 +1,960 @@
+# Observabilité & gestion d'erreurs backend (C1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** rendre visibles dans Sentry les exceptions serveur aujourd'hui avalées (catch fallback des Server Actions, error boundaries de segment, crons), sans bruit métier ni PII, + corriger le bug 23505 `updateProfile`.
+
+**Architecture:** deux petits helpers `lib/` (`captureServerError` pour la capture centralisée, `getPgErrorCode` pour l'unwrap `.cause` pg), puis remplacement mécanique des `logDev`/blocs inline dans `features/*/actions.ts`, ajout de `Sentry.captureException` dans les 3 boundaries, instrumentation des catch d'isolation des crons. Aucun changement de comportement utilisateur ni de config Sentry.
+
+**Tech Stack:** Next.js 16 · `@sentry/nextjs` (déjà installé) · Vitest (projet frontend, `bun run test`).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-observabilite-erreurs-design.md`
+
+**Préambule (une fois) :** on est sur `main` → créer la branche, puis formater
+les docs de campagne (la revue a montré qu'ils cassent le gate Prettier —
+constat #4) :
+
+```bash
+git checkout -b c1-observabilite
+bunx prettier --write docs/superpowers/specs/2026-07-14-observabilite-erreurs-design.md docs/superpowers/plans/2026-07-14-observabilite-erreurs.md docs/superpowers/reviews/2026-07-14-observabilite-erreurs-plan-review.md 2>/dev/null || true
+```
+
+(Le rapport de revue est jetable — il sera supprimé, pas committé.)
+
+**Règles projet à respecter :** commits conventionnels, JAMAIS d'attribution Claude. `bun run test` (jamais `bun test`). Commentaires = pourquoi non-évident seulement, pas de narration.
+
+---
+
+### Task 1: `lib/db-errors.ts` — `getPgErrorCode`
+
+**Files:**
+
+- Create: `lib/db-errors.ts`
+- Test: `tests/lib/db-errors.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/lib/db-errors.test.ts
+import { describe, expect, it } from "vitest"
+import { getPgErrorCode, isPgUniqueViolation } from "@/lib/db-errors"
+
+describe("getPgErrorCode", () => {
+  it("lit le code au premier niveau", () => {
+    expect(getPgErrorCode({ code: "23505" })).toBe("23505")
+  })
+
+  it("remonte la chaîne cause (forme DrizzleQueryError → DatabaseError pg)", () => {
+    const err = Object.assign(new Error("query failed"), {
+      cause: Object.assign(new Error("db"), { cause: { code: "23001" } }),
+    })
+    expect(getPgErrorCode(err)).toBe("23001")
+  })
+
+  it("renvoie undefined sans code dans la chaîne", () => {
+    expect(getPgErrorCode(new Error("boom"))).toBeUndefined()
+    expect(getPgErrorCode(null)).toBeUndefined()
+    expect(getPgErrorCode("string")).toBeUndefined()
+  })
+
+  it("ignore un code non-string", () => {
+    expect(getPgErrorCode({ code: 23505 })).toBeUndefined()
+  })
+
+  it("borne le parcours à 5 niveaux (pas de boucle infinie sur cycle)", () => {
+    const cyclic: { cause?: unknown } = {}
+    cyclic.cause = cyclic
+    expect(getPgErrorCode(cyclic)).toBeUndefined()
+
+    let deep: unknown = { code: "23505" }
+    for (let i = 0; i < 6; i++) deep = { cause: deep }
+    expect(getPgErrorCode(deep)).toBeUndefined()
+  })
+})
+
+describe("isPgUniqueViolation", () => {
+  it("détecte 23505 enveloppé", () => {
+    expect(isPgUniqueViolation({ cause: { code: "23505" } })).toBe(true)
+    expect(isPgUniqueViolation({ cause: { code: "23503" } })).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test tests/lib/db-errors.test.ts`
+Expected: FAIL — `Cannot find module '@/lib/db-errors'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// lib/db-errors.ts
+/**
+ * Drizzle enveloppe l'erreur pg (DrizzleQueryError → cause = DatabaseError),
+ * parfois sur plusieurs niveaux : on remonte la chaîne `cause` (bornée) jusqu'au
+ * premier `code` SQLSTATE. Source de vérité unique — ne pas retester `error.code`
+ * en surface dans les actions (branche morte, cf. bug updateProfile 23505).
+ */
+export const getPgErrorCode = (error: unknown): string | undefined => {
+  let cur: unknown = error
+  for (let i = 0; i < 5 && cur; i++) {
+    if (typeof cur === "object" && "code" in cur) {
+      const code = (cur as { code?: unknown }).code
+      if (typeof code === "string") return code
+    }
+    cur = (cur as { cause?: unknown }).cause
+  }
+  return undefined
+}
+
+export const isPgUniqueViolation = (error: unknown): boolean =>
+  getPgErrorCode(error) === "23505"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test tests/lib/db-errors.test.ts`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/db-errors.ts tests/lib/db-errors.test.ts
+git commit -m "feat(observabilite): helper getPgErrorCode (unwrap cause pg borné)"
+```
+
+---
+
+### Task 2: `lib/observability.ts` — `captureServerError`
+
+**Files:**
+
+- Create: `lib/observability.ts`
+- Test: `tests/lib/observability.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/lib/observability.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { captureServerError } from "@/lib/observability"
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
+vi.mock("@sentry/nextjs", () => ({ captureException }))
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  captureException.mockClear()
+})
+
+describe("captureServerError", () => {
+  it("hors prod : console.error, pas de Sentry", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    captureServerError("[test]", new Error("boom"))
+    expect(spy).toHaveBeenCalledOnce()
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it("en prod : console.error + Sentry avec tag action et userId", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const err = new Error("boom")
+    captureServerError("[finalizeExam]", err, { userId: "u1" })
+    expect(spy).toHaveBeenCalledOnce()
+    expect(captureException).toHaveBeenCalledWith(err, {
+      tags: { action: "[finalizeExam]" },
+      user: { id: "u1" },
+      extra: undefined,
+    })
+  })
+
+  it("en prod sans contexte : pas d'objet user, detail dans extra", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    const err = new Error("boom")
+    captureServerError("[cron]", err, { detail: "participation p1" })
+    expect(captureException).toHaveBeenCalledWith(err, {
+      tags: { action: "[cron]" },
+      user: undefined,
+      extra: { detail: "participation p1" },
+    })
+  })
+
+  it("inclut detail dans la ligne console", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const err = new Error("boom")
+    captureServerError("[notif:resultats]", err, { detail: "participation p1" })
+    expect(spy).toHaveBeenCalledWith("[notif:resultats] participation p1", err)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test tests/lib/observability.test.ts`
+Expected: FAIL — `Cannot find module '@/lib/observability'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// lib/observability.ts
+import * as Sentry from "@sentry/nextjs"
+import "server-only"
+
+/**
+ * Capture d'une exception INATTENDUE côté serveur (catch fallback générique
+ * des Server Actions, tâches cron). Les erreurs métier mappées (TIME_UP,
+ * ACCESS_EXPIRED, zod, 23505 username…) sont du flux de contrôle : elles ne
+ * passent JAMAIS ici — c'est ce qui garde le signal Sentry exploitable.
+ *
+ * `tag` doit rester statique (cardinalité des tags Sentry) ; les ids
+ * dynamiques vont dans `detail` (→ extra). Contexte léger uniquement : pas
+ * de payload (PII) dans les événements.
+ */
+export const captureServerError = (
+  tag: string,
+  error: unknown,
+  context?: { userId?: string; detail?: string },
+) => {
+  console.error(context?.detail ? `${tag} ${context.detail}` : tag, error)
+  if (process.env.NODE_ENV === "production") {
+    Sentry.captureException(error, {
+      tags: { action: tag },
+      user: context?.userId ? { id: context.userId } : undefined,
+      extra: context?.detail ? { detail: context.detail } : undefined,
+    })
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test tests/lib/observability.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/observability.ts tests/lib/observability.test.ts
+git commit -m "feat(observabilite): captureServerError (Sentry en prod, tag statique, sans PII)"
+```
+
+---
+
+### Task 3: `features/users/actions.ts` — fix 23505 + capture
+
+**Files:**
+
+- Modify: `features/users/actions.ts:157-170` (updateProfile), `:228-233` (createAvatarUpload), `:267-273` (confirmAvatarUpload), et tout autre bloc `NODE_ENV !== "production"` du fichier (vérifier par grep — il peut y en avoir au-delà des 3 recensés)
+- Test: `tests/features/users-actions-errors.test.ts` (nouveau)
+
+- [ ] **Step 1: Write the failing test**
+
+Le test unitaire mocke la chaîne Drizzle. `server-only` est déjà stubbé par le setup du projet frontend. Mocks module-level requis (les imports de `features/users/actions.ts` tirent env/S3/auth) :
+
+```ts
+// tests/features/users-actions-errors.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { setAccountPassword, updateProfile } from "@/features/users/actions"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    limitFn: vi.fn<() => Promise<unknown[]>>(async () => []),
+    updateWhere: vi.fn<() => Promise<unknown>>(async () => undefined),
+    setPassword: vi.fn<() => Promise<unknown>>(async () => undefined),
+  },
+}))
+
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: mocks.limitFn }) }),
+    }),
+    update: () => ({ set: () => ({ where: mocks.updateWhere }) }),
+  },
+}))
+vi.mock("@/db/schema", () => ({ user: {}, session: {} }))
+vi.mock("@/features/users/dal", () => ({}))
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { setPassword: mocks.setPassword } },
+}))
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "user" } })),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/aws", () => ({ createPresignedUpload: vi.fn() }))
+vi.mock("@/lib/cdn", () => ({
+  cdnUrl: (p: string) => p,
+  avatarStoragePathFromImageValue: () => null,
+}))
+vi.mock("@/lib/storage", () => ({
+  generateAvatarPath: vi.fn(),
+  getExtensionFromMimeType: vi.fn(),
+  isStorageConfigured: () => false,
+  tryDeleteFromStorage: vi.fn(),
+  validateImageFile: vi.fn(),
+}))
+vi.mock("@/lib/upload-rate-limit", () => ({ consumeUploadRateLimit: vi.fn() }))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+const VALID = { name: "Sam", username: "sam_p", bio: "" }
+
+beforeEach(() => {
+  mocks.captureServerError.mockClear()
+  mocks.limitFn.mockResolvedValue([]) // pré-check unicité : username libre
+})
+
+describe("updateProfile — catch fallback", () => {
+  it("23505 enveloppé (course post pré-check) → « déjà pris », PAS de capture Sentry", async () => {
+    mocks.updateWhere.mockRejectedValueOnce(
+      Object.assign(new Error("query failed"), { cause: { code: "23505" } }),
+    )
+    const res = await updateProfile(VALID)
+    expect(res).toEqual({
+      success: false,
+      error: "Ce nom d'utilisateur est déjà pris !",
+    })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("erreur inattendue → message neutre + captureServerError(tag, err, userId)", async () => {
+    const boom = new Error("connexion perdue")
+    mocks.updateWhere.mockRejectedValueOnce(boom)
+    const res = await updateProfile(VALID)
+    expect(res).toEqual({ success: false, error: "Erreur serveur. Réessayez." })
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[updateProfile]",
+      boom,
+      { userId: "u1" },
+    )
+  })
+})
+
+describe("setAccountPassword — catch filtré APIError (revue #5)", () => {
+  it("APIError Better Auth (métier) → message, PAS de capture", async () => {
+    const { APIError } = await import("better-auth/api")
+    mocks.setPassword.mockRejectedValueOnce(
+      new APIError("BAD_REQUEST", { message: "password already set" }),
+    )
+    const res = await setAccountPassword({ newPassword: "motdepasse123" })
+    expect(res).toEqual({
+      success: false,
+      error: "Impossible de définir le mot de passe.",
+    })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("erreur inattendue → même message + capture", async () => {
+    const boom = new Error("Better Auth down")
+    mocks.setPassword.mockRejectedValueOnce(boom)
+    const res = await setAccountPassword({ newPassword: "motdepasse123" })
+    expect(res).toEqual({
+      success: false,
+      error: "Impossible de définir le mot de passe.",
+    })
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[setAccountPassword]",
+      boom,
+      { userId: "u1" },
+    )
+  })
+})
+```
+
+Note exécutant : si le module tire un import non listé ici (le fichier peut avoir bougé), l'erreur au run le nommera — ajouter le `vi.mock` correspondant, façade minimale.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test tests/features/users-actions-errors.test.ts`
+Expected: FAIL — le cas 23505 renvoie « Erreur serveur. Réessayez. » (branche morte actuelle : `error.code` testé en surface, or l'erreur est enveloppée)
+
+- [ ] **Step 3: Implement — updateProfile**
+
+Dans `features/users/actions.ts`, remplacer le catch de `updateProfile` (lignes ~157-170) :
+
+```ts
+  } catch (error) {
+    if (isPgUniqueViolation(error)) {
+      return { success: false, error: "Ce nom d'utilisateur est déjà pris !" }
+    }
+    captureServerError("[updateProfile]", error, { userId: session.user.id })
+    return { success: false, error: "Erreur serveur. Réessayez." }
+  }
+```
+
+Imports à ajouter en tête de fichier :
+
+```ts
+import { isPgUniqueViolation } from "@/lib/db-errors"
+import { captureServerError } from "@/lib/observability"
+```
+
+- [ ] **Step 4: Implement — autres blocs du fichier**
+
+Grep de contrôle : `grep -n 'NODE_ENV !== "production"' features/users/actions.ts`
+Pour CHAQUE bloc restant (recensés : `createAvatarUpload` ~229, `confirmAvatarUpload` ~268), appliquer la transformation :
+
+```ts
+// AVANT
+if (process.env.NODE_ENV !== "production") {
+  console.error("[nomAction]", error)
+}
+// APRÈS (userId si une variable userId / session.user.id est en scope, sinon omettre)
+captureServerError("[nomAction]", error, { userId })
+```
+
+Le grep doit ensuite renvoyer **0 occurrence** dans ce fichier.
+
+**Cas spécial `setAccountPassword` (~:352-359, revue #5)** : catch actuellement
+NU (aucun log — invisible au grep NODE_ENV). `auth.api.setPassword` throw aussi
+des `APIError` Better Auth métier → capture filtrée :
+
+```ts
+import { APIError } from "better-auth/api"
+```
+
+```ts
+  } catch (error) {
+    if (!(error instanceof APIError)) {
+      captureServerError("[setAccountPassword]", error, {
+        userId: authSession.user.id,
+      })
+    }
+    return { success: false, error: "Impossible de définir le mot de passe." }
+  }
+```
+
+(Attention : dans cette fonction le retour de `requireSession()` n'est pas
+capturé dans une variable aujourd'hui — la fonction commence par
+`await requireSession()`. La capturer : `const authSession = await requireSession()`.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun run test tests/features/users-actions-errors.test.ts`
+Expected: PASS (2 tests)
+Puis suite complète : `bun run test`
+Expected: PASS (aucune régression — attention aux tests existants qui assertaient un `console.error`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/users/actions.ts tests/features/users-actions-errors.test.ts
+git commit -m "fix(users): doublon username 23505 détecté sous course + capture Sentry des erreurs inattendues"
+```
+
+---
+
+### Task 4: `features/{exams,training,questions}/actions.ts` — remplacer `logDev`
+
+**Files:**
+
+- Modify: `features/exams/actions.ts` (déf `logDev` :45-47 + 12 appels), `features/training/actions.ts` (déf :36-38 + 6 appels), `features/questions/actions.ts` (déf :51-53 + 8 appels, + refactor `isForeignKeyViolation` :311-327)
+
+- [ ] **Step 1: Transformation mécanique par fichier**
+
+Pour chacun des 3 fichiers :
+
+1. Supprimer la définition locale de `logDev`.
+2. Ajouter `import { captureServerError } from "@/lib/observability"`.
+3. Lister les appels : `grep -n "logDev(" features/exams/actions.ts` (idem training, questions).
+4. Chaque `logDev("[tag]", error)` devient `captureServerError("[tag]", error, { userId })` — `userId` seulement si une variable `userId` ou `session.user.id` existe dans la fonction englobante (c'est le cas de presque toutes ; les actions admin-only sans binding → omettre le 3ᵉ argument).
+
+Invariant à préserver (spec §Principe) : ces appels sont TOUS dans des catch fallback génériques — ne PAS ajouter de capture aux branches d'erreurs métier mappées (`map[error.message]`, FK 23001/23503…).
+
+- [ ] **Step 2: Refactor `isForeignKeyViolation` (questions)**
+
+Dans `features/questions/actions.ts`, remplacer le corps (:313-327) par un wrapper sur le helper partagé (conserver le commentaire existant sur 23001/23503 et la Set) :
+
+```ts
+import { getPgErrorCode } from "@/lib/db-errors"
+
+const FK_VIOLATION_CODES = new Set(["23001", "23503"])
+
+const isForeignKeyViolation = (error: unknown): boolean => {
+  const code = getPgErrorCode(error)
+  return code !== undefined && FK_VIOLATION_CODES.has(code)
+}
+```
+
+- [ ] **Step 3: Vérifier l'éradication**
+
+Run: `grep -rn "logDev" features/`
+Expected: 0 résultat.
+
+- [ ] **Step 4: Run gates**
+
+Run: `bun run test` puis `bunx tsc --noEmit && bunx eslint features/exams/actions.ts features/training/actions.ts features/questions/actions.ts`
+Expected: PASS / 0 erreur. (Des tests existants mockant `console.error` autour de ces actions peuvent casser — les adapter en mockant `@/lib/observability`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/exams/actions.ts features/training/actions.ts features/questions/actions.ts
+git commit -m "feat(observabilite): capture Sentry des catch fallback exams/training/questions (remplace logDev)"
+```
+
+---
+
+### Task 5: `features/payments/actions.ts` — 6 blocs inline
+
+**Files:**
+
+- Modify: `features/payments/actions.ts:154-157, 225-228, 279-282, 383-386, 425-428, 459-461`
+
+- [ ] **Step 1: Transformation mécanique (5 blocs sur 6)**
+
+Même règle que Task 3 Step 4 pour `recordManualPayment`, `updateManualTransaction`, `deleteManualTransaction`, `createStripeCheckout`, `createCustomerPortal`. Ajouter l'import `captureServerError`. Chemin d'argent → passer `{ userId }` partout où le binding existe.
+
+- [ ] **Step 2: Cas spécial `verifyStripeCheckout` (:411-429, revue #2) — PAS mécanique**
+
+Le `sessionId` vient du paramètre d'URL `?session_id=` (contrôlable/périmable
+par l'utilisateur) : `stripe.checkout.sessions.retrieve` throw
+`resource_missing` sur tout id invalide, et le catch mappe déjà ça au message
+métier « Session non trouvée ou invalide » (le même que le garde anti-IDOR).
+C'est un faux fallback — une capture mécanique enverrait à Sentry chaque visite
+de la page succès avec un id bidon. Transformation :
+
+```ts
+// Helper local en tête de fichier (duck-check — évite d'importer les classes
+// d'erreur Stripe pour un seul code)
+const isStripeResourceMissing = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { code?: unknown }).code === "resource_missing"
+```
+
+```ts
+  } catch (error) {
+    if (!isStripeResourceMissing(error)) {
+      captureServerError("[verifyStripeCheckout]", error, {
+        userId: session.user.id,
+      })
+    }
+    return { success: false, error: "Session non trouvée ou invalide" }
+  }
+```
+
+Test (ajouter à `tests/features/payments-actions-errors.test.ts`, nouveau —
+mêmes mocks que Task 3 adaptés aux imports de `features/payments/actions.ts` ;
+mocker `@/lib/stripe` `getStripe` pour faire rejeter `retrieve`) :
+
+```ts
+it("session_id invalide (resource_missing) → message métier, PAS de capture", async () => {
+  mocks.retrieve.mockRejectedValueOnce(
+    Object.assign(new Error("No such checkout.session"), {
+      code: "resource_missing",
+    }),
+  )
+  const res = await verifyStripeCheckout("cs_bidon")
+  expect(res).toEqual({
+    success: false,
+    error: "Session non trouvée ou invalide",
+  })
+  expect(mocks.captureServerError).not.toHaveBeenCalled()
+})
+
+it("erreur Stripe inattendue → même message + capture", async () => {
+  const boom = new Error("Stripe API down")
+  mocks.retrieve.mockRejectedValueOnce(boom)
+  const res = await verifyStripeCheckout("cs_x")
+  expect(res).toEqual({
+    success: false,
+    error: "Session non trouvée ou invalide",
+  })
+  expect(mocks.captureServerError).toHaveBeenCalledWith(
+    "[verifyStripeCheckout]",
+    boom,
+    { userId: "u1" },
+  )
+})
+```
+
+Contrôle : `grep -n 'NODE_ENV !== "production"' features/payments/actions.ts` → 0 occurrence.
+
+- [ ] **Step 3: Run gates**
+
+Run: `bun run test` et `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/payments/actions.ts tests/features/payments-actions-errors.test.ts
+git commit -m "feat(observabilite): capture Sentry des catch fallback payments (resource_missing exclu)"
+```
+
+---
+
+### Task 6: Error boundaries de segment → Sentry
+
+**Files:**
+
+- Modify: `app/error.tsx`, `app/(dashboard)/error.tsx`, `app/(admin)/error.tsx`
+- Test: `tests/components/error-boundaries.test.tsx` (nouveau)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/error-boundaries.test.tsx
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import DashboardError from "@/app/(dashboard)/error"
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
+vi.mock("@sentry/nextjs", () => ({ captureException }))
+
+describe("error boundaries de segment", () => {
+  it("remonte l'erreur à Sentry au montage", () => {
+    const error = Object.assign(new Error("crash rendu"), { digest: "d1" })
+    render(<DashboardError error={error} reset={() => {}} />)
+    expect(captureException).toHaveBeenCalledWith(error)
+  })
+})
+```
+
+(Si l'import du composant via l'alias `@/app/(dashboard)/error` pose problème de résolution des parenthèses dans le glob Vitest, utiliser un import relatif `../../app/(dashboard)/error`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test tests/components/error-boundaries.test.tsx`
+Expected: FAIL — `captureException` jamais appelé.
+
+- [ ] **Step 3: Implement (3 fichiers, même patch)**
+
+Dans `app/error.tsx`, `app/(dashboard)/error.tsx`, `app/(admin)/error.tsx` :
+
+```tsx
+import * as Sentry from "@sentry/nextjs"
+```
+
+et dans le `useEffect` existant :
+
+```tsx
+useEffect(() => {
+  // Doublon SSR voulu : crash serveur = event onRequestError (vraie stack)
+  // + cet event digest ; crash client = cet event seul. Ne pas retirer.
+  Sentry.captureException(error)
+  console.error("Dashboard Error:", error) // ligne existante conservée (libellé propre à chaque fichier)
+}, [error])
+```
+
+UI strictement inchangée. (`global-error.tsx` reste tel quel — il capture déjà.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test tests/components/error-boundaries.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/error.tsx "app/(dashboard)/error.tsx" "app/(admin)/error.tsx" tests/components/error-boundaries.test.tsx
+git commit -m "fix(observabilite): les error boundaries de segment remontent a Sentry"
+```
+
+---
+
+### Task 7: Crons & webhook Stripe — rendre visibles les échecs isolés
+
+**Files:**
+
+- Modify: `app/api/cron/close-expired/route.ts:52-91` (helper `run` + appels), `features/notifications/cron.ts:83-91, 153-155`, `features/users/cron.ts:42-44`, `app/api/stripe/webhook/route.ts:38-41, 77-82, 110-113`
+
+- [ ] **Step 1: `close-expired` — catch d'isolation, tag PAR tâche (revue #6)**
+
+Les tags Sentry sont filtrables/alertables, `extra` non — un tag statique par
+tâche (cardinalité 5) permet d'alerter par tâche. Le helper `run` prend le tag
+en argument (le comportement isolation + `failed=true` + 500 final est
+inchangé) :
+
+```ts
+const run = async <T>(
+  label: string,
+  tag: string,
+  task: () => Promise<T>,
+  empty: T,
+): Promise<T> => {
+  try {
+    return await task()
+  } catch (error) {
+    failed = true
+    captureServerError(tag, error, { detail: label })
+    return empty
+  }
+}
+```
+
+Et les 5 appels :
+
+```ts
+const examParticipations = await run(
+  "clôture examens",
+  "[cron:exams]",
+  closeExpiredExamParticipations,
+  { closedCount: 0 },
+)
+const trainingSessions = await run(
+  "clôture entraînements",
+  "[cron:trainings]",
+  closeExpiredTrainingSessions,
+  { closedCount: 0 },
+)
+const anonymizedAccounts = await run(
+  "anonymisation",
+  "[cron:anonymize]",
+  anonymizeExpiredDeletedAccounts,
+  { anonymizedCount: 0 },
+)
+const quizRateLimitCleanup = await run(
+  "purge rate-limit quiz",
+  "[cron:quiz-rl]",
+  cleanupQuizRateLimits,
+  { deletedCount: 0 },
+)
+// (l'appel notifications existant, après les clôtures :)
+const notifications = await run(
+  "notifications",
+  "[cron:notifications]",
+  sendPendingNotifications,
+  { examResultsSent: 0, accessRemindersSent: 0 },
+)
+```
+
+Import : `import { captureServerError } from "@/lib/observability"`.
+
+- [ ] **Step 2: `features/users/cron.ts` — isolation par ligne de l'anonymisation (revue #3)**
+
+Le catch poison-row (:42-44) n'est jamais vu par le `run()` de la route (la
+fonction retourne normalement) — une panne RGPD persistante resterait
+invisible. Remplacer le `console.error` (comportement d'isolation inchangé,
+conserver le commentaire résilience existant) :
+
+```ts
+    } catch (error) {
+      captureServerError("[cron:anonymize]", error, { detail: `user ${id}` })
+    }
+```
+
+Import : `import { captureServerError } from "@/lib/observability"`.
+(`user ${id}` = id technique, pas de PII — cohérent avec `participation ${id}`.)
+
+- [ ] **Step 3: Webhook Stripe (revue #1 — l'exclusion du scope initial reposait sur une prémisse fausse)**
+
+`onRequestError` ne se déclenche QUE pour les exceptions que Next capture
+lui-même ; ce handler catche puis RETOURNE une `Response` 500 → aucun événement
+Sentry aujourd'hui. Instrumenter `app/api/stripe/webhook/route.ts` en conservant
+STRICTEMENT les réponses HTTP (le 500 → retry Stripe est le contrat) :
+
+Catch de configuration (:38-41) :
+
+```ts
+  } catch (error) {
+    captureServerError("[stripe:webhook]", error, { detail: "configuration" })
+    return new Response("Server configuration error", { status: 500 })
+  }
+```
+
+Branche `not_found` (:77-82) — transaction fantôme = vraie anomalie
+(cf. audit #81), le 200 est conservé (rejouer ne la fera pas apparaître) :
+
+```ts
+if (result.status === "not_found") {
+  captureServerError(
+    "[stripe:webhook]",
+    new Error("aucune transaction pour la session Stripe"),
+    { detail: `session ${checkoutSession.id}` },
+  )
+}
+```
+
+Catch de traitement (:110-113) :
+
+```ts
+  } catch (error) {
+    captureServerError("[stripe:webhook]", error, { detail: event.type })
+    return new Response("Webhook handler error", { status: 500 })
+  }
+```
+
+Le catch de signature invalide (:52-57) reste SANS capture (entrée forgeable
+par n'importe qui → bruit) — `console.error` existant conservé.
+
+Import : `import { captureServerError } from "@/lib/observability"`.
+
+- [ ] **Step 4: `notifications/cron.ts` — 2 catch best-effort**
+
+Remplacer les deux `console.error` (marqueur conservé, boucle continue — inchangé ; conserver le commentaire best-effort existant) :
+
+```ts
+    } catch (error) {
+      captureServerError("[notif:resultats]", error, {
+        detail: `participation ${r.participationId}`,
+      })
+    }
+```
+
+```ts
+    } catch (error) {
+      captureServerError("[notif:acces]", error, { detail: `accès ${r.accessId}` })
+    }
+```
+
+- [ ] **Step 5: Test du catch webhook (capture + 500 conservé)**
+
+Nouveau `tests/features/stripe-webhook-errors.test.ts` — vérifie le contrat du
+catch de traitement (le contrat HTTP complet reste la cible de la campagne C3) :
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+import { POST } from "@/app/api/stripe/webhook/route"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    completeStripeTransaction: vi.fn(),
+    constructEventAsync: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/features/payments/stripe", () => ({
+  completeStripeTransaction: mocks.completeStripeTransaction,
+  failStripeTransaction: vi.fn(),
+}))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    webhooks: { constructEventAsync: mocks.constructEventAsync },
+  }),
+  getStripeWebhookSecret: () => "whsec_test",
+}))
+
+const request = () =>
+  new Request("http://localhost/api/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": "sig" },
+    body: "{}",
+  })
+
+describe("webhook Stripe — catch de traitement", () => {
+  it("échec de fulfillment → captureServerError + 500 (retry Stripe conservé)", async () => {
+    const boom = new Error("Neon down")
+    mocks.constructEventAsync.mockResolvedValueOnce({
+      id: "evt_1",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_1",
+          payment_status: "paid",
+          payment_intent: "pi_1",
+          amount_total: 100,
+          currency: "cad",
+        },
+      },
+    })
+    mocks.completeStripeTransaction.mockRejectedValueOnce(boom)
+
+    const res = await POST(request())
+    expect(res.status).toBe(500)
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[stripe:webhook]",
+      boom,
+      { detail: "checkout.session.completed" },
+    )
+  })
+})
+```
+
+Run: `bun run test tests/features/stripe-webhook-errors.test.ts`
+Expected: PASS. (Si un import du route handler tire un module non mocké, même
+règle que Task 3 : l'erreur le nommera, ajouter le `vi.mock` façade.)
+
+- [ ] **Step 6: Adapter les tests cron existants si besoin**
+
+`tests/integration/notifications-cron.test.ts` (et tout test frontend mockant ces modules) : la revue a vérifié qu'AUCUN test n'asserte les `console.error` actuels — si ça a bougé, repointer sur le nouveau libellé (`captureServerError` fait toujours un `console.error` : `[notif:resultats] participation X`).
+
+Run: `bun run test` (frontend). Les tests d'intégration ne tournent PAS dans cette task (coûteux) — ils seront lancés une fois au checkpoint final.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/api/cron/close-expired/route.ts features/notifications/cron.ts features/users/cron.ts app/api/stripe/webhook/route.ts tests/features/stripe-webhook-errors.test.ts
+git commit -m "feat(observabilite): capture Sentry des echecs isoles (crons, anonymisation RGPD, webhook Stripe)"
+```
+
+---
+
+### Task 8: Documentation des patterns + gates finaux
+
+**Files:**
+
+- Modify: `.claude/rules/data-layer.md` (section Server Actions)
+- Modify: `docs/superpowers/specs/2026-07-14-observabilite-erreurs-design.md` (statut)
+
+- [ ] **Step 1: Documenter la convention dans data-layer.md**
+
+Ajouter à la section Server Actions de `.claude/rules/data-layer.md` :
+
+```markdown
+- **Catch fallback = `captureServerError`** (`lib/observability.ts`) : tag
+  statique + `{ userId }` si en scope — JAMAIS de payload (PII). Réservé aux
+  exceptions inattendues : les erreurs métier mappées (zod, TIME_UP,
+  ACCESS_EXPIRED, 23505 username…) `return fail(...)` sans capture. Codes pg :
+  `getPgErrorCode`/`isPgUniqueViolation` (`lib/db-errors.ts`) — ne JAMAIS
+  tester `error.code` en surface (Drizzle enveloppe dans `cause`).
+```
+
+- [ ] **Step 2: Gates complets**
+
+```bash
+bun run check          # prettier + tsc + eslint
+bun run test           # suite frontend complète
+bun run test:integration  # UNE seule fois (branche Neon éphémère, ~70 s) — payments/notifications/users touchés
+```
+
+Expected: tout vert. En cas d'échec d'un test d'intégration sur le libellé des logs cron → adapter le test (Task 7 Step 3), pas le code.
+
+- [ ] **Step 3: Vérification globale d'éradication**
+
+```bash
+grep -rn "logDev" features/ app/
+grep -rn 'NODE_ENV !== "production"' features/*/actions.ts
+```
+
+Expected: 0 résultat aux deux.
+
+- [ ] **Step 4: Supprimer le rapport de revue jetable**
+
+```bash
+rm docs/superpowers/reviews/2026-07-14-observabilite-erreurs-plan-review.md
+```
+
+(Constats déjà triés et intégrés au spec/plan — le rapport ne se committe pas.)
+
+- [ ] **Step 5: Statut spec + commit final**
+
+Passer le statut du spec à « implémenté » et committer (docs déjà formatés au
+préambule ; re-vérifier avec `bun run format:check` sinon `bun run format`) :
+
+```bash
+git add .claude/rules/data-layer.md docs/superpowers/specs/2026-07-14-observabilite-erreurs-design.md docs/superpowers/plans/2026-07-14-observabilite-erreurs.md
+git commit -m "docs(observabilite): convention captureServerError dans data-layer.md + spec/plan C1"
+```
+
+---
+
+## Critères de done (rappel spec)
+
+1. Exception inattendue dans un catch fallback → événement Sentry en prod (tag + userId), message utilisateur neutre inchangé.
+2. Crash de rendu `(dashboard)`/`(admin)`/racine → événement Sentry.
+3. Erreur métier mappée → AUCUN événement (test Task 3 le verrouille).
+4. Doublon username sous course → « déjà pris » (test Task 3).
+5. `logDev` + blocs inline disparus (Task 8 Step 3).
+6. `bun run check` + `bun run test` + `bun run test:integration` verts.

--- a/docs/superpowers/plans/2026-07-14-tests-ci.md
+++ b/docs/superpowers/plans/2026-07-14-tests-ci.md
@@ -1,0 +1,538 @@
+# Filet de tests & CI (C3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** faire tourner les tests d'intégration en CI + combler les trous de test du chemin d'argent (createStripeCheckout, contrat HTTP webhook, course de fulfillment, IDOR verifyStripeCheckout).
+
+**Architecture:** un job CI `integration` séparé qui réutilise l'orchestrateur Neon existant (`scripts/test-integration.ts`) ; des tests d'intégration (vraie DB, Stripe mocké) pour l'entrée du chemin d'argent et la course ; des tests frontend (mocks) pour le contrat HTTP du webhook et l'IDOR. Aucun code applicatif modifié — uniquement CI + tests.
+
+**Tech Stack:** GitHub Actions · Bun 1.3.10 · Vitest (frontend + integration Neon) · Neon API (orchestrateur existant).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-tests-ci-design.md`
+
+**Préambule (une fois) :** branche sur C2 (milestone) :
+
+```bash
+git checkout c2-integrite-examens
+git checkout -b c3-tests-ci
+```
+
+**Règles projet :** commits conventionnels, aucune attribution Claude. `bun run test` (jamais `bun test`). Tests d'intégration lancés UNE fois au checkpoint (Task 6). Par tâche : tests frontend ciblés + `bunx tsc --noEmit`.
+
+---
+
+### Task 1: Job CI `integration`
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Ajouter le job**
+
+Après le job `quality` (même niveau d'indentation sous `jobs:`), ajouter :
+
+```yaml
+integration:
+  name: Integration Tests
+  runs-on: ubuntu-latest
+
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.10
+
+    - name: Cache Bun install
+      uses: actions/cache@v6
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      run: bun install --frozen-lockfile
+
+    # Orchestrateur : crée une branche Neon jetable (test-*), migre, lance le
+    # projet vitest `integration`, détruit la branche. Seuls secrets requis :
+    # NEON_API_KEY + NEON_PROJECT_ID (l'URL DB vient de la branche créée ;
+    # l'env applicatif vient de tests/helpers/test-env.ts).
+    - name: Integration tests (ephemeral Neon branch)
+      run: bun run test:integration
+      env:
+        NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+        NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+```
+
+(Le bloc `permissions: contents: read` et `concurrency` en tête du fichier
+s'appliquent à tous les jobs — rien à dupliquer.)
+
+- [ ] **Step 2: Vérifier la syntaxe YAML**
+
+Run: `bunx yaml-lint .github/workflows/ci.yml` si dispo, sinon vérifier
+visuellement l'indentation (2 espaces, aligné sur `quality:`). Optionnel :
+`bun -e "import('js-yaml')"` n'est pas requis — une relecture suffit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: job dédié pour les tests d'intégration (branche Neon éphémère)"
+```
+
+- [ ] **Step 4: ⚠️ ACTION UTILISATEUR (hors code) — ajouter les secrets GitHub**
+
+Le job restera **rouge** tant que les secrets ne sont pas posés. Marche à suivre
+(à faire par l'utilisateur, une fois) :
+
+1. GitHub → repo → Settings → Secrets and variables → Actions → New repository secret.
+2. Ajouter `NEON_API_KEY` (même valeur que `.env.local`) et `NEON_PROJECT_ID`.
+3. Re-déclencher le job (push ou « Re-run jobs »).
+
+Rappeler ce point dans la description de la PR du milestone.
+
+---
+
+### Task 2: `createStripeCheckout` — création de la transaction pending (intégration)
+
+**Files:**
+
+- Test: `tests/integration/payments-checkout.test.ts` (nouveau)
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { products, transactions, user } from "@/db/schema"
+import { createStripeCheckout } from "@/features/payments/actions"
+import { createId } from "@/lib/ids"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    sessionUserId: { current: "" },
+    create: vi.fn<() => Promise<{ id: string; url: string | null }>>(),
+  },
+}))
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(async () => ({
+    user: { id: mocks.sessionUserId.current, email: "chk@test.invalid" },
+  })),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({ checkout: { sessions: { create: mocks.create } } }),
+}))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const PID = createId()
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: `Chk ${suffix}`,
+    email: `chk-${suffix}@test.invalid`,
+  })
+  await db.insert(products).values({
+    id: PID,
+    code: "exam_access",
+    name: `Exam ${suffix}`,
+    description: "desc",
+    priceCad: 5000,
+    durationDays: 90,
+    accessType: "exam",
+    isCombo: false,
+    stripeProductId: `prod_${suffix}`,
+    stripePriceId: `price_${suffix}`,
+  })
+  mocks.sessionUserId.current = USER_ID
+})
+
+afterAll(async () => {
+  await db.delete(transactions).where(eq(transactions.userId, USER_ID))
+  await db.delete(products).where(eq(products.id, PID))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("createStripeCheckout", () => {
+  it("crée une transaction pending liée à la session Stripe + metadata.userId", async () => {
+    const sessionId = `cs_${suffix}`
+    mocks.create.mockResolvedValueOnce({
+      id: sessionId,
+      url: "https://stripe.test/checkout",
+    })
+
+    const res = await createStripeCheckout({
+      productCode: "exam_access",
+      successPath: "/tableau-de-bord",
+      cancelPath: "/tarifs",
+    })
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/checkout" })
+
+    // metadata.userId transmis à Stripe (invariant anti-IDOR côté verify + fulfillment).
+    // PAS d'assertion sur metadata.productId : products.code n'est pas unique et
+    // develop contient déjà un exam_access → le produit résolu (ORDER BY id ASC)
+    // est non déterministe (revue #2).
+    const arg = mocks.create.mock.calls[0]![0] as {
+      metadata: { userId: string }
+    }
+    expect(arg.metadata.userId).toBe(USER_ID)
+
+    // Transaction pending retrouvable par le webhook via stripeSessionId
+    // (invariants robustes, indépendants du produit résolu).
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.stripeSessionId, sessionId))
+    expect(tx.status).toBe("pending")
+    expect(tx.type).toBe("stripe")
+    expect(tx.userId).toBe(USER_ID)
+    expect(tx.stripeSessionId).toBe(sessionId)
+  })
+
+  it("refuse un productCode inconnu (pas d'appel Stripe)", async () => {
+    const res = await createStripeCheckout({
+      productCode: "does_not_exist",
+      successPath: "/tableau-de-bord",
+      cancelPath: "/tarifs",
+    })
+    expect(res).toEqual({ error: "Produit invalide" })
+  })
+})
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `bunx tsc --noEmit && bunx eslint tests/integration/payments-checkout.test.ts` → 0 erreur.
+(Le test tourne au checkpoint Task 6 — pas de run intégration isolé ici.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/payments-checkout.test.ts
+git commit -m "test(payments): createStripeCheckout crée la transaction pending (couple pending↔webhook)"
+```
+
+---
+
+### Task 3: Contrat HTTP du webhook (frontend, étend le fichier C1)
+
+**Files:**
+
+- Modify: `tests/features/stripe-webhook-errors.test.ts`
+
+- [ ] **Step 1: Ajouter les cas de contrat**
+
+Le fichier mocke déjà `captureServerError`, `completeStripeTransaction`/
+`failStripeTransaction`, `getStripe`/`getStripeWebhookSecret`. Ajouter à
+`mocks` : `failStripeTransaction` doit être espionnable (remplacer le
+`vi.fn()` inline du mock `@/features/payments/stripe` par une réf `mocks.fail`).
+
+⚠️ **Réinitialiser les mocks entre tests** (revue #3) : le fichier n'a PAS de
+`beforeEach` de reset et vitest.config n'active pas `clearMocks`. Sans ça, les
+assertions `not.toHaveBeenCalled()` verraient les appels du test C1 précédent, et
+`toHaveBeenCalled()` deviendrait tautologique. Ajouter en tête du `describe` :
+
+```ts
+import { beforeEach } from "vitest"
+
+// (déjà importé ? sinon ajouter)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Défaut happy path pour les tests qui ne le posent pas eux-mêmes :
+  mocks.completeStripeTransaction.mockResolvedValue({ status: "completed" })
+})
+```
+
+Puis ajouter ces tests dans le `describe` existant (chacun pose son
+`mockResolvedValueOnce`/`mockRejectedValueOnce` APRÈS le beforeEach) :
+
+```ts
+it("signature absente → 400 (jamais rejoué)", async () => {
+  const req = new Request("http://localhost/api/stripe/webhook", {
+    method: "POST",
+    body: "{}",
+  })
+  const res = await POST(req)
+  expect(res.status).toBe(400)
+})
+
+it("signature invalide → 400", async () => {
+  mocks.constructEventAsync.mockRejectedValueOnce(new Error("bad sig"))
+  const res = await POST(request())
+  expect(res.status).toBe(400)
+})
+
+it("payment_status non fulfillable → pas de fulfillment, 200", async () => {
+  mocks.constructEventAsync.mockResolvedValueOnce({
+    id: "evt_unpaid",
+    type: "checkout.session.completed",
+    data: { object: { id: "cs_unpaid", payment_status: "unpaid" } },
+  })
+  const res = await POST(request())
+  expect(res.status).toBe(200)
+  expect(mocks.completeStripeTransaction).not.toHaveBeenCalled()
+})
+
+it("transaction fantôme (not_found) → capture + 200", async () => {
+  mocks.constructEventAsync.mockResolvedValueOnce({
+    id: "evt_ghost",
+    type: "checkout.session.completed",
+    data: {
+      object: {
+        id: "cs_ghost",
+        payment_status: "paid",
+        payment_intent: "pi_1",
+        amount_total: 5000,
+        currency: "cad",
+      },
+    },
+  })
+  mocks.completeStripeTransaction.mockResolvedValueOnce({ status: "not_found" })
+  const res = await POST(request())
+  expect(res.status).toBe(200)
+  expect(mocks.captureServerError).toHaveBeenCalled()
+})
+
+it("checkout.session.expired → failStripeTransaction, 200", async () => {
+  mocks.constructEventAsync.mockResolvedValueOnce({
+    id: "evt_exp",
+    type: "checkout.session.expired",
+    data: { object: { id: "cs_exp" } },
+  })
+  const res = await POST(request())
+  expect(res.status).toBe(200)
+  expect(mocks.fail).toHaveBeenCalledWith({
+    stripeSessionId: "cs_exp",
+    stripeEventId: "evt_exp",
+  })
+})
+```
+
+Adapter le mock `@/features/payments/stripe` :
+
+```ts
+vi.mock("@/features/payments/stripe", () => ({
+  completeStripeTransaction: mocks.completeStripeTransaction,
+  failStripeTransaction: mocks.fail,
+}))
+```
+
+et déclarer `fail: vi.fn()` dans le `vi.hoisted`. Le `completeStripeTransaction`
+happy path doit renvoyer un statut ≠ not_found par défaut si un test l'exige
+(ajouter `mockResolvedValue({ status: "completed" })` en `beforeEach` si besoin).
+
+- [ ] **Step 2: Run + lint**
+
+Run: `bun run test tests/features/stripe-webhook-errors.test.ts` → PASS
+Run: `bunx eslint tests/features/stripe-webhook-errors.test.ts` → 0 erreur
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/features/stripe-webhook-errors.test.ts
+git commit -m "test(payments): contrat HTTP du webhook Stripe (400 signature, 200 not_found, filtre, expired)"
+```
+
+---
+
+### Task 4: Course de fulfillment (intégration, étend payments-stripe)
+
+**Files:**
+
+- Modify: `tests/integration/payments-stripe.test.ts`
+
+- [ ] **Step 1: Ajouter le test de course**
+
+Dans le `describe("completeStripeTransaction")`, réutiliser `seedPending` +
+`approxDays` + `PEXAM` du fichier. **Test discriminant** (revue #1) : deux
+transactions DISTINCTES (events/sessions différents), même user non-combo, 90 j
+chacune → le verrou `FOR UPDATE` sur la ligne `user` (`stripe.ts:78`) sérialise
+le cumul → expiration finale `now + 180 j`. Sans le verrou, les deux liraient
+`base = now` → `now + 90` (perte d'une durée). L'assertion `approxDays(…, 180)`
+tombe à 90 si le verrou saute — c'est ce qui prouve le verrou (deux fulfillments
+IDENTIQUES ne prouveraient rien : l'unicité de `userAccess` vient de
+`onConflictDoUpdate`, pas du verrou).
+
+```ts
+it("deux fulfillments concurrents (2 tx distinctes, même user non-combo) → accès CUMULÉ 180j (verrou FOR UPDATE)", async () => {
+  const sidA = `sess_raceA_${suffix}`
+  const sidB = `sess_raceB_${suffix}`
+  await seedPending({
+    id: createId(),
+    userId: U_RACE,
+    productId: PEXAM,
+    sessionId: sidA,
+    accessType: "exam",
+    durationDays: 90,
+  })
+  await seedPending({
+    id: createId(),
+    userId: U_RACE,
+    productId: PEXAM,
+    sessionId: sidB,
+    accessType: "exam",
+    durationDays: 90,
+  })
+
+  await Promise.all([
+    completeStripeTransaction({
+      stripeSessionId: sidA,
+      stripePaymentIntentId: `pi_a_${suffix}`,
+      stripeEventId: `evt_a_${suffix}`,
+      amountTotal: 5000,
+      currency: "cad",
+    }),
+    completeStripeTransaction({
+      stripeSessionId: sidB,
+      stripePaymentIntentId: `pi_b_${suffix}`,
+      stripeEventId: `evt_b_${suffix}`,
+      amountTotal: 5000,
+      currency: "cad",
+    }),
+  ])
+
+  const rows = await db
+    .select()
+    .from(userAccess)
+    .where(eq(userAccess.userId, U_RACE))
+  expect(rows).toHaveLength(1)
+  // Cumul des deux durées (90 + 90). Tombe à ~90 si le verrou FOR UPDATE saute.
+  expect(approxDays(rows[0].expiresAt, 180)).toBe(true)
+})
+```
+
+Note exécutant : ajouter `U_RACE = createId()` à la constante `U` (liste des
+users seedés/nettoyés dans `beforeAll`/`afterAll`) et au `db.insert(user)` ; `eq`
+est importé si absent (sinon le fichier utilise déjà `inArray` — vérifier).
+`U_RACE` doit être un user SANS accès préexistant (sinon le `base` initial n'est
+pas `now`).
+
+- [ ] **Step 2: Lint**
+
+Run: `bunx tsc --noEmit && bunx eslint tests/integration/payments-stripe.test.ts` → 0 erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/payments-stripe.test.ts
+git commit -m "test(payments): course de fulfillment → cumul d'accès 180j prouve le verrou FOR UPDATE"
+```
+
+---
+
+### Task 5: `verifyStripeCheckout` — IDOR + happy path (frontend, étend C1)
+
+**Files:**
+
+- Modify: `tests/features/payments-actions-errors.test.ts`
+
+- [ ] **Step 1: Ajouter les cas**
+
+Le fichier mocke déjà `getStripe` (`mocks.retrieve`) + `requireSession`
+(user id `u1`). Ajouter :
+
+```ts
+it("metadata.userId ≠ session → refus (anti-IDOR), pas de capture", async () => {
+  mocks.retrieve.mockResolvedValueOnce({
+    metadata: { userId: "someone_else" },
+    payment_status: "paid",
+    amount_total: 5000,
+    currency: "cad",
+    customer_email: "x@test.invalid",
+  })
+  const res = await verifyStripeCheckout("cs_ok")
+  expect(res).toEqual({
+    success: false,
+    error: "Session non trouvée ou invalide",
+  })
+  expect(mocks.captureServerError).not.toHaveBeenCalled()
+})
+
+it("metadata.userId == session → succès", async () => {
+  mocks.retrieve.mockResolvedValueOnce({
+    metadata: { userId: "u1" },
+    payment_status: "paid",
+    amount_total: 5000,
+    currency: "cad",
+    customer_email: "x@test.invalid",
+  })
+  const res = await verifyStripeCheckout("cs_ok")
+  expect(res).toMatchObject({ success: true, status: "paid" })
+})
+```
+
+Note exécutant : vérifier la forme réelle du retour succès de
+`verifyStripeCheckout` (`{ success, status, amountTotal, currency,
+customerEmail }`) et ajuster `toMatchObject`.
+
+- [ ] **Step 2: Run + lint**
+
+Run: `bun run test tests/features/payments-actions-errors.test.ts` → PASS
+Run: `bunx eslint tests/features/payments-actions-errors.test.ts` → 0 erreur
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/features/payments-actions-errors.test.ts
+git commit -m "test(payments): verifyStripeCheckout anti-IDOR + happy path"
+```
+
+---
+
+### Task 6: Checkpoint final — gates complets
+
+- [ ] **Step 1: Formater les docs de campagne**
+
+```bash
+bunx prettier --write docs/superpowers/specs/2026-07-14-tests-ci-design.md docs/superpowers/plans/2026-07-14-tests-ci.md
+```
+
+- [ ] **Step 2: `bun run check` + suite frontend**
+
+Run: `bun run check` → exit 0
+Run: `bun run test` → PASS (les nouveaux tests frontend webhook + verify inclus)
+
+- [ ] **Step 3: Intégration (un seul run Neon)**
+
+Run: `bun run test:integration`
+Expected: PASS, incluant `payments-checkout` (nouveau) et la course dans
+`payments-stripe`.
+
+- [ ] **Step 4: Statut spec + commit final**
+
+Passer le statut du spec à « implémenté » :
+
+```bash
+git add docs/superpowers/specs/2026-07-14-tests-ci-design.md docs/superpowers/plans/2026-07-14-tests-ci.md
+git commit -m "docs(tests): spec/plan C3 + statut implémenté"
+```
+
+- [ ] **Step 5: Rappeler le prérequis secrets**
+
+Confirmer à l'utilisateur qu'il doit ajouter `NEON_API_KEY` + `NEON_PROJECT_ID`
+en secrets GitHub pour que le job CI `integration` passe au vert (le reste de la
+CI et les tests locaux sont indépendants de ce point).
+
+---
+
+## Critères de done (rappel spec)
+
+1. Job CI `integration` sur PR + push main (vert après ajout des secrets).
+2. `createStripeCheckout` : transaction pending prouvée (couple pending↔webhook).
+3. Contrat HTTP webhook verrouillé (400/200/filtre/dispatch).
+4. Double crédit concurrent prouvé impossible.
+5. `verifyStripeCheckout` : IDOR refusé + happy path.
+6. `bun run check` + `bun run test` + `bun run test:integration` verts.

--- a/docs/superpowers/specs/2026-07-14-integrite-examens-design.md
+++ b/docs/superpowers/specs/2026-07-14-integrite-examens-design.md
@@ -1,0 +1,192 @@
+# Spec — Intégrité & sécurité des examens (campagne C2)
+
+- **Date** : 2026-07-14
+- **Statut** : IMPLÉMENTÉ le 2026-07-14 (branche `c2-integrite-examens` sur
+  `c1-observabilite`) — revue adversariale design passée, constats A/B/C/D/E/F/G/H/I
+  intégrés ; gates verts (check + 950 front + 276 intégration)
+- **Branche** : `c2-integrite-examens` sur `c1-observabilite` (touche
+  `features/exams/actions.ts` déjà modifié par C1 ; milestone commun C1+C2+C3).
+- **Origine** : audit du 2026-07-13 — agent sécurité (🔴 fuite examens) + agent
+  data-layer (#1 budget-temps, #2 race save, #3 race updateExam, #5 read non
+  borné).
+
+## Problème
+
+Cinq failles dans `features/exams`, toutes vérifiées à la source :
+
+1. **🔴 Fuite du contenu d'examen.** `getExamWithQuestions` (`dal.ts:269`) ne
+   pose de garde d'audience que pour `restricted` ; pour `subscribers` il
+   renvoie l'énoncé + les options de TOUTES les questions à n'importe quel
+   utilisateur authentifié (seul `correctAnswer` masqué). La page de passation
+   `evaluation/page.tsx` rend ces questions **sans aucune garde** (elle ne
+   redirige que si la participation est déjà `completed`). Un utilisateur gratuit
+   qui connaît l'`examId` exfiltre l'examen complet ; un abonné lit les questions
+   **avant l'ouverture de la fenêtre**. En creusant : le trou touche aussi
+   `restricted` (un membre sans participation peut pré-lire via la page
+   evaluation, non gardée).
+2. **🔴 Budget-temps contournable.** `finalizeExam` saute le contrôle `TIME_UP`
+   quand `isAutoSubmit=true` (`actions.ts:817`) — or ce flag vient du client. Et
+   `saveExamAnswer` ne vérifie que la fenêtre de dates de l'examen, jamais
+   `startedAt + completionTime`. Sur une fenêtre large (jours) avec budget 83 s/q,
+   l'étudiant répond des heures puis finalise avec `isAutoSubmit:true` → score
+   complet en temps illimité, indiscernable au leaderboard.
+3. **🟠 Race `saveExamAnswer`.** Le check `status = 'in_progress'`
+   (`actions.ts:638`) et l'`UPDATE examAnswers` (`:656`) sont séparés : une
+   finalisation concurrente peut committer le score entre les deux → réponse
+   écrite après, incohérente avec le score affiché.
+4. **🟠 Race `updateExam` vs `startExam`.** `startExam` verrouille la ligne
+   `user` ; `updateExam` ne verrouille rien sur `exams`. Un étudiant démarre
+   (crée la participation) entre le `count` d'`updateExam` (lit 0) et son
+   delete+réinsert de `examQuestions` → participation sur l'ancien set, examen
+   servi avec le nouveau.
+5. **🟠 `loadExamQuestionExplanations` non borné.** `questionIds[]` du client
+   sans zod ni cap (`actions.ts:56`) ; pour un admin `authorized = requested`
+   (`dal.ts:791`) → `inArray` + `fetchImages` sans limite.
+
+## Principe directeur
+
+L'ancre d'autorisation d'une passation est **`startExam`** : c'est le seul
+chemin qui vérifie fenêtre + accès + audience et crée la participation
+`in_progress`. Toute la campagne renforce cette invariante : on ne rend/écrit du
+contenu d'examen que pour une participation `in_progress` valide, et jamais
+au-delà du budget-temps.
+
+## Design
+
+### 1. Fuite du contenu d'examen — livraison conditionnelle + garde DAL
+
+⚠️ **La page evaluation est le GUICHET d'entrée**, pas seulement la salle
+d'examen : la liste pousse vers `/evaluation` **sans** participation
+(`examen-blanc-client.tsx:447`), et c'est le dialog « Règles importantes » de
+cette page qui appelle `startExam` (`evaluation-client.tsx:205-215`). Un gate
+`notFound` sur l'absence de participation `in_progress` casserait donc tout
+démarrage (constat A de la revue). Le remède conditionne la **livraison des
+questions**, pas l'accès à la page.
+
+**Primaire — `evaluation/page.tsx`** : la page reste accessible sans
+participation. On récupère `getExamSession(examId)` d'abord :
+
+- `completed`/`auto_submitted` → `redirect('…/soumis')` (comportement actuel
+  conservé) ;
+- `in_progress` → fetch `getExamWithQuestions` + `getExamAnswersForParticipation`
+  et livrer les questions ;
+- sinon (pas de participation) → rendre `EvaluationClient` avec **`questions=[]`**
+  (métadonnées légères pour l'écran de démarrage, AUCUNE question dans le payload
+  RSC).
+
+**Client — `evaluation-client.tsx`** : après un `startExam` réussi, ajouter
+`router.refresh()` pour que le Server Component re-livre les questions (désormais
+`in_progress`). L'état client (`serverStartTime`, dialog fermé) est préservé au
+travers du refresh (App Router). Nouvelle invariante : **pas de participation
+`in_progress` ⇒ aucune question dans le payload RSC** — ferme la fuite pour
+`subscribers`, `restricted` ET le cas pré-fenêtre (car `startExam` garde
+fenêtre+accès+audience).
+
+**Défense en profondeur — `getExamWithQuestions`** : pour un non-admin sur un
+examen `subscribers`, exiger `hasAccess("exam")` (entitlement actif). Symétrique
+avec `startExam` (`actions.ts:475-493`) ; branche `restricted` inchangée. Un
+utilisateur sans accès reçoit `null`.
+
+- **Régression E évitée — page détail** : `getExamWithQuestions` renvoyant `null`
+  pour un non-abonné, la page détail (`[examId]/page.tsx`) doit rendre la **carte
+  paywall** (« Vous devez avoir un accès exam actif ») quand le DAL renvoie
+  `null`, PAS `notFound()` — sinon un non-abonné qui suit un lien reçoit un 404
+  sec (régression du tunnel d'achat). Les pages admin bypassent (admin).
+- **Consommateurs cachés vérifiés** (revue) : evaluation (livraison
+  conditionnelle ci-dessus), `[examId]/page.tsx` (détail — paywall préservé), 2
+  pages admin (bypass). Tous les personas non-admin des tests d'intégration ont
+  un `userAccess` 'exam' seedé → la garde ne casse aucun test existant.
+
+### 2. Budget-temps — garde à l'écriture + finalize
+
+**Primaire — `saveExamAnswer`** : rejeter la réponse quand
+`now > startedAt + completionTime·1000 + pauseMs + GRACE`. La pause ACTIVE
+interdisant déjà l'écriture (`pauseStartedAt` non nul → `fail`), `pauseMs` = le
+cumul figé `totalPauseDurationMs` uniquement (pas de branche pause active — elle
+serait morte, constat H). Nécessite d'AJOUTER au SELECT : `exams.completionTime`
+et `examParticipations.{startedAt, totalPauseDurationMs}`. `GRACE` = 10 000 ms
+(latence réseau du dernier envoi ; distinct du +5 s de finalize). Nouvelle erreur
+mappée « Temps écoulé. » (métier, PAS capturée).
+
+**Défense en profondeur — `finalizeExam`** : conserver le recalcul serveur
+d'`elapsed` (déjà présent). Comme les réponses hors-temps ne persistent plus, un
+`finalizeExam` forgé `isAutoSubmit:true` tardif ne finalise que les réponses
+dans les temps → aucun gonflement de score.
+
+### 3. Race `saveExamAnswer` — transaction + verrou participation
+
+Une sous-requête `EXISTS` ne suffit PAS (constat C) : sous READ COMMITTED elle
+lit la dernière version committée et ne se met pas en file derrière le
+`FOR UPDATE` d'un `finalizeExam` **en vol** → une réponse peut encore committer
+entre l'agrégat de score et le commit de finalize. Fermeture complète (idiome
+AGENTS.md « verrou de ligne englobant check + écriture ») : envelopper le SELECT
+participation + la garde budget-temps + l'`UPDATE examAnswers` dans
+`db.transaction`, avec `SELECT … FROM exam_participations … .for("update")` sur
+la ligne participation. `finalizeExam` verrouille déjà cette même ligne
+(`actions.ts:777`) → les deux se sérialisent : si finalize gagne, le save re-lit
+un statut terminal sous le verrou et refuse (« Cette session d'examen n'est plus
+active. »). Les lectures immuables (exam, question/correctAnswer) restent hors
+transaction.
+
+### 4. Race `updateExam` vs `startExam` — verrou commun
+
+`SELECT id FROM exams WHERE id = ? FOR UPDATE` en TÊTE des deux transactions
+(avant toute lecture de participations/questions). Verrou commun sur la ligne
+d'examen → les deux se sérialisent. `updateExam` verrouille aujourd'hui la ligne
+qu'il lit déjà (`:211`) mais SANS `FOR UPDATE` ; `startExam` verrouille `user`,
+pas `exams`. On aligne les deux sur la ligne `exams`.
+
+### 5. `loadExamQuestionExplanations` — cap zod
+
+Schéma `z.array(z.string()).min(1).max(MAX_EXAM_QUESTIONS)` dans l'action wrapper
+(dédup gardée par le DAL via `new Set`). **Cap = `MAX_EXAM_QUESTIONS` (500), PAS
+100** (constat B) : un examen peut avoir jusqu'à 500 questions (schéma) / 230
+(formulaire admin), et « Tout déplier » (`session-results.tsx:232`) envoie tous
+les ids en UN appel ; un cap trop bas → `[]` silencieux + ids marqués chargés →
+explications définitivement vides. Le cap reste un garde-fou anti-abus
+(`inArray` de 500 borné). Entrée hors bornes → `[]` (refus silencieux, parité
+`scoreQuizAnswersSchema`).
+
+## Hors scope (YAGNI)
+
+- Contrat HTTP complet du webhook, scoring, découpage `exams/dal.ts` (→ C6/C3).
+- Pas de changement du modèle d'audience ni du leaderboard.
+- Pas de re-vérification `hasAccess` dans le DAL pour `restricted` (l'audience
+  EST l'autorisation — inchangé).
+
+## Tests (intégration Neon, sauf cap = frontend)
+
+- **Fuite (DAL)** : free user → `getExamWithQuestions` (subscribers) = `null` ;
+  abonné avec accès → questions.
+- **Fuite (livraison)** : la page evaluation ne livre pas de questions sans
+  participation `in_progress` (assertion au niveau du Server Component / props :
+  `questions=[]` sans participation ; peuplées avec `in_progress`). Les deux
+  audiences.
+- **Budget-temps** : `saveExamAnswer` au-delà de `startedAt + completionTime +
+GRACE` → `TIME_UP`, réponse non persistée ; dans les temps → OK.
+- **Attaque #2 bout-en-bout** : réponse hors-temps refusée PUIS
+  `finalizeExam({ isAutoSubmit: true })` tardif → le score final N'inclut PAS la
+  réponse hors-temps (le scénario d'attaque complet).
+- **Race save-vs-finalize (déterministe)** : `finalizeExam` PUIS `saveExamAnswer`
+  → save refusé (« session incohérente »). Éviter l'assertion d'ordre sur un
+  `Promise.all` (flaky, constat D) ; si concurrence testée, asserter l'invariant
+  final `score ≡ computeScorePercent(réponses comptées)`.
+- **Race updateExam-vs-startExam** : `Promise.all` → invariant : si une
+  participation est créée, ses `examAnswers` correspondent au set effectivement
+  servi (pas de mélange ancien/nouveau).
+- **Cap zod (frontend)** : schéma accepte 1..500, refuse 0 et 501.
+- **Non-régression** : `passation-anti-cheat`, `exam-audience`, `exam-runner`,
+  `exams` verts + e2e `examen-blanc*` (la livraison conditionnelle ne doit PAS
+  casser le démarrage — vérifier ou adapter les POMs).
+
+## Critères de succès
+
+1. Un utilisateur sans participation `in_progress` ne reçoit AUCUNE question dans
+   le payload RSC de la page de passation (mais peut toujours démarrer l'examen).
+2. Une réponse enregistrée au-delà du budget-temps est refusée et non persistée,
+   quel que soit `isAutoSubmit`.
+3. Une réponse concurrente à une finalisation ne s'écrit pas après le score.
+4. `updateExam` et `startExam` concurrents ne produisent jamais une participation
+   sur un set de questions remplacé.
+5. `loadExamQuestionExplanations` borne l'entrée à 100 ids.
+6. Gates verts : `bun run check`, `bun run test`, `bun run test:integration`.

--- a/docs/superpowers/specs/2026-07-14-observabilite-erreurs-design.md
+++ b/docs/superpowers/specs/2026-07-14-observabilite-erreurs-design.md
@@ -1,0 +1,201 @@
+# Spec — Observabilité & gestion d'erreurs backend (campagne C1)
+
+- **Date** : 2026-07-14
+- **Statut** : IMPLÉMENTÉ le 2026-07-14 (branche `c1-observabilite`) — revue
+  adversariale design passée, constats #1 #2 #3 #4 #5 #6 #7 #9 intégrés
+- **Origine** : audit complet du 2026-07-13 — constat 🔴 « cécité totale sur les
+  erreurs de prod » (agents data-layer #4 et frontend #3), + bug 23505
+  `updateProfile` (agent data-layer #6).
+
+## Problème
+
+Sentry est branché (`instrumentation.ts` exporte
+`onRequestError = Sentry.captureRequestError`), mais trois familles de code
+**catchent l'exception avant qu'elle remonte** et la réduisent à un message
+générique sans trace :
+
+1. **Server Actions** : les catch fallback (`"Erreur serveur. Réessayez."`)
+   loggent via `logDev` (3 copies identiques dans `features/{exams,training,questions}/actions.ts`)
+   ou via des blocs inline `if (NODE_ENV !== "production") console.error`
+   (6 blocs dans `features/payments/actions.ts`, d'autres dans
+   `features/users/actions.ts`) — **rien en prod**. Une régression d'écriture
+   (contrainte violée à chaque soumission d'examen, échec Stripe) serait
+   invisible.
+2. **Error boundaries de segment** : `app/error.tsx`,
+   `app/(dashboard)/error.tsx`, `app/(admin)/error.tsx` font seulement
+   `console.error`. Seul `app/global-error.tsx` appelle
+   `Sentry.captureException`, or il ne se déclenche que si aucun boundary de
+   segment ne capte — donc les crashs de rendu dashboard/admin n'atteignent
+   jamais Sentry.
+3. **Crons** : l'isolation par tâche de `app/api/cron/close-expired/route.ts`
+   et le best-effort d'envoi email de `features/notifications/cron.ts`
+   avalent les erreurs des tâches qui échouent (comportement voulu pour la
+   continuité, mais panne silencieuse).
+
+Bug corrélé : `updateProfile` (`features/users/actions.ts:158`) teste
+`error.code === "23505"` au **premier niveau**, alors que Drizzle enveloppe
+l'erreur pg dans `DrizzleQueryError.cause` — la branche est morte ; sous course
+(pré-check d'unicité passé des deux côtés), l'utilisateur reçoit « Erreur
+serveur » au lieu de « déjà pris ». Le projet connaît déjà le pattern d'unwrap
+(`isForeignKeyViolation`, `features/questions/actions.ts:313`, remontée de
+`cause` bornée à 5).
+
+## Principe directeur
+
+**Capturer uniquement dans les catch fallback génériques.** Les erreurs métier
+mappées (validation zod, `TIME_UP`, `ACCESS_EXPIRED`, `ALREADY_TAKEN`,
+`NOT_IN_PROGRESS`, FK 23001/23503 du delete hybride, 23505 username…) sont du
+flux de contrôle normal : elles ne vont **jamais** à Sentry. C'est ce qui garde
+le signal exploitable — l'inverse du bruit qu'on a déjà dû filtrer (#105).
+
+Deux catch sont des **faux fallbacks** (revue design #2 et #5) — leur erreur
+« attendue » fait partie du flux métier et doit être filtrée AVANT capture :
+
+- `verifyStripeCheckout` : le `session_id` vient de l'URL de la page de succès
+  (contrôlable/périmable par l'utilisateur) ; `stripe.checkout.sessions.retrieve`
+  **throw** `resource_missing` sur tout id invalide et le catch mappe déjà ça au
+  message métier « Session non trouvée ou invalide ». → pas de capture si
+  `code === "resource_missing"` (duck-check), capture sinon.
+- `setAccountPassword` : catch actuellement **nu** (aucun log — pire que les
+  blocs recensés) ; `auth.api.setPassword` throw aussi des `APIError` Better
+  Auth métier. → capture seulement si `!(error instanceof APIError)`
+  (`better-auth/api`).
+
+## Design
+
+### 1. `lib/observability.ts` — capture centralisée (nouveau)
+
+Module serveur : première ligne `import "server-only"` (revue #7 — verrouille
+l'invariant « jamais importé côté client » ; le stub de test existe déjà,
+alias `server-only` dans `vitest.config.ts`).
+
+```ts
+export const captureServerError = (
+  tag: string,               // ex. "[finalizeExam]" — statique (cardinalité de tag Sentry)
+  error: unknown,
+  context?: { userId?: string; detail?: string },
+) => { ... }
+```
+
+- `console.error` **inconditionnel** (dev : terminal ; prod : logs Vercel —
+  on ne perd pas la trace texte que les crons ont déjà aujourd'hui).
+- Prod uniquement : `Sentry.captureException(error, { tags: { action: tag },
+user: context?.userId ? { id } : undefined, extra: { detail } })`. Pas
+  d'envoi Sentry en dev/test (bruit local).
+- `tag` reste **statique** (les tags Sentry sont à faible cardinalité) ; les
+  ids dynamiques (participation, accès) passent dans `detail` → `extra`.
+- **Contexte léger uniquement** : nom d'action + userId + ids techniques.
+  Jamais de payload (emails, réponses d'examen, montants) — pas de PII dans
+  Sentry.
+- Remplace : les 3 `logDev` copiés-collés + tous les blocs inline
+  `NODE_ENV !== "production" → console.error` des catch fallback de
+  `features/*/actions.ts`.
+- Les erreurs métier mappées ne passent pas par ce helper (elles `return fail(...)`
+  avant).
+
+### 2. `lib/db-errors.ts` — extraction de code pg (nouveau)
+
+```ts
+export const getPgErrorCode = (error: unknown): string | undefined
+```
+
+- Remonte la chaîne `.cause` (bornée à 5 niveaux, même idiome que
+  `isForeignKeyViolation`) et renvoie le premier `.code` string rencontré.
+- `isForeignKeyViolation` (questions) devient un wrapper mince :
+  `FK_VIOLATION_CODES.has(getPgErrorCode(e) ?? "")` — dédup du parcours.
+- **Fix 23505** : `updateProfile` remplace son test de surface par
+  `isPgUniqueViolation(error)` (wrapper nommé de
+  `getPgErrorCode(error) === "23505"`) → « Ce nom d'utilisateur est déjà
+  pris ! » fonctionne sous course.
+
+### 3. Error boundaries de segment
+
+`app/error.tsx`, `app/(dashboard)/error.tsx`, `app/(admin)/error.tsx` :
+ajouter `Sentry.captureException(error)` dans le `useEffect` existant (import
+direct `@sentry/nextjs`, comme `global-error.tsx` — le helper serveur n'est
+PAS importé côté client, aucune fuite de bundle). UI inchangée.
+
+Doublon SSR attendu (revue #9, setup standard Sentry) : un crash de rendu
+**serveur** produit deux événements — un serveur (vraie stack, via
+`onRequestError`) et un client (erreur digest, via le boundary) ; un crash
+**client** ne produit que l'événement boundary — c'est le trou comblé. Ne pas
+« corriger » ce doublon plus tard en retirant la capture boundary (commentaire
+d'une ligne dans les boundaries).
+
+### 4. Crons, webhook Stripe & route handlers
+
+- `app/api/cron/close-expired/route.ts` : dans le catch d'isolation du helper
+  `run`, capturer avec un **tag par tâche** (`[cron:exams]`, `[cron:trainings]`,
+  `[cron:anonymize]`, `[cron:quiz-rl]`, `[cron:notifications]` — filtrables dans
+  Sentry, cardinalité triviale ; revue #6) puis continuer (isolation,
+  `failed=true` et 500 final inchangés).
+- `features/notifications/cron.ts` : capturer l'échec d'envoi email dans les 2
+  catch best-effort existants (marqueur conservé, boucle continue — inchangé).
+- `features/users/cron.ts` : l'anonymisation RGPD a sa **propre isolation par
+  ligne** (poison-row) que le `run()` de la route ne voit jamais (revue #3) →
+  capturer dans ce catch aussi (`[cron:anonymize]`, detail `user <id>` — id
+  technique, pas de PII).
+- **Webhook Stripe : DANS le scope** (revue #1 — la prémisse « le 500 est
+  retracé par `onRequestError` » était fausse : le handler **catche** puis
+  retourne une `Response` 500, Next ne voit jamais d'exception,
+  `captureRequestError` ne se déclenche pas). À instrumenter, réponses HTTP
+  strictement inchangées :
+  - catch de traitement (`route.ts:110-113`) : capture `[stripe:webhook]`
+    (detail `event.type`) + **500 conservé** (le retry Stripe est le
+    comportement à ne pas régresser) ;
+  - catch de configuration (`route.ts:38-41`) : capture + 500 conservé ;
+  - branche `not_found` (`route.ts:77-82`) : capture (transaction fantôme =
+    vraie anomalie, cf. audit #81) + **200 conservé** ;
+  - catch de signature invalide (`route.ts:52-57`) : **pas de capture** (entrée
+    forgeable par n'importe qui → bruit) + 400 conservé.
+
+## Hors scope (YAGNI)
+
+- Pas de capture dans les DAL : elles throw → remontent aux pages → boundaries
+  (désormais instrumentés) ou `onRequestError`. En capturer créerait des
+  doublons. (Confirmé en revue : les rares catch silencieux des DAL —
+  `training/dal.ts:46`, `payments/dal.ts:187`, `quiz-token.ts:51` — sont des
+  parseurs d'entrée qui retournent `null` = validation métier, pas des erreurs
+  avalées.)
+- Pas de payload/PII dans les événements Sentry.
+- Aucun changement de config Sentry (`instrumentation*.ts`, filtres
+  `beforeSend` existants — le filtre `$RS` reste tel quel).
+- Pas de nouveau service de logging, pas de niveaux de log, pas de wrapper
+  d'action générique (les try/catch existants restent en place, seul le corps
+  du catch change).
+
+## Tests
+
+- **`getPgErrorCode`** (unit) : code au 1er niveau, code dans `cause` imbriquée
+  (2-3 niveaux), borne à 5 (pas de boucle infinie sur cycle), erreur sans code
+  → `undefined`, non-objet → `undefined`.
+- **`updateProfile` 23505** (unit, `tests/`) : `db.update` mocké qui throw une
+  erreur enveloppée `{ cause: { code: "23505" } }` → message « déjà pris » ;
+  erreur autre → « Erreur serveur » + `captureServerError` appelé.
+- **`captureServerError`** (unit) : mock `@sentry/nextjs` — en prod appelle
+  `captureException` avec tags/user ; en dev appelle `console.error` sans
+  Sentry.
+- **Boundaries** (unit léger) : rendu du composant avec une erreur → mock
+  Sentry appelé une fois.
+- **Non-régression bruit** : un test vérifie qu'une erreur métier mappée
+  ne déclenche PAS `captureServerError` (mock compté à 0) — couvert par le cas
+  23505 de `updateProfile`, plus les deux faux-fallbacks : `verifyStripeCheckout`
+  avec une erreur `resource_missing` (pas de capture) vs erreur inattendue
+  (capture), et `setAccountPassword` avec une `APIError` (pas de capture).
+- **Webhook** : le contrat HTTP complet du webhook (signature, 500→retry) reste
+  la cible de la campagne C3 ; ici on vérifie seulement que le catch de
+  traitement appelle `captureServerError` et répond toujours 500 (unit, Stripe
+  mocké).
+
+## Critères de succès
+
+1. Une exception inattendue dans n'importe quel catch fallback de
+   `features/*/actions.ts` produit un événement Sentry en prod (tag action +
+   userId) tout en gardant le message utilisateur neutre.
+2. Un crash de rendu sous `(dashboard)`/`(admin)`/racine produit un événement
+   Sentry.
+3. Une erreur métier mappée ne produit AUCUN événement Sentry.
+4. Le doublon de username sous course affiche « déjà pris ».
+5. `logDev` et les blocs inline `NODE_ENV` ont disparu (une seule
+   implémentation).
+6. Gates verts : `bun run check`, `bun run test`.

--- a/docs/superpowers/specs/2026-07-14-tests-ci-design.md
+++ b/docs/superpowers/specs/2026-07-14-tests-ci-design.md
@@ -1,0 +1,137 @@
+# Spec — Filet de tests & CI (campagne C3)
+
+- **Date** : 2026-07-14
+- **Statut** : IMPLÉMENTÉ le 2026-07-14 (branche `c3-tests-ci` sur
+  `c2-integrite-examens`) — revue adversariale design passée (#1/#2/#3 corrigés) ;
+  gates verts (check + 957 front + 279 intégration). ⚠️ Job CI `integration`
+  rouge tant que les secrets `NEON_API_KEY`/`NEON_PROJECT_ID` ne sont pas posés.
+- **Branche** : `c3-tests-ci` sur `c2-integrite-examens` (milestone commun
+  C1+C2+C3, revus ensemble).
+- **Origine** : audit du 2026-07-13 — agent tests (#1 intégration jamais en CI,
+  #2 `payments/actions.ts` zéro test, #3 contrat HTTP webhook, #4 course
+  fulfillment).
+
+## Problème
+
+Le cœur métier (fulfillment Stripe, verrous, crons, anti-triche) est bien testé
+en intégration — **mais ces tests ne tournent jamais en CI**. La CI
+(`.github/workflows/ci.yml`) n'exécute que `test:coverage` (projet `frontend`) ;
+`tests/integration/**` ne s'exécute que si quelqu'un lance `bun run
+test:integration` en local. Une régression dans `features/**` (9 300 lignes)
+merge avec une CI verte. Corollaires vérifiés à la source :
+
+- `features/payments/actions.ts` : **zéro test** des Server Actions. `payments-
+stripe.test.ts` teste `completeStripeTransaction`/`failStripeTransaction`
+  (lib `stripe.ts`) ; `payments-manual.test.ts` teste `grantManualAccess`/
+  `revokeAccessIfLast` (lib `lib.ts`). Les ACTIONS — `createStripeCheckout`
+  (création de la transaction _pending_ : si mal créée, le webhook répond
+  `not_found` → **l'utilisateur paie sans accès**), `verifyStripeCheckout`
+  (anti-IDOR), les 3 actions manuelles — ne sont pas couvertes (seul le catch
+  `resource_missing` de `verifyStripeCheckout` l'est, via C1).
+- Route webhook (`app/api/stripe/webhook/route.ts`) : C1 teste le catch de
+  traitement (→ 500). Le reste du contrat HTTP n'est pas testé : signature
+  absente/invalide → 400, `not_found` → 200, filtre `payment_status`, dispatch
+  `checkout.session.expired`.
+- Course de fulfillment : `payments-stripe.test.ts` teste l'idempotence en
+  **séquentiel** ; le verrou `FOR UPDATE` (garantie centrale contre le double
+  crédit) n'est jamais exercé en parallèle.
+
+## Design
+
+### 1. Job CI `integration` (le constat #1)
+
+L'infra existe : `scripts/test-integration.ts` provisionne une branche Neon
+jetable (`test-*` depuis `develop`), migre, lance vitest (projet `integration`),
+détruit la branche (housekeeping des orphelines > 1 h). `tests/helpers/test-env.ts`
+fournit l'env applicatif factice ; l'orchestrateur pose `DATABASE_URL`.
+
+Ajouter à `ci.yml` un **job séparé** `integration` (parallèle au job `quality`),
+sur `pull_request` et `push:main` (comme `quality`), qui : setup Bun → install →
+`bun run test:integration`. Le seul secret nécessaire côté job = **`NEON_API_KEY`
+
+- `NEON_PROJECT_ID`** (création/suppression de branche). Rien d'autre (migrate et
+  tests tirent l'URL de l'orchestrateur ; le reste de l'env vient de `test-env`).
+
+* **⚠️ Prérequis manuel (utilisateur, hors code)** : ajouter `NEON_API_KEY` et
+  `NEON_PROJECT_ID` dans les **secrets GitHub** du repo (Settings → Secrets and
+  variables → Actions). Sans eux, le job échoue. Documenté dans le plan.
+* **Concurrence** : le groupe `concurrency` existant (`workflow-ref`,
+  `cancel-in-progress`) annule les runs obsolètes ; deux PR parallèles créent
+  deux branches Neon distinctes (préfixe unique) — pas de collision. Le cleanup
+  des orphelines > 1 h couvre un run annulé en plein vol.
+
+### 2. `createStripeCheckout` — entrée du chemin d'argent (intégration)
+
+Test intégration (vraie DB, `getStripe` mocké) : vérifie que la transaction
+_pending_ est créée avec le bon `userId`, `status='pending'`, `type='stripe'`,
+`stripeSessionId` = la session Stripe, et que Stripe reçoit `metadata.userId`
+(l'invariant qui permet au webhook de la retrouver). ⚠️ **Assertions
+indépendantes du produit résolu** (revue #2) : `products.code` n'est pas unique
+et la branche `develop` (parent des branches de test) contient déjà un produit
+`exam_access` ; `createStripeCheckout` résout par `code` `ORDER BY id ASC LIMIT
+1` (`actions.ts:325-338`) → le `productId`/montant retenu est non déterministe.
+Ne PAS asserter `productId`/`amountPaid` en dur ; asserter les invariants
+robustes (pending, type, userId, stripeSessionId, metadata.userId). + garde
+produit invalide. Fichier : `tests/integration/payments-checkout.test.ts`.
+
+### 3. Contrat HTTP du webhook (unit, étend le fichier C1)
+
+Étendre `tests/features/stripe-webhook-errors.test.ts` : signature absente →
+**400**, signature invalide (`constructEventAsync` throw) → **400**, `not_found`
+→ **200** + `captureServerError`, filtre `payment_status` (`paid` +
+`no_payment_required` → `completeStripeTransaction` appelé ; autre → non appelé),
+dispatch `checkout.session.expired` → `failStripeTransaction`. Objectif : le
+contrat « 500 → retry, 200 → acquitté » ne peut plus régresser silencieusement
+(un 200 sur erreur transitoire = fulfillment perdu définitivement).
+
+### 4. Course de fulfillment (intégration, étend payments-stripe)
+
+⚠️ **Test discriminant** (revue #1) : deux fulfillments IDENTIQUES ne prouvent
+rien — l'unicité de la ligne `userAccess` vient de `onConflictDoUpdate` sur
+`(userId, accessType)` (`stripe.ts:182`) + la contrainte unique, PAS du verrou.
+Le verrou `FOR UPDATE` sur la ligne `user` (`stripe.ts:78`) protège le **cumul**
+d'expiration (non-combo : `txAccessExpiresAt = base + durée`, `base` = accès
+existant lu sous verrou, `:111-116`). Le bon test : **deux transactions
+DISTINCTES** (events/sessions différents), même user non-combo, 90 j chacune,
+`Promise.all` → l'expiration finale doit être `now + 180 j`. Sans le verrou, les
+deux lisent `base = now` → `now + 90` (perte d'une durée). L'assertion
+`approxDays(expiry, 180)` tombe à 90 si le verrou saute — idiome discriminant de
+`training-concurrency.test.ts`.
+
+- idempotence `stripeEventId` exercés en parallèle). Vérifier `userAccess`
+  crédité une seule fois.
+
+### 5. `verifyStripeCheckout` — anti-IDOR + happy path (complément C1)
+
+Étendre `tests/features/payments-actions-errors.test.ts` (déjà les mocks) :
+`metadata.userId ≠ session.user.id` → `{ success: false }` (anti-IDOR, sans
+capture) ; happy path (`metadata.userId === session`) → `{ success: true, … }`.
+
+## Hors scope (YAGNI / différé)
+
+- **Reset mot de passe** : parcours e2e reporté (capture d'email/token Better
+  Auth = campagne dédiée après le milestone).
+- `coverage.include` des `features/**/lib` purs : faible valeur, risque de tirer
+  des modules server-only non happy-dom → différé.
+- Nettoyage des `waitForTimeout` e2e : polish, hors filet.
+- Tests des 3 actions manuelles (`recordManualPayment`…) : leurs libs sont
+  testées ; les gardes/zod pourront être couverts plus tard — non bloquant pour
+  le chemin d'argent principal (checkout Stripe public).
+
+## Tests / gates
+
+- Nouveaux tests webhook + verifyStripeCheckout = **frontend** (rapides, mocks).
+- Nouveaux tests checkout + course = **intégration** (un run Neon au checkpoint).
+- `bun run check` + `bun run test` + `bun run test:integration` verts ; le
+  nouveau job CI vert **après** ajout des secrets (sinon rouge attendu, documenté).
+
+## Critères de succès
+
+1. Un job CI dédié exécute `tests/integration/**` sur chaque PR et push `main`.
+2. `createStripeCheckout` a un test qui prouve la création correcte de la
+   transaction _pending_ (couple pending↔webhook).
+3. Le contrat HTTP du webhook (400/200/500, filtre, dispatch) est verrouillé par
+   des tests.
+4. Le double crédit concurrent est prouvé impossible (verrou exercé en parallèle).
+5. `verifyStripeCheckout` : IDOR refusé, happy path couvert.
+6. Gates verts (le job CI intégration devient vert une fois les secrets posés).

--- a/features/exams/actions.ts
+++ b/features/exams/actions.ts
@@ -15,6 +15,7 @@ import {
 } from "@/db/schema"
 import { requireRole, requireSession } from "@/lib/auth-guards"
 import { createId } from "@/lib/ids"
+import { captureServerError } from "@/lib/observability"
 import { computeScorePercent } from "@/lib/score"
 import { hasAccess } from "../payments/dal"
 import { type SelectableUser, searchSelectableUsers } from "../users/dal"
@@ -41,10 +42,6 @@ import {
 } from "./schemas"
 
 const fail = (error: string) => ({ success: false as const, error })
-
-const logDev = (tag: string, error: unknown) => {
-  if (process.env.NODE_ENV !== "production") console.error(tag, error)
-}
 
 const resolvePause = (enablePause: boolean, minutes?: number) => {
   if (!enablePause) return null
@@ -174,7 +171,7 @@ export const createExam = async (
         return fail("Certains utilisateurs sélectionnés sont introuvables.")
       }
     }
-    logDev("[createExam]", error)
+    captureServerError("[createExam]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -318,7 +315,7 @@ export const updateExam = async (
         return fail("Certains utilisateurs sélectionnés sont introuvables.")
       }
     }
-    logDev("[updateExam]", error)
+    captureServerError("[updateExam]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -337,7 +334,7 @@ export const deleteExam = async ({
     revalidatePath("/admin/examens")
     return { success: true }
   } catch (error) {
-    logDev("[deleteExam]", error)
+    captureServerError("[deleteExam]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -357,7 +354,7 @@ export const deactivateExam = async ({
     revalidatePath(`/admin/examens/${examId}`)
     return { success: true }
   } catch (error) {
-    logDev("[deactivateExam]", error)
+    captureServerError("[deactivateExam]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -377,7 +374,7 @@ export const reactivateExam = async ({
     revalidatePath(`/admin/examens/${examId}`)
     return { success: true }
   } catch (error) {
-    logDev("[reactivateExam]", error)
+    captureServerError("[reactivateExam]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -406,7 +403,7 @@ export const deleteParticipation = async ({
     revalidatePath(`/admin/examens/${p.examId}`)
     return { success: true }
   } catch (error) {
-    logDev("[deleteParticipation]", error)
+    captureServerError("[deleteParticipation]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -572,7 +569,7 @@ export const startExam = async ({
         return fail("Votre accès aux examens a expiré.")
       }
     }
-    logDev("[startExam]", error)
+    captureServerError("[startExam]", error, { userId })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -668,7 +665,7 @@ export const saveExamAnswer = async (
 
     return { success: true } // never return isCorrect (anti-cheat)
   } catch (error) {
-    logDev("[saveExamAnswer]", error)
+    captureServerError("[saveExamAnswer]", error, { userId })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -712,7 +709,7 @@ export const saveExamFlag = async (
       return fail("Marquage non enregistré (session incohérente).")
     return { success: true }
   } catch (error) {
-    logDev("[saveExamFlag]", error)
+    captureServerError("[saveExamFlag]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -861,7 +858,7 @@ export const finalizeExam = async (
       const msg = map[error.message]
       if (msg) return fail(msg)
     }
-    logDev("[finalizeExam]", error)
+    captureServerError("[finalizeExam]", error, { userId })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -929,7 +926,7 @@ export const pauseExam = async ({
       }
     })
   } catch (error) {
-    logDev("[pauseExam]", error)
+    captureServerError("[pauseExam]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -989,7 +986,7 @@ export const resumeExam = async ({
       return { success: true as const, totalPauseDurationMs: total }
     })
   } catch (error) {
-    logDev("[resumeExam]", error)
+    captureServerError("[resumeExam]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }

--- a/features/exams/actions.ts
+++ b/features/exams/actions.ts
@@ -36,6 +36,7 @@ import {
   type UpdateExamInput,
   createExamSchema,
   finalizeExamSchema,
+  loadExamQuestionExplanationsSchema,
   saveExamAnswerSchema,
   saveExamFlagSchema,
   updateExamSchema,
@@ -57,7 +58,9 @@ export const loadExamQuestionExplanations = async (
   questionIds: string[],
 ): Promise<QuestionExplanationView[]> => {
   await requireSession()
-  return getExamQuestionExplanations(questionIds)
+  const parsed = loadExamQuestionExplanationsSchema.safeParse(questionIds)
+  if (!parsed.success) return []
+  return getExamQuestionExplanations(parsed.data)
 }
 
 /** [Admin] Recherche serveur d'utilisateurs sélectionnables (picker d'audience). */

--- a/features/exams/actions.ts
+++ b/features/exams/actions.ts
@@ -215,10 +215,15 @@ export const updateExam = async (
 
   try {
     await db.transaction(async (tx) => {
+      // Verrou de ligne examen : commun avec startExam → sérialise le
+      // remplacement du set de questions et le démarrage d'une participation
+      // (sinon le count ci-dessous peut lire 0 avant qu'un startExam concurrent
+      // ne commite sa participation).
       const [exam] = await tx
         .select({ id: exams.id })
         .from(exams)
         .where(eq(exams.id, id))
+        .for("update")
         .limit(1)
       if (!exam) throw new Error("NOT_FOUND")
 
@@ -447,6 +452,10 @@ export const startExam = async ({
         .where(eq(user.id, userId))
         .for("update")
 
+      // Verrou de ligne examen (après le verrou user, ordre déterministe) :
+      // commun avec updateExam → un remplacement du set de questions ne peut pas
+      // s'intercaler entre la création de la participation et la pré-création des
+      // examAnswers.
       const [exam] = await tx
         .select({
           startDate: exams.startDate,
@@ -455,6 +464,7 @@ export const startExam = async ({
         })
         .from(exams)
         .where(eq(exams.id, examId))
+        .for("update")
         .limit(1)
       if (!exam) throw new Error("NOT_FOUND")
 

--- a/features/exams/actions.ts
+++ b/features/exams/actions.ts
@@ -44,6 +44,10 @@ import {
 
 const fail = (error: string) => ({ success: false as const, error })
 
+// Grâce accordée au dernier envoi de réponse (latence réseau) au-delà du budget
+// de temps, distincte du +5 s de finalizeExam.
+const SAVE_GRACE_MS = 10_000
+
 const resolvePause = (enablePause: boolean, minutes?: number) => {
   if (!enablePause) return null
   return Math.min(minutes ?? DEFAULT_PAUSE_MINUTES, MAX_PAUSE_MINUTES)
@@ -601,6 +605,7 @@ export const saveExamAnswer = async (
         startDate: exams.startDate,
         endDate: exams.endDate,
         audienceType: exams.audienceType,
+        completionTime: exams.completionTime,
       })
       .from(exams)
       .where(eq(exams.id, examId))
@@ -620,25 +625,7 @@ export const saveExamAnswer = async (
     )
       return fail("Votre accès aux examens a expiré.")
 
-    const [p] = await db
-      .select({
-        id: examParticipations.id,
-        status: examParticipations.status,
-        pauseStartedAt: examParticipations.pauseStartedAt,
-      })
-      .from(examParticipations)
-      .where(
-        and(
-          eq(examParticipations.examId, examId),
-          eq(examParticipations.userId, userId),
-        ),
-      )
-      .limit(1)
-    if (!p) return fail("Participation introuvable.")
-    if (p.status !== "in_progress")
-      return fail("Cette session d'examen n'est plus active.")
-    if (p.pauseStartedAt) return fail("Réponse impossible pendant la pause.")
-
+    // Question immuable (appartenance + bonne réponse) : hors transaction.
     const [q] = await db
       .select({ correctAnswer: questions.correctAnswer })
       .from(examQuestions)
@@ -651,21 +638,64 @@ export const saveExamAnswer = async (
       )
       .limit(1)
     if (!q) return fail("Cette question ne fait pas partie de l'examen.")
-
     const isCorrect = q.correctAnswer === selectedAnswer
-    const updated = await db
-      .update(examAnswers)
-      .set({ selectedAnswer, isCorrect })
-      .where(
-        and(
-          eq(examAnswers.participationId, p.id),
-          eq(examAnswers.questionId, questionId),
-        ),
-      )
-      .returning({ id: examAnswers.id })
-    if (updated.length === 0)
-      return fail("Réponse non enregistrée (session incohérente).")
 
+    // Verrou participation englobant check-statut + budget + écriture : sérialise
+    // avec finalizeExam (qui verrouille la même ligne) → aucune écriture après le
+    // score. Budget-temps gardé À L'ÉCRITURE (anti-triche : finalize saute TIME_UP
+    // quand isAutoSubmit=true, flag client). Narrowing : valeur renvoyée DEPUIS le
+    // callback (AGENTS.md).
+    const outcome = await db.transaction(async (tx) => {
+      const [p] = await tx
+        .select({
+          id: examParticipations.id,
+          status: examParticipations.status,
+          startedAt: examParticipations.startedAt,
+          totalPauseDurationMs: examParticipations.totalPauseDurationMs,
+          pauseStartedAt: examParticipations.pauseStartedAt,
+        })
+        .from(examParticipations)
+        .where(
+          and(
+            eq(examParticipations.examId, examId),
+            eq(examParticipations.userId, userId),
+          ),
+        )
+        .for("update")
+        .limit(1)
+      if (!p) return { ok: false as const, msg: "Participation introuvable." }
+      if (p.status !== "in_progress")
+        return {
+          ok: false as const,
+          msg: "Cette session d'examen n'est plus active.",
+        }
+      if (p.pauseStartedAt)
+        return {
+          ok: false as const,
+          msg: "Réponse impossible pendant la pause.",
+        }
+
+      // Pause ACTIVE déjà exclue → pauseMs = cumul figé uniquement.
+      if (!isAdmin && p.startedAt) {
+        const pauseMs = p.totalPauseDurationMs ?? 0
+        const elapsed = now - p.startedAt.getTime() - pauseMs
+        if (elapsed > exam.completionTime * 1000 + SAVE_GRACE_MS)
+          return { ok: false as const, msg: "Temps écoulé." }
+      }
+
+      await tx
+        .update(examAnswers)
+        .set({ selectedAnswer, isCorrect })
+        .where(
+          and(
+            eq(examAnswers.participationId, p.id),
+            eq(examAnswers.questionId, questionId),
+          ),
+        )
+      return { ok: true as const }
+    })
+
+    if (!outcome.ok) return fail(outcome.msg)
     return { success: true } // never return isCorrect (anti-cheat)
   } catch (error) {
     captureServerError("[saveExamAnswer]", error, { userId })

--- a/features/exams/actions.ts
+++ b/features/exams/actions.ts
@@ -693,7 +693,7 @@ export const saveExamAnswer = async (
           return { ok: false as const, msg: "Temps écoulé." }
       }
 
-      await tx
+      const updated = await tx
         .update(examAnswers)
         .set({ selectedAnswer, isCorrect })
         .where(
@@ -702,6 +702,12 @@ export const saveExamAnswer = async (
             eq(examAnswers.questionId, questionId),
           ),
         )
+        .returning({ id: examAnswers.id })
+      if (updated.length === 0)
+        return {
+          ok: false as const,
+          msg: "Réponse non enregistrée (session incohérente).",
+        }
       return { ok: true as const }
     })
 

--- a/features/exams/dal.ts
+++ b/features/exams/dal.ts
@@ -323,6 +323,19 @@ export const getExamWithQuestions = async (
     }
   }
 
+  // Examen `subscribers` : l'abonnement actif EST l'autorisation (symétrique
+  // startExam/saveExamAnswer). Anti-fuite du texte des questions à un
+  // utilisateur sans entitlement. La fenêtre de dates est gardée par les
+  // appelants (page evaluation via participation in_progress ; page détail via
+  // isClosed) — pas ici, car le DAL sert aussi la revue après clôture.
+  if (
+    !isAdmin &&
+    exam.audienceType === "subscribers" &&
+    !(await hasAccess("exam"))
+  ) {
+    return null
+  }
+
   const items = await db
     .select({
       questionId: examQuestions.questionId,

--- a/features/exams/schemas.ts
+++ b/features/exams/schemas.ts
@@ -91,3 +91,8 @@ export const finalizeExamSchema = z.object({
   isAutoSubmit: z.boolean().optional(),
 })
 export type FinalizeExamInput = z.infer<typeof finalizeExamSchema>
+
+export const loadExamQuestionExplanationsSchema = z
+  .array(z.string())
+  .min(1)
+  .max(MAX_EXAM_QUESTIONS)

--- a/features/notifications/cron.ts
+++ b/features/notifications/cron.ts
@@ -4,6 +4,7 @@ import { db } from "@/db"
 import { examParticipations, exams, user, userAccess } from "@/db/schema"
 import { sendAccessExpiringEmail, sendExamResultsEmail } from "@/email"
 import { getBaseUrl } from "@/lib/base-url"
+import { captureServerError } from "@/lib/observability"
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const EXAM_RESULTS_LIMIT = 500
@@ -84,10 +85,9 @@ export async function sendExamResultsNotifications(): Promise<number> {
       // Best-effort : si l'envoi échoue, le marqueur reste posé (anti-double), pas
       // de réessai — les résultats restent visibles en app. Perte tolérée d'un
       // email (cf. spec §5 + Notes d'implémentation).
-      console.error(
-        `[notif] résultats — échec (participation ${r.participationId})`,
-        error,
-      )
+      captureServerError("[notif:resultats]", error, {
+        detail: `participation ${r.participationId}`,
+      })
     }
   }
   return sent
@@ -151,7 +151,9 @@ export async function sendAccessExpiryReminders(): Promise<number> {
       })
       sent++
     } catch (error) {
-      console.error(`[notif] accès — échec (accès ${r.accessId})`, error)
+      captureServerError("[notif:acces]", error, {
+        detail: `accès ${r.accessId}`,
+      })
     }
   }
   return sent

--- a/features/payments/actions.ts
+++ b/features/payments/actions.ts
@@ -7,6 +7,7 @@ import { products, transactions } from "@/db/schema"
 import { requireRole, requireSession } from "@/lib/auth-guards"
 import { getBaseUrl } from "@/lib/base-url"
 import { createId } from "@/lib/ids"
+import { captureServerError } from "@/lib/observability"
 import { getStripe } from "@/lib/stripe"
 import {
   type AccessImpact,
@@ -27,6 +28,12 @@ import {
   recordManualPaymentSchema,
   updateManualTransactionSchema,
 } from "./schemas"
+
+// Duck-check (évite d'importer les classes d'erreur Stripe pour un seul code).
+const isStripeResourceMissing = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { code?: unknown }).code === "resource_missing"
 
 /**
  * Charge la page suivante de l'historique des transactions de l'utilisateur
@@ -151,9 +158,9 @@ export const recordManualPayment = async (
     if (error instanceof Error && error.message === "USER_NOT_FOUND") {
       return { success: false, error: "Utilisateur introuvable" }
     }
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[recordManualPayment]", error)
-    }
+    captureServerError("[recordManualPayment]", error, {
+      userId: session.user.id,
+    })
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 }
@@ -222,9 +229,7 @@ export const updateManualTransaction = async (
         error: "Seules les transactions manuelles peuvent être modifiées",
       }
     }
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[updateManualTransaction]", error)
-    }
+    captureServerError("[updateManualTransaction]", error)
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 }
@@ -276,9 +281,7 @@ export const deleteManualTransaction = async (
         error: "Seules les transactions manuelles peuvent être supprimées",
       }
     }
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[deleteManualTransaction]", error)
-    }
+    captureServerError("[deleteManualTransaction]", error)
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 }
@@ -380,9 +383,7 @@ export const createStripeCheckout = async (input: {
 
     return { checkoutUrl: checkout.url }
   } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[createStripeCheckout]", error)
-    }
+    captureServerError("[createStripeCheckout]", error, { userId: session.user.id })
     return { error: "Erreur lors de la création du paiement. Réessayez." }
   }
 }
@@ -422,8 +423,12 @@ export const verifyStripeCheckout = async (
       customerEmail: checkout.customer_email,
     }
   } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[verifyStripeCheckout]", error)
+    // `resource_missing` = session_id d'URL invalide/périmé (contrôlable par
+    // l'utilisateur) : flux métier, pas une erreur inattendue.
+    if (!isStripeResourceMissing(error)) {
+      captureServerError("[verifyStripeCheckout]", error, {
+        userId: session.user.id,
+      })
     }
     return { success: false, error: "Session non trouvée ou invalide" }
   }
@@ -456,9 +461,7 @@ export const createCustomerPortal = async (
     })
     return { portalUrl: portal.url }
   } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[createCustomerPortal]", error)
-    }
+    captureServerError("[createCustomerPortal]", error, { userId: session.user.id })
     return {
       error: "Impossible d'ouvrir le portail de facturation. Réessayez.",
     }

--- a/features/payments/actions.ts
+++ b/features/payments/actions.ts
@@ -383,7 +383,9 @@ export const createStripeCheckout = async (input: {
 
     return { checkoutUrl: checkout.url }
   } catch (error) {
-    captureServerError("[createStripeCheckout]", error, { userId: session.user.id })
+    captureServerError("[createStripeCheckout]", error, {
+      userId: session.user.id,
+    })
     return { error: "Erreur lors de la création du paiement. Réessayez." }
   }
 }
@@ -461,7 +463,9 @@ export const createCustomerPortal = async (
     })
     return { portalUrl: portal.url }
   } catch (error) {
-    captureServerError("[createCustomerPortal]", error, { userId: session.user.id })
+    captureServerError("[createCustomerPortal]", error, {
+      userId: session.user.id,
+    })
     return {
       error: "Impossible d'ouvrir le portail de facturation. Réessayez.",
     }

--- a/features/questions/actions.ts
+++ b/features/questions/actions.ts
@@ -605,7 +605,9 @@ export const createQuestionImageUpload = async (input: {
     )
     return { success: true, url, fields, storagePath }
   } catch (error) {
-    captureServerError("[createQuestionImageUpload]", error, { userId: session.user.id })
+    captureServerError("[createQuestionImageUpload]", error, {
+      userId: session.user.id,
+    })
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 }

--- a/features/questions/actions.ts
+++ b/features/questions/actions.ts
@@ -7,7 +7,9 @@ import { questionExplanations, questionImages, questions } from "@/db/schema"
 import { getOpenExamQuestionIds } from "@/features/exams/dal"
 import { requireRole } from "@/lib/auth-guards"
 import { copyInS3, createPresignedUpload } from "@/lib/aws"
+import { getPgErrorCode } from "@/lib/db-errors"
 import { createId } from "@/lib/ids"
+import { captureServerError } from "@/lib/observability"
 import { consumeQuizRateLimit, getClientIpKey } from "@/lib/quiz-rate-limit"
 import {
   assertSafeStoragePath,
@@ -47,10 +49,6 @@ import {
 } from "./schemas"
 
 const fail = (error: string) => ({ success: false as const, error })
-
-const logDev = (tag: string, error: unknown) => {
-  if (process.env.NODE_ENV !== "production") console.error(tag, error)
-}
 
 /** [Admin] Charge une page de la liste filtrée (browser : filtres + « charger plus »). */
 export const loadQuestionsPage = async (
@@ -240,7 +238,7 @@ export const createQuestion = async (
     revalidatePath("/admin/questions")
     return { success: true, id }
   } catch (error) {
-    logDev("[createQuestion]", error)
+    captureServerError("[createQuestion]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -297,7 +295,7 @@ export const updateQuestion = async (
     if (error instanceof Error && error.message === "Q_NOT_FOUND") {
       return fail("Question introuvable")
     }
-    logDev("[updateQuestion]", error)
+    captureServerError("[updateQuestion]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -311,19 +309,8 @@ export const updateQuestion = async (
 const FK_VIOLATION_CODES = new Set(["23001", "23503"])
 
 const isForeignKeyViolation = (error: unknown): boolean => {
-  let cur: unknown = error
-  for (let i = 0; i < 5 && cur; i++) {
-    if (
-      typeof cur === "object" &&
-      "code" in cur &&
-      typeof (cur as { code?: unknown }).code === "string" &&
-      FK_VIOLATION_CODES.has((cur as { code: string }).code)
-    ) {
-      return true
-    }
-    cur = (cur as { cause?: unknown }).cause
-  }
-  return false
+  const code = getPgErrorCode(error)
+  return code !== undefined && FK_VIOLATION_CODES.has(code)
 }
 
 export type DeleteQuestionResult =
@@ -371,7 +358,7 @@ export const deleteQuestion = async (
       return fail("Question introuvable")
     }
     if (!isForeignKeyViolation(error)) {
-      logDev("[deleteQuestion]", error)
+      captureServerError("[deleteQuestion]", error)
       return fail("Erreur serveur. Réessayez.")
     }
   }
@@ -387,7 +374,7 @@ export const deleteQuestion = async (
     revalidatePath("/admin/questions")
     return { success: true, mode: "soft" }
   } catch (error) {
-    logDev("[deleteQuestion]", error)
+    captureServerError("[deleteQuestion]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -446,7 +433,7 @@ export const setQuestionImages = async (
       if (!p.finalPath.startsWith(finalPrefix)) throw new Error("BAD_PREFIX")
     }
   } catch (error) {
-    logDev("[setQuestionImages] validate", error)
+    captureServerError("[setQuestionImages] validate", error)
     return fail("Chemin d'image invalide")
   }
 
@@ -460,7 +447,7 @@ export const setQuestionImages = async (
       copiedFinalPaths.push(p.finalPath)
     }
   } catch (error) {
-    logDev("[setQuestionImages] copy", error)
+    captureServerError("[setQuestionImages] copy", error)
     await Promise.all(copiedFinalPaths.map((p) => tryDeleteFromStorage(p)))
     return fail("Erreur serveur. Réessayez.")
   }
@@ -527,7 +514,7 @@ export const setQuestionImages = async (
     if (error instanceof Error && error.message === "Q_NOT_FOUND") {
       return fail("Question introuvable")
     }
-    logDev("[setQuestionImages]", error)
+    captureServerError("[setQuestionImages]", error)
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -618,7 +605,7 @@ export const createQuestionImageUpload = async (input: {
     )
     return { success: true, url, fields, storagePath }
   } catch (error) {
-    logDev("[createQuestionImageUpload]", error)
+    captureServerError("[createQuestionImageUpload]", error, { userId: session.user.id })
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 }

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema"
 import { requireSession } from "@/lib/auth-guards"
 import { createId } from "@/lib/ids"
+import { captureServerError } from "@/lib/observability"
 import { computeScorePercent } from "@/lib/score"
 import { getOpenExamLockedQuestionIds } from "../exams/dal"
 import { hasAccess } from "../payments/dal"
@@ -32,10 +33,6 @@ const SESSION_EXPIRATION_MS = 24 * 60 * 60 * 1000 // 24 h
 const MAX_SESSIONS_PER_HOUR = 10
 
 const fail = (error: string) => ({ success: false as const, error })
-
-const logDev = (tag: string, error: unknown) => {
-  if (process.env.NODE_ENV !== "production") console.error(tag, error)
-}
 
 // ============================================
 // Lectures (wrappers pour composants clients)
@@ -212,7 +209,7 @@ export const createTrainingSession = async (
         )
       }
     }
-    logDev("[createTrainingSession]", error)
+    captureServerError("[createTrainingSession]", error, { userId })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -336,7 +333,7 @@ export const saveTrainingAnswer = async (
     // Mode test : ne pas exposer isCorrect sur le fil réseau (anti-triche).
     return { success: true }
   } catch (error) {
-    logDev("[saveTrainingAnswer]", error)
+    captureServerError("[saveTrainingAnswer]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -428,7 +425,7 @@ export const completeTrainingSession = async ({
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true, score, correctCount, totalQuestions }
   } catch (error) {
-    logDev("[completeTrainingSession]", error)
+    captureServerError("[completeTrainingSession]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -478,7 +475,7 @@ export const abandonTrainingSession = async ({
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true }
   } catch (error) {
-    logDev("[abandonTrainingSession]", error)
+    captureServerError("[abandonTrainingSession]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -516,7 +513,7 @@ export const deleteTrainingSession = async ({
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true }
   } catch (error) {
-    logDev("[deleteTrainingSession]", error)
+    captureServerError("[deleteTrainingSession]", error, { userId: session.user.id })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -543,7 +540,7 @@ export const deleteAllTrainingSessions = async (): Promise<{
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true, deletedCount: deleted.length }
   } catch (error) {
-    logDev("[deleteAllTrainingSessions]", error)
+    captureServerError("[deleteAllTrainingSessions]", error, { userId: session.user.id })
     return { success: false, deletedCount: 0, error: "Erreur serveur." }
   }
 }

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -333,7 +333,9 @@ export const saveTrainingAnswer = async (
     // Mode test : ne pas exposer isCorrect sur le fil réseau (anti-triche).
     return { success: true }
   } catch (error) {
-    captureServerError("[saveTrainingAnswer]", error, { userId: session.user.id })
+    captureServerError("[saveTrainingAnswer]", error, {
+      userId: session.user.id,
+    })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -425,7 +427,9 @@ export const completeTrainingSession = async ({
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true, score, correctCount, totalQuestions }
   } catch (error) {
-    captureServerError("[completeTrainingSession]", error, { userId: session.user.id })
+    captureServerError("[completeTrainingSession]", error, {
+      userId: session.user.id,
+    })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -475,7 +479,9 @@ export const abandonTrainingSession = async ({
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true }
   } catch (error) {
-    captureServerError("[abandonTrainingSession]", error, { userId: session.user.id })
+    captureServerError("[abandonTrainingSession]", error, {
+      userId: session.user.id,
+    })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -513,7 +519,9 @@ export const deleteTrainingSession = async ({
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true }
   } catch (error) {
-    captureServerError("[deleteTrainingSession]", error, { userId: session.user.id })
+    captureServerError("[deleteTrainingSession]", error, {
+      userId: session.user.id,
+    })
     return fail("Erreur serveur. Réessayez.")
   }
 }
@@ -540,7 +548,9 @@ export const deleteAllTrainingSessions = async (): Promise<{
     revalidatePath("/tableau-de-bord/entrainement")
     return { success: true, deletedCount: deleted.length }
   } catch (error) {
-    captureServerError("[deleteAllTrainingSessions]", error, { userId: session.user.id })
+    captureServerError("[deleteAllTrainingSessions]", error, {
+      userId: session.user.id,
+    })
     return { success: false, deletedCount: 0, error: "Erreur serveur." }
   }
 }

--- a/features/users/actions.ts
+++ b/features/users/actions.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { APIError } from "better-auth/api"
 import { and, eq, inArray, isNull, ne } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { headers } from "next/headers"
@@ -17,6 +18,8 @@ import { auth } from "@/lib/auth"
 import { requireRole, requireSession } from "@/lib/auth-guards"
 import { createPresignedUpload } from "@/lib/aws"
 import { avatarStoragePathFromImageValue, cdnUrl } from "@/lib/cdn"
+import { isPgUniqueViolation } from "@/lib/db-errors"
+import { captureServerError } from "@/lib/observability"
 import {
   generateAvatarPath,
   getExtensionFromMimeType,
@@ -155,17 +158,10 @@ export const updateProfile = async (input: {
       .set({ name, username, bio })
       .where(eq(user.id, session.user.id))
   } catch (error) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      (error as { code?: string }).code === "23505"
-    ) {
+    if (isPgUniqueViolation(error)) {
       return { success: false, error: "Ce nom d'utilisateur est déjà pris !" }
     }
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[updateProfile]", error)
-    }
+    captureServerError("[updateProfile]", error, { userId: session.user.id })
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 
@@ -226,9 +222,7 @@ export const createAvatarUpload = async (input: {
     )
     return { success: true, url, fields, storagePath }
   } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[createAvatarUpload]", error)
-    }
+    captureServerError("[createAvatarUpload]", error, { userId })
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
 }
@@ -265,9 +259,7 @@ export const confirmAvatarUpload = async (input: {
   try {
     await db.update(user).set({ image: newUrl }).where(eq(user.id, userId))
   } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[confirmAvatarUpload]", error)
-    }
+    captureServerError("[confirmAvatarUpload]", error, { userId })
     await tryDeleteFromStorage(input.storagePath)
     return { success: false, error: "Erreur serveur. Réessayez." }
   }
@@ -340,7 +332,7 @@ export const revokeOtherUserSessions =
 export const setAccountPassword = async (input: {
   newPassword: string
 }): Promise<AccountActionResult> => {
-  await requireSession()
+  const authSession = await requireSession()
 
   if (input.newPassword.length < 8 || input.newPassword.length > 128) {
     return {
@@ -354,7 +346,13 @@ export const setAccountPassword = async (input: {
       body: { newPassword: input.newPassword },
       headers: await headers(),
     })
-  } catch {
+  } catch (error) {
+    // Les APIError Better Auth sont du flux métier (ex. credential déjà posé).
+    if (!(error instanceof APIError)) {
+      captureServerError("[setAccountPassword]", error, {
+        userId: authSession.user.id,
+      })
+    }
     return { success: false, error: "Impossible de définir le mot de passe." }
   }
 

--- a/features/users/cron.ts
+++ b/features/users/cron.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { db } from "@/db"
 import { account, user } from "@/db/schema"
 import { DELETION_GRACE_MS } from "@/features/users/lib/account-deletion"
+import { captureServerError } from "@/lib/observability"
 
 export type AnonymizeResult = { anonymizedCount: number }
 
@@ -40,7 +41,7 @@ export async function anonymizeExpiredDeletedAccounts(): Promise<AnonymizeResult
       })
       anonymizedCount++
     } catch (error) {
-      console.error(`[anonymize] échec pour l'utilisateur ${id}`, error)
+      captureServerError("[cron:anonymize]", error, { detail: `user ${id}` })
     }
   }
 

--- a/lib/db-errors.ts
+++ b/lib/db-errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Drizzle enveloppe l'erreur pg (DrizzleQueryError → cause = DatabaseError),
+ * parfois sur plusieurs niveaux : on remonte la chaîne `cause` (bornée) jusqu'au
+ * premier `code` SQLSTATE. Source de vérité unique — ne pas retester `error.code`
+ * en surface dans les actions (branche morte, cf. bug updateProfile 23505).
+ */
+export const getPgErrorCode = (error: unknown): string | undefined => {
+  let cur: unknown = error
+  for (let i = 0; i < 5 && cur; i++) {
+    if (typeof cur === "object" && "code" in cur) {
+      const code = (cur as { code?: unknown }).code
+      if (typeof code === "string") return code
+    }
+    cur = (cur as { cause?: unknown }).cause
+  }
+  return undefined
+}
+
+export const isPgUniqueViolation = (error: unknown): boolean =>
+  getPgErrorCode(error) === "23505"

--- a/lib/observability.ts
+++ b/lib/observability.ts
@@ -1,0 +1,28 @@
+import * as Sentry from "@sentry/nextjs"
+import "server-only"
+
+/**
+ * Capture d'une exception INATTENDUE côté serveur (catch fallback générique
+ * des Server Actions, tâches cron, webhook). Les erreurs métier mappées
+ * (TIME_UP, ACCESS_EXPIRED, zod, 23505 username…) sont du flux de contrôle :
+ * elles ne passent JAMAIS ici — c'est ce qui garde le signal Sentry
+ * exploitable.
+ *
+ * `tag` doit rester statique (cardinalité des tags Sentry) ; les ids
+ * dynamiques vont dans `detail` (→ extra). Contexte léger uniquement : pas de
+ * payload (PII) dans les événements.
+ */
+export const captureServerError = (
+  tag: string,
+  error: unknown,
+  context?: { userId?: string; detail?: string },
+) => {
+  console.error(context?.detail ? `${tag} ${context.detail}` : tag, error)
+  if (process.env.NODE_ENV === "production") {
+    Sentry.captureException(error, {
+      tags: { action: tag },
+      user: context?.userId ? { id: context.userId } : undefined,
+      extra: context?.detail ? { detail: context.detail } : undefined,
+    })
+  }
+}

--- a/tests/components/error-boundaries.test.tsx
+++ b/tests/components/error-boundaries.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import AdminError from "@/app/(admin)/error"
+import DashboardError from "@/app/(dashboard)/error"
+import RootError from "@/app/error"
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
+vi.mock("@sentry/nextjs", () => ({ captureException }))
+
+afterEach(() => {
+  captureException.mockClear()
+})
+
+describe.each([
+  ["racine", RootError],
+  ["(dashboard)", DashboardError],
+  ["(admin)", AdminError],
+])("error boundary %s", (_name, Boundary) => {
+  it("remonte l'erreur à Sentry au montage", () => {
+    const error = Object.assign(new Error("crash rendu"), { digest: "d1" })
+    render(<Boundary error={error} reset={() => {}} />)
+    expect(captureException).toHaveBeenCalledWith(error)
+  })
+})

--- a/tests/features/exam-explanations-cap.test.ts
+++ b/tests/features/exam-explanations-cap.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import {
+  MAX_EXAM_QUESTIONS,
+  loadExamQuestionExplanationsSchema,
+} from "@/features/exams/schemas"
+
+describe("loadExamQuestionExplanationsSchema", () => {
+  it("accepte 1 à MAX_EXAM_QUESTIONS ids", () => {
+    expect(loadExamQuestionExplanationsSchema.safeParse(["a"]).success).toBe(
+      true,
+    )
+    expect(
+      loadExamQuestionExplanationsSchema.safeParse(
+        Array(MAX_EXAM_QUESTIONS).fill("a"),
+      ).success,
+    ).toBe(true)
+  })
+  it("refuse 0 id et > MAX_EXAM_QUESTIONS ids", () => {
+    expect(loadExamQuestionExplanationsSchema.safeParse([]).success).toBe(false)
+    expect(
+      loadExamQuestionExplanationsSchema.safeParse(
+        Array(MAX_EXAM_QUESTIONS + 1).fill("a"),
+      ).success,
+    ).toBe(false)
+  })
+})

--- a/tests/features/payments-actions-errors.test.ts
+++ b/tests/features/payments-actions-errors.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    retrieve: vi.fn<() => Promise<unknown>>(),
+  },
+}))
+
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/db", () => ({ db: {} }))
+vi.mock("@/db/schema", () => ({
+  products: {},
+  transactions: {},
+  productCode: { enumValues: ["exam_access"] },
+  currency: { enumValues: ["CAD", "XAF"] },
+}))
+vi.mock("@/features/payments/dal", () => ({
+  getAccessStatus: vi.fn(),
+  getAllTransactions: vi.fn(),
+  getMyTransactions: vi.fn(),
+  getTransactionAccessImpact: vi.fn(),
+  getTransactionStats: vi.fn(),
+}))
+vi.mock("@/features/payments/lib", () => ({
+  grantManualAccess: vi.fn(),
+  revokeAccessIfLast: vi.fn(),
+}))
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "user" } })),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/base-url", () => ({ getBaseUrl: () => "http://localhost:3000" }))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({ checkout: { sessions: { retrieve: mocks.retrieve } } }),
+}))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+import { verifyStripeCheckout } from "@/features/payments/actions"
+
+beforeEach(() => {
+  mocks.captureServerError.mockClear()
+})
+
+describe("verifyStripeCheckout — catch filtré resource_missing", () => {
+  it("session_id invalide (resource_missing) → message métier, PAS de capture", async () => {
+    mocks.retrieve.mockRejectedValueOnce(
+      Object.assign(new Error("No such checkout.session"), {
+        code: "resource_missing",
+      }),
+    )
+    const res = await verifyStripeCheckout("cs_bidon")
+    expect(res).toEqual({
+      success: false,
+      error: "Session non trouvée ou invalide",
+    })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("erreur Stripe inattendue → même message + capture", async () => {
+    const boom = new Error("Stripe API down")
+    mocks.retrieve.mockRejectedValueOnce(boom)
+    const res = await verifyStripeCheckout("cs_x")
+    expect(res).toEqual({
+      success: false,
+      error: "Session non trouvée ou invalide",
+    })
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[verifyStripeCheckout]",
+      boom,
+      { userId: "u1" },
+    )
+  })
+})

--- a/tests/features/payments-actions-errors.test.ts
+++ b/tests/features/payments-actions-errors.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { verifyStripeCheckout } from "@/features/payments/actions"
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -37,8 +38,6 @@ vi.mock("@/lib/stripe", () => ({
   getStripe: () => ({ checkout: { sessions: { retrieve: mocks.retrieve } } }),
 }))
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
-
-import { verifyStripeCheckout } from "@/features/payments/actions"
 
 beforeEach(() => {
   mocks.captureServerError.mockClear()

--- a/tests/features/payments-actions-errors.test.ts
+++ b/tests/features/payments-actions-errors.test.ts
@@ -73,3 +73,33 @@ describe("verifyStripeCheckout — catch filtré resource_missing", () => {
     )
   })
 })
+
+describe("verifyStripeCheckout — anti-IDOR + happy path", () => {
+  it("metadata.userId ≠ session → refus (anti-IDOR), pas de capture", async () => {
+    mocks.retrieve.mockResolvedValueOnce({
+      metadata: { userId: "someone_else" },
+      payment_status: "paid",
+      amount_total: 5000,
+      currency: "cad",
+      customer_email: "x@test.invalid",
+    })
+    const res = await verifyStripeCheckout("cs_ok")
+    expect(res).toEqual({
+      success: false,
+      error: "Session non trouvée ou invalide",
+    })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("metadata.userId == session → succès", async () => {
+    mocks.retrieve.mockResolvedValueOnce({
+      metadata: { userId: "u1" },
+      payment_status: "paid",
+      amount_total: 5000,
+      currency: "cad",
+      customer_email: "x@test.invalid",
+    })
+    const res = await verifyStripeCheckout("cs_ok")
+    expect(res).toMatchObject({ success: true, status: "paid" })
+  })
+})

--- a/tests/features/stripe-webhook-errors.test.ts
+++ b/tests/features/stripe-webhook-errors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    completeStripeTransaction: vi.fn<() => Promise<unknown>>(),
+    constructEventAsync: vi.fn<() => Promise<unknown>>(),
+  },
+}))
+
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/features/payments/stripe", () => ({
+  completeStripeTransaction: mocks.completeStripeTransaction,
+  failStripeTransaction: vi.fn(),
+}))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    webhooks: { constructEventAsync: mocks.constructEventAsync },
+  }),
+  getStripeWebhookSecret: () => "whsec_test",
+}))
+
+import { POST } from "@/app/api/stripe/webhook/route"
+
+const request = () =>
+  new Request("http://localhost/api/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": "sig" },
+    body: "{}",
+  })
+
+describe("webhook Stripe — catch de traitement", () => {
+  it("échec de fulfillment → captureServerError + 500 (retry Stripe conservé)", async () => {
+    const boom = new Error("Neon down")
+    mocks.constructEventAsync.mockResolvedValueOnce({
+      id: "evt_1",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_1",
+          payment_status: "paid",
+          payment_intent: "pi_1",
+          amount_total: 100,
+          currency: "cad",
+        },
+      },
+    })
+    mocks.completeStripeTransaction.mockRejectedValueOnce(boom)
+
+    const res = await POST(request())
+    expect(res.status).toBe(500)
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[stripe:webhook]",
+      boom,
+      { detail: "checkout.session.completed" },
+    )
+  })
+})

--- a/tests/features/stripe-webhook-errors.test.ts
+++ b/tests/features/stripe-webhook-errors.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { POST } from "@/app/api/stripe/webhook/route"
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     captureServerError: vi.fn(),
     completeStripeTransaction: vi.fn<() => Promise<unknown>>(),
+    fail: vi.fn(),
     constructEventAsync: vi.fn<() => Promise<unknown>>(),
   },
 }))
@@ -14,7 +15,7 @@ vi.mock("@/lib/observability", () => ({
 }))
 vi.mock("@/features/payments/stripe", () => ({
   completeStripeTransaction: mocks.completeStripeTransaction,
-  failStripeTransaction: vi.fn(),
+  failStripeTransaction: mocks.fail,
 }))
 vi.mock("@/lib/stripe", () => ({
   getStripe: () => ({
@@ -30,7 +31,13 @@ const request = () =>
     body: "{}",
   })
 
-describe("webhook Stripe — catch de traitement", () => {
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Défaut happy path pour les tests qui ne posent pas leur propre valeur.
+  mocks.completeStripeTransaction.mockResolvedValue({ status: "completed" })
+})
+
+describe("webhook Stripe — contrat HTTP", () => {
   it("échec de fulfillment → captureServerError + 500 (retry Stripe conservé)", async () => {
     const boom = new Error("Neon down")
     mocks.constructEventAsync.mockResolvedValueOnce({
@@ -55,5 +62,67 @@ describe("webhook Stripe — catch de traitement", () => {
       boom,
       { detail: "checkout.session.completed" },
     )
+  })
+
+  it("signature absente → 400 (jamais rejoué)", async () => {
+    const req = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: "{}",
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("signature invalide → 400", async () => {
+    mocks.constructEventAsync.mockRejectedValueOnce(new Error("bad sig"))
+    const res = await POST(request())
+    expect(res.status).toBe(400)
+  })
+
+  it("payment_status non fulfillable → pas de fulfillment, 200", async () => {
+    mocks.constructEventAsync.mockResolvedValueOnce({
+      id: "evt_unpaid",
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_unpaid", payment_status: "unpaid" } },
+    })
+    const res = await POST(request())
+    expect(res.status).toBe(200)
+    expect(mocks.completeStripeTransaction).not.toHaveBeenCalled()
+  })
+
+  it("transaction fantôme (not_found) → capture + 200", async () => {
+    mocks.constructEventAsync.mockResolvedValueOnce({
+      id: "evt_ghost",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_ghost",
+          payment_status: "paid",
+          payment_intent: "pi_1",
+          amount_total: 5000,
+          currency: "cad",
+        },
+      },
+    })
+    mocks.completeStripeTransaction.mockResolvedValueOnce({
+      status: "not_found",
+    })
+    const res = await POST(request())
+    expect(res.status).toBe(200)
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  it("checkout.session.expired → failStripeTransaction, 200", async () => {
+    mocks.constructEventAsync.mockResolvedValueOnce({
+      id: "evt_exp",
+      type: "checkout.session.expired",
+      data: { object: { id: "cs_exp" } },
+    })
+    const res = await POST(request())
+    expect(res.status).toBe(200)
+    expect(mocks.fail).toHaveBeenCalledWith({
+      stripeSessionId: "cs_exp",
+      stripeEventId: "evt_exp",
+    })
   })
 })

--- a/tests/features/stripe-webhook-errors.test.ts
+++ b/tests/features/stripe-webhook-errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { POST } from "@/app/api/stripe/webhook/route"
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -21,8 +22,6 @@ vi.mock("@/lib/stripe", () => ({
   }),
   getStripeWebhookSecret: () => "whsec_test",
 }))
-
-import { POST } from "@/app/api/stripe/webhook/route"
 
 const request = () =>
   new Request("http://localhost/api/stripe/webhook", {

--- a/tests/features/users-actions-errors.test.ts
+++ b/tests/features/users-actions-errors.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    limitFn: vi.fn<() => Promise<unknown[]>>(async () => []),
+    updateWhere: vi.fn<() => Promise<unknown>>(async () => undefined),
+    setPassword: vi.fn<() => Promise<unknown>>(async () => undefined),
+  },
+}))
+
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: mocks.limitFn }) }),
+    }),
+    update: () => ({ set: () => ({ where: mocks.updateWhere }) }),
+  },
+}))
+vi.mock("@/db/schema", () => ({ user: {}, session: {} }))
+vi.mock("@/features/users/dal", () => ({}))
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { setPassword: mocks.setPassword } },
+}))
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "user" } })),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/aws", () => ({ createPresignedUpload: vi.fn() }))
+vi.mock("@/lib/cdn", () => ({
+  cdnUrl: (p: string) => p,
+  avatarStoragePathFromImageValue: () => null,
+}))
+vi.mock("@/lib/storage", () => ({
+  generateAvatarPath: vi.fn(),
+  getExtensionFromMimeType: vi.fn(),
+  isStorageConfigured: () => false,
+  tryDeleteFromStorage: vi.fn(),
+  validateImageFile: vi.fn(),
+}))
+vi.mock("@/lib/upload-rate-limit", () => ({ consumeUploadRateLimit: vi.fn() }))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("next/headers", () => ({ headers: vi.fn() }))
+
+import { setAccountPassword, updateProfile } from "@/features/users/actions"
+
+const VALID = { name: "Sam", username: "sam_p", bio: "" }
+
+beforeEach(() => {
+  mocks.captureServerError.mockClear()
+  mocks.limitFn.mockResolvedValue([])
+})
+
+describe("updateProfile — catch fallback", () => {
+  it("23505 enveloppé (course post pré-check) → « déjà pris », PAS de capture Sentry", async () => {
+    mocks.updateWhere.mockRejectedValueOnce(
+      Object.assign(new Error("query failed"), { cause: { code: "23505" } }),
+    )
+    const res = await updateProfile(VALID)
+    expect(res).toEqual({
+      success: false,
+      error: "Ce nom d'utilisateur est déjà pris !",
+    })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("erreur inattendue → message neutre + captureServerError(tag, err, userId)", async () => {
+    const boom = new Error("connexion perdue")
+    mocks.updateWhere.mockRejectedValueOnce(boom)
+    const res = await updateProfile(VALID)
+    expect(res).toEqual({ success: false, error: "Erreur serveur. Réessayez." })
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[updateProfile]",
+      boom,
+      { userId: "u1" },
+    )
+  })
+})
+
+describe("setAccountPassword — catch filtré APIError", () => {
+  it("APIError Better Auth (métier) → message, PAS de capture", async () => {
+    const { APIError } = await import("better-auth/api")
+    mocks.setPassword.mockRejectedValueOnce(
+      new APIError("BAD_REQUEST", { message: "password already set" }),
+    )
+    const res = await setAccountPassword({ newPassword: "motdepasse123" })
+    expect(res).toEqual({
+      success: false,
+      error: "Impossible de définir le mot de passe.",
+    })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("erreur inattendue → même message + capture", async () => {
+    const boom = new Error("Better Auth down")
+    mocks.setPassword.mockRejectedValueOnce(boom)
+    const res = await setAccountPassword({ newPassword: "motdepasse123" })
+    expect(res).toEqual({
+      success: false,
+      error: "Impossible de définir le mot de passe.",
+    })
+    expect(mocks.captureServerError).toHaveBeenCalledWith(
+      "[setAccountPassword]",
+      boom,
+      { userId: "u1" },
+    )
+  })
+})

--- a/tests/features/users-actions-errors.test.ts
+++ b/tests/features/users-actions-errors.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { setAccountPassword, updateProfile } from "@/features/users/actions"
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -44,8 +45,6 @@ vi.mock("@/lib/storage", () => ({
 vi.mock("@/lib/upload-rate-limit", () => ({ consumeUploadRateLimit: vi.fn() }))
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
 vi.mock("next/headers", () => ({ headers: vi.fn() }))
-
-import { setAccountPassword, updateProfile } from "@/features/users/actions"
 
 const VALID = { name: "Sam", username: "sam_p", bio: "" }
 

--- a/tests/integration/exam-audience.test.ts
+++ b/tests/integration/exam-audience.test.ts
@@ -463,6 +463,17 @@ describe("getExamWithQuestions — anti-fuite du texte des questions restreintes
     expect(view?.questions).toHaveLength(qIds.length)
   })
 
+  it("subscribers → null pour un utilisateur SANS accès exam actif (C2)", async () => {
+    const examId = await makeSubscribersExam()
+
+    asNoSub() // aucun abonnement
+    expect(await getExamWithQuestions(examId)).toBeNull()
+
+    asSubscriber() // abonné avec accès actif
+    const view = await getExamWithQuestions(examId)
+    expect(view?.questions).toHaveLength(qIds.length)
+  })
+
   it("restreint → questions pour un membre RETIRÉ de l'audience mais avec participation in_progress (#6)", async () => {
     const examId = await makeRestrictedExam([MEMBER_ID])
 

--- a/tests/integration/exam-runner.test.ts
+++ b/tests/integration/exam-runner.test.ts
@@ -311,3 +311,93 @@ describe("pauseExam / resumeExam", () => {
     expect(res.error).toContain("pause")
   })
 })
+
+describe("saveExamAnswer — budget-temps + anti-race (C2)", () => {
+  // completionTime = 4 questions × 83 s = 332 s ; budget dépassé au-delà de
+  // 332 s + SAVE_GRACE (10 s). Chaque test crée son examen + participation avec
+  // un startedAt reculé.
+  const makeStartedExam = async (backdateMs: number): Promise<string> => {
+    asAdmin()
+    const t = Date.now()
+    const r = await createExam({
+      title: `ER Budget ${suffix} ${createId().slice(0, 4)}`,
+      startDate: t - 3600_000,
+      endDate: t + 3600_000,
+      questionIds: qIds,
+      enablePause: false,
+    })
+    if (!r.success) throw new Error(r.error)
+    const eId = r.examId
+    asStudent()
+    const s = await startExam({ examId: eId })
+    if (!s.success) throw new Error(s.error)
+    await db
+      .update(examParticipations)
+      .set({ startedAt: new Date(Date.now() - backdateMs) })
+      .where(
+        and(
+          eq(examParticipations.examId, eId),
+          eq(examParticipations.userId, STUDENT_ID),
+        ),
+      )
+    return eId
+  }
+
+  it("refuse une réponse au-delà du budget-temps (TIME_UP) et ne la persiste pas", async () => {
+    const eId = await makeStartedExam(400_000)
+    asStudent()
+    const res = await saveExamAnswer({
+      examId: eId,
+      questionId: qIds[0],
+      selectedAnswer: "A",
+    })
+    expect(res).toEqual({ success: false, error: "Temps écoulé." })
+
+    const [row] = await db
+      .select({ selectedAnswer: examAnswers.selectedAnswer })
+      .from(examAnswers)
+      .innerJoin(
+        examParticipations,
+        eq(examParticipations.id, examAnswers.participationId),
+      )
+      .where(
+        and(
+          eq(examParticipations.examId, eId),
+          eq(examAnswers.questionId, qIds[0]),
+        ),
+      )
+    expect(row?.selectedAnswer).toBeNull()
+  })
+
+  it("attaque #2 bout-en-bout : réponse hors-temps refusée puis finalize isAutoSubmit tardif → score ne l'inclut pas", async () => {
+    const eId = await makeStartedExam(400_000)
+    asStudent()
+    const save = await saveExamAnswer({
+      examId: eId,
+      questionId: qIds[0],
+      selectedAnswer: "A", // bonne réponse (correctAnswer = "A")
+    })
+    expect(save.success).toBe(false) // TIME_UP
+
+    const fin = await finalizeExam({ examId: eId, isAutoSubmit: true })
+    expect(fin.success).toBe(true)
+    if (fin.success) expect(fin.correctAnswers).toBe(0)
+  })
+
+  it("race déterministe : finalize PUIS save → save refusé (session plus active)", async () => {
+    const eId = await makeStartedExam(1_000) // dans les temps
+    asStudent()
+    const fin = await finalizeExam({ examId: eId, isAutoSubmit: false })
+    expect(fin.success).toBe(true)
+
+    const save = await saveExamAnswer({
+      examId: eId,
+      questionId: qIds[0],
+      selectedAnswer: "A",
+    })
+    expect(save).toEqual({
+      success: false,
+      error: "Cette session d'examen n'est plus active.",
+    })
+  })
+})

--- a/tests/integration/exams.test.ts
+++ b/tests/integration/exams.test.ts
@@ -4,6 +4,7 @@ import { db } from "@/db"
 import {
   examAnswers,
   examParticipations,
+  examQuestions,
   exams,
   products,
   questionExplanations,
@@ -219,6 +220,51 @@ describe("Admin CRUD", () => {
     expect(view?.exam.title).toBe(`Updated ${suffix}`)
     expect(view?.questions).toHaveLength(6)
     expect(view?.exam.completionTime).toBe(6 * 83)
+  })
+
+  it("updateExam et startExam concurrents : participation cohérente avec le set servi (verrou commun)", async () => {
+    const id = await makeExam({ questionIds: examQIds.slice(0, 4) })
+    const newSet = examQIds // set différent (6 questions)
+
+    const now = Date.now()
+    const [, start] = await Promise.all([
+      (async () => {
+        asAdmin()
+        return updateExam({
+          id,
+          title: `Race ${suffix}`,
+          startDate: now - 1000,
+          endDate: now + DAY,
+          questionIds: newSet,
+          enablePause: false,
+        })
+      })(),
+      (async () => {
+        asStudent()
+        return startExam({ examId: id })
+      })(),
+    ])
+
+    // Invariant : si une participation a été créée, ses examAnswers correspondent
+    // EXACTEMENT au set de questions effectivement stocké (pas de mélange
+    // ancien/nouveau). Le verrou commun sur la ligne examen sérialise les deux.
+    if (start.success) {
+      const stored = await db
+        .select({ questionId: examQuestions.questionId })
+        .from(examQuestions)
+        .where(eq(examQuestions.examId, id))
+      const answers = await db
+        .select({ questionId: examAnswers.questionId })
+        .from(examAnswers)
+        .innerJoin(
+          examParticipations,
+          eq(examParticipations.id, examAnswers.participationId),
+        )
+        .where(eq(examParticipations.examId, id))
+      const storedSet = new Set(stored.map((r) => r.questionId))
+      const answerSet = new Set(answers.map((r) => r.questionId))
+      expect(answerSet).toEqual(storedSet)
+    }
   })
 
   it("deactivate puis reactivate bascule isActive", async () => {

--- a/tests/integration/payments-checkout.test.ts
+++ b/tests/integration/payments-checkout.test.ts
@@ -98,11 +98,13 @@ describe("createStripeCheckout", () => {
   })
 
   it("refuse un productCode inconnu (pas d'appel Stripe)", async () => {
+    mocks.create.mockClear()
     const res = await createStripeCheckout({
       productCode: "does_not_exist",
       successPath: "/tableau-de-bord",
       cancelPath: "/tarifs",
     })
     expect(res).toEqual({ error: "Produit invalide" })
+    expect(mocks.create).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/payments-checkout.test.ts
+++ b/tests/integration/payments-checkout.test.ts
@@ -1,0 +1,108 @@
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { products, transactions, user } from "@/db/schema"
+import { createStripeCheckout } from "@/features/payments/actions"
+import { createId } from "@/lib/ids"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    sessionUserId: { current: "" },
+    create:
+      vi.fn<
+        (arg: {
+          metadata: { userId: string }
+        }) => Promise<{ id: string; url: string | null }>
+      >(),
+  },
+}))
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+vi.mock("@/lib/auth-guards", () => ({
+  requireSession: vi.fn(async () => ({
+    user: { id: mocks.sessionUserId.current, email: "chk@test.invalid" },
+  })),
+  requireRole: vi.fn(),
+}))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({ checkout: { sessions: { create: mocks.create } } }),
+}))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const PID = createId()
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: `Chk ${suffix}`,
+    email: `chk-${suffix}@test.invalid`,
+  })
+  await db.insert(products).values({
+    id: PID,
+    code: "exam_access",
+    name: `Exam ${suffix}`,
+    description: "desc",
+    priceCad: 5000,
+    durationDays: 90,
+    accessType: "exam",
+    isCombo: false,
+    stripeProductId: `prod_${suffix}`,
+    stripePriceId: `price_${suffix}`,
+  })
+  mocks.sessionUserId.current = USER_ID
+})
+
+afterAll(async () => {
+  await db.delete(transactions).where(eq(transactions.userId, USER_ID))
+  await db.delete(products).where(eq(products.id, PID))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("createStripeCheckout", () => {
+  it("crée une transaction pending liée à la session Stripe + metadata.userId", async () => {
+    const sessionId = `cs_${suffix}`
+    mocks.create.mockResolvedValueOnce({
+      id: sessionId,
+      url: "https://stripe.test/checkout",
+    })
+
+    const res = await createStripeCheckout({
+      productCode: "exam_access",
+      successPath: "/tableau-de-bord",
+      cancelPath: "/tarifs",
+    })
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/checkout" })
+
+    // metadata.userId transmis à Stripe (invariant anti-IDOR côté verify +
+    // fulfillment). PAS d'assertion sur metadata.productId : products.code n'est
+    // pas unique et develop contient déjà un exam_access → le produit résolu
+    // (ORDER BY id ASC) est non déterministe.
+    const arg = mocks.create.mock.calls[0]![0]
+    expect(arg.metadata.userId).toBe(USER_ID)
+
+    // Transaction pending retrouvable par le webhook via stripeSessionId
+    // (invariants robustes, indépendants du produit résolu).
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.stripeSessionId, sessionId))
+    expect(tx.status).toBe("pending")
+    expect(tx.type).toBe("stripe")
+    expect(tx.userId).toBe(USER_ID)
+    expect(tx.stripeSessionId).toBe(sessionId)
+  })
+
+  it("refuse un productCode inconnu (pas d'appel Stripe)", async () => {
+    const res = await createStripeCheckout({
+      productCode: "does_not_exist",
+      successPath: "/tableau-de-bord",
+      cancelPath: "/tarifs",
+    })
+    expect(res).toEqual({ error: "Produit invalide" })
+  })
+})

--- a/tests/integration/payments-stripe.test.ts
+++ b/tests/integration/payments-stripe.test.ts
@@ -28,7 +28,7 @@ const suffix = createId().slice(0, 8)
 
 const PEXAM = createId() // produit exam non-combo
 const PCOMBO = createId() // produit combo (exam + training)
-const U = Array.from({ length: 10 }, () => createId())
+const U = Array.from({ length: 11 }, () => createId())
 const [
   U_HAPPY,
   U_CUMUL,
@@ -40,6 +40,7 @@ const [
   U_DEGNULL,
   U_DEGUSD,
   U_PROMO100,
+  U_RACE,
 ] = U
 
 const accessOf = (userId: string, accessType: "exam" | "training") =>
@@ -278,6 +279,52 @@ describe("completeStripeTransaction", () => {
       stripeEventId: `evt_ghost_${suffix}`,
     })
     expect(res).toEqual({ status: "not_found" })
+  })
+
+  it("deux fulfillments concurrents (2 tx distinctes, même user non-combo) → accès CUMULÉ 180j (verrou FOR UPDATE)", async () => {
+    const sidA = `sess_raceA_${suffix}`
+    const sidB = `sess_raceB_${suffix}`
+    await seedPending({
+      id: createId(),
+      userId: U_RACE,
+      productId: PEXAM,
+      sessionId: sidA,
+      accessType: "exam",
+      durationDays: 90,
+    })
+    await seedPending({
+      id: createId(),
+      userId: U_RACE,
+      productId: PEXAM,
+      sessionId: sidB,
+      accessType: "exam",
+      durationDays: 90,
+    })
+
+    await Promise.all([
+      completeStripeTransaction({
+        stripeSessionId: sidA,
+        stripePaymentIntentId: `pi_a_${suffix}`,
+        stripeEventId: `evt_a_${suffix}`,
+        amountTotal: 5000,
+        currency: "cad",
+      }),
+      completeStripeTransaction({
+        stripeSessionId: sidB,
+        stripePaymentIntentId: `pi_b_${suffix}`,
+        stripeEventId: `evt_b_${suffix}`,
+        amountTotal: 5000,
+        currency: "cad",
+      }),
+    ])
+
+    const rows = await db
+      .select()
+      .from(userAccess)
+      .where(eq(userAccess.userId, U_RACE))
+    expect(rows).toHaveLength(1)
+    // Cumul des deux durées (90 + 90). Tombe à ~90 si le verrou FOR UPDATE saute.
+    expect(approxDays(rows[0].expiresAt, 180)).toBe(true)
   })
 })
 

--- a/tests/lib/db-errors.test.ts
+++ b/tests/lib/db-errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { getPgErrorCode, isPgUniqueViolation } from "@/lib/db-errors"
+
+describe("getPgErrorCode", () => {
+  it("lit le code au premier niveau", () => {
+    expect(getPgErrorCode({ code: "23505" })).toBe("23505")
+  })
+
+  it("remonte la chaîne cause (forme DrizzleQueryError → DatabaseError pg)", () => {
+    const err = Object.assign(new Error("query failed"), {
+      cause: Object.assign(new Error("db"), { cause: { code: "23001" } }),
+    })
+    expect(getPgErrorCode(err)).toBe("23001")
+  })
+
+  it("renvoie undefined sans code dans la chaîne", () => {
+    expect(getPgErrorCode(new Error("boom"))).toBeUndefined()
+    expect(getPgErrorCode(null)).toBeUndefined()
+    expect(getPgErrorCode("string")).toBeUndefined()
+  })
+
+  it("ignore un code non-string", () => {
+    expect(getPgErrorCode({ code: 23505 })).toBeUndefined()
+  })
+
+  it("borne le parcours à 5 niveaux (pas de boucle infinie sur cycle)", () => {
+    const cyclic: { cause?: unknown } = {}
+    cyclic.cause = cyclic
+    expect(getPgErrorCode(cyclic)).toBeUndefined()
+
+    let deep: unknown = { code: "23505" }
+    for (let i = 0; i < 6; i++) deep = { cause: deep }
+    expect(getPgErrorCode(deep)).toBeUndefined()
+  })
+})
+
+describe("isPgUniqueViolation", () => {
+  it("détecte 23505 enveloppé", () => {
+    expect(isPgUniqueViolation({ cause: { code: "23505" } })).toBe(true)
+    expect(isPgUniqueViolation({ cause: { code: "23503" } })).toBe(false)
+  })
+})

--- a/tests/lib/observability.test.ts
+++ b/tests/lib/observability.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { captureServerError } from "@/lib/observability"
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
+vi.mock("@sentry/nextjs", () => ({ captureException }))
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  captureException.mockClear()
+})
+
+describe("captureServerError", () => {
+  it("hors prod : console.error, pas de Sentry", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    captureServerError("[test]", new Error("boom"))
+    expect(spy).toHaveBeenCalledOnce()
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it("en prod : console.error + Sentry avec tag action et userId", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const err = new Error("boom")
+    captureServerError("[finalizeExam]", err, { userId: "u1" })
+    expect(spy).toHaveBeenCalledOnce()
+    expect(captureException).toHaveBeenCalledWith(err, {
+      tags: { action: "[finalizeExam]" },
+      user: { id: "u1" },
+      extra: undefined,
+    })
+  })
+
+  it("en prod sans userId : pas d'objet user, detail dans extra", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    const err = new Error("boom")
+    captureServerError("[cron]", err, { detail: "participation p1" })
+    expect(captureException).toHaveBeenCalledWith(err, {
+      tags: { action: "[cron]" },
+      user: undefined,
+      extra: { detail: "participation p1" },
+    })
+  })
+
+  it("inclut detail dans la ligne console", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const err = new Error("boom")
+    captureServerError("[notif:resultats]", err, { detail: "participation p1" })
+    expect(spy).toHaveBeenCalledWith("[notif:resultats] participation p1", err)
+  })
+})


### PR DESCRIPTION
Milestone issu de l'audit complet du repo (2026-07-13) — socle sécurité / observabilité / tests. Les 3 campagnes ont été conçues, revues (design **et** implémentation, en sessions adversariales dédiées) et implémentées ensemble.

## C1 — Observabilité & erreurs
- `lib/observability.ts` (`captureServerError` : `server-only`, Sentry prod-only, tag statique + `userId`, **zéro PII**) + `lib/db-errors.ts` (`getPgErrorCode`/`isPgUniqueViolation` — corrige un bug 23505 masqué de `updateProfile`, Drizzle enveloppant l'erreur pg dans `cause`).
- Remplace 26 `logDev` + 9 blocs `NODE_ENV`. Filtres métier : `resource_missing` (Stripe), `APIError` (Better Auth) — pas de bruit sur erreur attendue.
- Boundaries → Sentry ; crons taggés par tâche + anonymisation RGPD.
- **Webhook Stripe capturé explicitement** : `onRequestError` ne voit pas une erreur catchée puis répondue en 500 (réponses HTTP inchangées).

## C2 — Intégrité & sécurité examens
- **Fuite de contenu fermée** : la page evaluation est le guichet d'entrée (`startExam`) → livraison **conditionnelle** des questions (payload RSC non peuplé hors participation `in_progress`) + garde DAL `hasAccess` pour les examens `subscribers`. Page détail : paywall préservé (pas de 404).
- **Budget-temps anti-triche gardé À L'ÉCRITURE** (`saveExamAnswer`), pas seulement à la finalisation (`isAutoSubmit` vient du client).
- **Races** : transaction + `FOR UPDATE` sur la participation (save vs finalize) ; `FOR UPDATE` commun sur la ligne `exams` (updateExam vs startExam).

## C3 — Filet de tests & CI
- Nouveau job CI `integration` (branche Neon éphémère via `scripts/test-integration.ts`) sur PR et push `main`.
- Tests : `createStripeCheckout` (transaction pending), contrat HTTP du webhook (400/200/500 + filtre + dispatch), `verifyStripeCheckout` (anti-IDOR), course de fulfillment (verrou `FOR UPDATE` prouvé par cumul d'expiration).

## Vérifications
- `bun run check` (prettier + tsc + eslint) — vert
- `bun run test` — **957/957** (frontend)
- `bun run test:integration` — **279/279** (30 fichiers, branche Neon éphémère)
- E2E `examen-blanc.spec.ts` — **9/9** (journey complet en vrai navigateur)

## ⚠️ CI
Le job `integration` a besoin des secrets `NEON_API_KEY` + `NEON_PROJECT_ID` — **déjà posés** dans les secrets du repo. Il verdira au 1er run de cette PR.