### PR TITLE
fix: hydratation — ancrer le formatage des dates sur le fuseau du Québec (NOMAQBANQ-5)

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -123,6 +123,26 @@ storagePath,order}` pour rester assignable aux composants partagés
   (Node) vs client → _hydration mismatch_ (« 2 880 » ≠ « 2 880 » à l'œil ; l'arbre
   est régénéré côté client et l'état local peut sauter). Toujours passer une locale
   fixe : `n.toLocaleString("fr-CA")`.
+- **Hydration — fuseau des dates** : `format()` de date-fns rend dans le fuseau
+  du RUNTIME → serveur en UTC (TZ=UTC en prod/CI) vs navigateur en heure locale
+  = mismatch systématique de 4-5 h, et de jour entier près de minuit (post-mortem
+  Sentry NOMAQBANQ-5, 29 users). TOUT formatage de date passe par `lib/format.ts`,
+  qui ancre l'instant sur `America/Toronto` via `TZDate` (`@date-fns/tz`) — ne
+  JAMAIS appeler `format()` de date-fns directement dans un composant rendu côté
+  serveur ; ajouter un helper au module plutôt qu'un `format()` inline. Une échéance
+  que le lecteur pourrait prendre pour son heure locale (ouverture/fermeture d'examen)
+  s'affiche via `formatDeadline`, qui suffixe « (heure de l'Est) » — sans ça un
+  étudiant hors Québec se trompe de plusieurs heures sur la fermeture.
+  Exceptions assumées, à ne pas « corriger » sans réfléchir :
+  - date pickers admin (`exam-form`, `users-filter-bar`) : ils formatent la valeur
+    locale du calendrier, cohérente avec ce que l'admin vient de cliquer ;
+  - `SESSION_DATE_FMT` (`features/users/dal.ts`) : formatage côté DAL, antérieur
+    au module et volontairement autonome ;
+  - `getRevenueByDay` : `parseISO` sur du date-only (`YYYY-MM-DD`) rend bien le même
+    jour partout, MAIS le bucket lui-même est un **jour UTC** (`payments/dal.ts`),
+    donc ses bornes ne coïncident pas avec les heures Toronto affichées dans la
+    table des transactions. Pré-existant, non corrigé — ne pas le présenter comme
+    cohérent.
 - **Hydration — bruit tiers filtré** : les crashs `$RS` (`Cannot read properties
 of null (reading 'parentNode')`, script inline du streaming React) causés par
   un tiers qui mute le DOM (traduction, extension, proxy) sont DROPPÉS par le

--- a/app/(admin)/admin/_components/admin-dashboard-client.tsx
+++ b/app/(admin)/admin/_components/admin-dashboard-client.tsx
@@ -1,8 +1,6 @@
 "use client"
 
 import { IconLayoutDashboard } from "@tabler/icons-react"
-import { format } from "date-fns"
-import { fr } from "date-fns/locale"
 import { motion } from "motion/react"
 import dynamic from "next/dynamic"
 import { useRouter } from "next/navigation"
@@ -22,6 +20,7 @@ import type {
 } from "@/features/payments/dal"
 import type { QuestionStats } from "@/features/questions/dal"
 import type { AdminStats } from "@/features/users/dal"
+import { formatWeekdayLongDate } from "@/lib/format"
 
 // Lazy-load la modale (ssr:false → uniquement dans un composant client).
 const ManualPaymentModal = dynamic(
@@ -60,9 +59,7 @@ export function AdminDashboardClient({
 }: AdminDashboardClientProps) {
   const router = useRouter()
   const [showManualPaymentModal, setShowManualPaymentModal] = useState(false)
-  const [today] = useState(() =>
-    format(new Date(), "EEEE d MMMM yyyy", { locale: fr }),
-  )
+  const [today] = useState(() => formatWeekdayLongDate(new Date()))
 
   return (
     <div className="flex flex-col gap-6 p-4 md:gap-8 lg:p-6">

--- a/app/(admin)/admin/examens/[id]/_components/exam-details.tsx
+++ b/app/(admin)/admin/examens/[id]/_components/exam-details.tsx
@@ -14,7 +14,7 @@ import type {
   LeaderboardEntry,
 } from "@/features/exams/dal"
 import { getExamStatus } from "@/lib/exam-status"
-import { formatFullDateTime } from "@/lib/format"
+import { formatDeadline } from "@/lib/format"
 import { EligibleCandidatesSection } from "./eligible-candidates-section"
 import { ExamLeaderboard } from "./exam-leaderboard"
 import { ExamSectionStats } from "./exam-section-stats"
@@ -65,7 +65,7 @@ export function ExamDetails({
               <div>
                 <p className="text-sm font-medium">Date de début</p>
                 <p className="text-muted-foreground text-sm">
-                  {formatFullDateTime(exam.startDate)}
+                  {formatDeadline(exam.startDate)}
                 </p>
               </div>
             </div>
@@ -74,7 +74,7 @@ export function ExamDetails({
               <div>
                 <p className="text-sm font-medium">Date de fin</p>
                 <p className="text-muted-foreground text-sm">
-                  {formatFullDateTime(exam.endDate)}
+                  {formatDeadline(exam.endDate)}
                 </p>
               </div>
             </div>

--- a/app/(dashboard)/tableau-de-bord/examen-blanc/_components/examen-blanc-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/examen-blanc/_components/examen-blanc-client.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { format } from "date-fns"
-import { fr } from "date-fns/locale"
 import {
   Award,
   CalendarClock,
@@ -28,7 +26,11 @@ import {
 } from "@/components/ui/dialog"
 import { EmptyState } from "@/components/ui/empty-state"
 import type { ExamListItem } from "@/features/exams/dal"
-import { formatFullDateTime } from "@/lib/format"
+import {
+  formatDeadline,
+  formatFullDateTime,
+  formatPaddedMediumDate,
+} from "@/lib/format"
 import { cn } from "@/lib/utils"
 
 type ExamVariant = "active" | "upcoming" | "past"
@@ -51,9 +53,6 @@ const ExamCard = ({
   onViewResults,
   index,
 }: ExamCardProps) => {
-  const formatDateShort = (timestamp: number) =>
-    format(new Date(timestamp), "dd MMM yyyy", { locale: fr })
-
   const variantStyles = {
     active: {
       gradient:
@@ -176,11 +175,11 @@ const ExamCard = ({
             <CalendarDays className={cn("h-4 w-4", styles.iconColor)} />
             <span className="text-sm text-gray-700 dark:text-gray-300">
               {variant === "active" &&
-                `Jusqu'au ${formatFullDateTime(exam.endDate)}`}
+                `Jusqu'au ${formatDeadline(exam.endDate)}`}
               {variant === "upcoming" &&
-                `Ouverture le ${formatFullDateTime(exam.startDate)}`}
+                `Ouverture le ${formatDeadline(exam.startDate)}`}
               {variant === "past" &&
-                `Terminé le ${formatFullDateTime(exam.endDate)}`}
+                `Terminé le ${formatDeadline(exam.endDate)}`}
             </span>
           </div>
           <div
@@ -274,7 +273,7 @@ const ExamCard = ({
               className="w-full cursor-not-allowed bg-blue-100 font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
             >
               <CalendarClock className="mr-2 h-4 w-4" />
-              Disponible le {formatDateShort(exam.startDate)}
+              Disponible le {formatPaddedMediumDate(exam.startDate)}
             </Button>
           )}
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@aws-sdk/client-s3": "^3.1085.0",
         "@aws-sdk/client-sesv2": "^3.1085.0",
         "@aws-sdk/s3-presigned-post": "^3.1085.0",
+        "@date-fns/tz": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -230,7 +231,7 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.3.1", "", {}, "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g=="],
 
-    "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+    "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
@@ -2173,6 +2174,8 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-day-picker/@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,5 +1,30 @@
+import { TZDate } from "@date-fns/tz"
 import { format, formatDistanceToNow } from "date-fns"
 import { fr } from "date-fns/locale"
+
+/**
+ * Fuseau de référence de la plateforme (Québec). `format()` de date-fns rend
+ * dans le fuseau du runtime : serveur en UTC (TZ=UTC en prod/CI) vs navigateur
+ * en heure locale → la même date sort différente au SSR et à l'hydratation
+ * (mismatch React, arbre régénéré). Ancrer le fuseau rend la chaîne stable des
+ * deux côtés, et une échéance d'examen désigne le même instant pour tous.
+ */
+const APP_TIME_ZONE = "America/Toronto"
+
+/**
+ * Une chaîne date-only (`"2026-07-03"`) est parsée en minuit **UTC** par
+ * `new Date()`, donc rendue la veille en heure de l'Est. Ne passer ici que des
+ * instants réels (timestamp, `Date`, ISO complet).
+ */
+const inAppZone = (d: Date | number | string) =>
+  new TZDate(new Date(d), APP_TIME_ZONE)
+
+/**
+ * L'heure affichée est un mur-horloge de l'Est, pas l'heure locale du lecteur.
+ * Sans cette mention, un utilisateur hors Québec lit l'échéance dans son propre
+ * fuseau et se trompe de plusieurs heures sur la fermeture d'un examen.
+ */
+export const APP_TIME_ZONE_LABEL = "heure de l'Est"
 
 /**
  * Formate un montant en cents vers une devise lisible
@@ -35,13 +60,14 @@ export const formatCurrency = (
  * Formate un timestamp en date lisible
  */
 export const formatExpiration = (timestamp: number): string => {
-  return format(new Date(timestamp), "d MMMM yyyy", { locale: fr })
+  return format(inAppZone(timestamp), "d MMMM yyyy", { locale: fr })
 }
 
 /**
  * Formate un timestamp en temps relatif
  */
 export const formatTimeRemaining = (timestamp: number): string => {
+  // Un écart entre deux instants ne dépend pas du fuseau : pas d'ancrage ici.
   return formatDistanceToNow(new Date(timestamp), {
     locale: fr,
     addSuffix: true,
@@ -52,39 +78,57 @@ export const formatTimeRemaining = (timestamp: number): string => {
  * Formate un timestamp en date courte
  */
 export const formatShortDate = (timestamp: number): string => {
-  return format(new Date(timestamp), "dd/MM/yyyy", { locale: fr })
+  return format(inAppZone(timestamp), "dd/MM/yyyy", { locale: fr })
 }
 
 /**
  * Formate un timestamp en date et heure
  */
 export const formatDateTime = (timestamp: number): string => {
-  return format(new Date(timestamp), "d MMM yyyy à HH:mm", { locale: fr })
+  return format(inAppZone(timestamp), "d MMM yyyy à HH:mm", { locale: fr })
 }
 
 /**
  * Formate un timestamp en heure uniquement (HH:mm)
  */
 export const formatTimeOnly = (timestamp: number): string => {
-  return format(new Date(timestamp), "HH:mm", { locale: fr })
+  return format(inAppZone(timestamp), "HH:mm", { locale: fr })
 }
 
 /** « 3 juil. 2026 » — listes/cards admin. */
 export const formatMediumDate = (d: Date | number | string): string => {
-  return format(new Date(d), "d MMM yyyy", { locale: fr })
+  return format(inAppZone(d), "d MMM yyyy", { locale: fr })
 }
 
 /** « 3 juillet 2026 à 14:05 » — panneaux de détail. */
 export const formatLongDateTime = (d: Date | number | string): string => {
-  return format(new Date(d), "d MMMM yyyy 'à' HH:mm", { locale: fr })
+  return format(inAppZone(d), "d MMMM yyyy 'à' HH:mm", { locale: fr })
 }
 
 /** « 3 juillet 2026 à 14:05 » (variante PPP) — détails examen. */
 export const formatFullDateTime = (d: Date | number | string): string => {
-  return format(new Date(d), "PPP 'à' HH:mm", { locale: fr })
+  return format(inAppZone(d), "PPP 'à' HH:mm", { locale: fr })
 }
+
+/**
+ * « 3 juillet 2026 à 14:05 (heure de l'Est) » — bornes d'une fenêtre d'examen
+ * (ouverture, fermeture). À utiliser partout où le lecteur pourrait confondre
+ * l'heure affichée avec la sienne et se tromper d'échéance.
+ */
+export const formatDeadline = (d: Date | number | string): string =>
+  `${formatFullDateTime(d)} (${APP_TIME_ZONE_LABEL})`
 
 /** « 03/07/2026, 14:05 » — lignes compactes (leaderboard, tables). */
 export const formatCompactDateTime = (d: Date | number | string): string => {
-  return format(new Date(d), "Pp", { locale: fr })
+  return format(inAppZone(d), "Pp", { locale: fr })
+}
+
+/** « 03 juil. 2026 » (jour zéro-préfixé) — boutons d'ouverture d'examen. */
+export const formatPaddedMediumDate = (d: Date | number | string): string => {
+  return format(inAppZone(d), "dd MMM yyyy", { locale: fr })
+}
+
+/** « vendredi 3 juillet 2026 » — sous-titres de page. */
+export const formatWeekdayLongDate = (d: Date | number | string): string => {
+  return format(inAppZone(d), "EEEE d MMMM yyyy", { locale: fr })
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/client-s3": "^3.1085.0",
     "@aws-sdk/client-sesv2": "^3.1085.0",
     "@aws-sdk/s3-presigned-post": "^3.1085.0",
+    "@date-fns/tz": "^1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -3,14 +3,22 @@ import {
   formatCompactDateTime,
   formatCurrency,
   formatDateTime,
+  formatDeadline,
   formatExpiration,
   formatFullDateTime,
   formatLongDateTime,
   formatMediumDate,
+  formatPaddedMediumDate,
   formatShortDate,
   formatTimeOnly,
   formatTimeRemaining,
+  formatWeekdayLongDate,
 } from "@/lib/format"
+
+// Ces suites tournent sous TZ=UTC (vitest.config.ts) et assertent des valeurs
+// heure de Toronto : un formateur qui retomberait sur le fuseau du runtime
+// rendrait de l'UTC et échouerait ici. C'est le filet contre la régression
+// d'hydratation (SSR en UTC vs navigateur en heure locale).
 
 describe("formatCurrency", () => {
   // Note: Intl.NumberFormat utilise des espaces insécables (\u00A0) dans le formatage
@@ -86,12 +94,19 @@ describe("formatExpiration", () => {
   })
 
   it("gère différentes dates", () => {
-    const timestamp = new Date("2025-12-25T00:00:00Z").getTime()
+    const timestamp = new Date("2025-12-20T12:00:00Z").getTime()
     const result = formatExpiration(timestamp)
 
-    expect(result).toContain("25")
+    expect(result).toContain("20")
     expect(result).toContain("décembre")
     expect(result).toContain("2025")
+  })
+
+  it("rend la veille pour un instant UTC déjà passé minuit à Toronto", () => {
+    // Minuit UTC le 25 = 19:00 le 24 à Toronto (EST). C'est ce décalage de
+    // jour, invisible en UTC, qui cassait l'hydratation.
+    const timestamp = new Date("2025-12-25T00:00:00Z").getTime()
+    expect(formatExpiration(timestamp)).toBe("24 décembre 2025")
   })
 })
 
@@ -163,15 +178,15 @@ describe("formatDateTime", () => {
     expect(result).toContain("mars")
     expect(result).toContain("2024")
     expect(result).toContain("à")
-    expect(result).toContain("14:30")
+    expect(result).toContain("10:30")
   })
 
   it("utilise le format 24h", () => {
-    const timestamp = new Date("2024-03-15T23:45:00Z").getTime()
+    const timestamp = new Date("2024-03-16T02:45:00Z").getTime()
     const result = formatDateTime(timestamp)
 
     // Vérifie que c'est bien en format 24h
-    expect(result).toContain("23:45")
+    expect(result).toContain("22:45")
   })
 })
 
@@ -191,7 +206,7 @@ describe("formatMediumDate", () => {
 describe("formatLongDateTime", () => {
   it("formate en « d MMMM yyyy à HH:mm »", () => {
     const timestamp = new Date("2024-03-15T14:05:00Z").getTime()
-    expect(formatLongDateTime(timestamp)).toBe("15 mars 2024 à 14:05")
+    expect(formatLongDateTime(timestamp)).toBe("15 mars 2024 à 10:05")
   })
 })
 
@@ -200,7 +215,16 @@ describe("formatFullDateTime", () => {
     const timestamp = new Date("2024-03-15T14:05:00Z").getTime()
     const result = formatFullDateTime(timestamp)
     expect(result).toContain("15 mars 2024")
-    expect(result).toContain("à 14:05")
+    expect(result).toContain("à 10:05")
+  })
+})
+
+describe("formatDeadline", () => {
+  it("suffixe le fuseau pour lever l'ambiguïté hors Québec", () => {
+    const timestamp = new Date("2024-03-15T14:05:00Z").getTime()
+    expect(formatDeadline(timestamp)).toBe(
+      "15 mars 2024 à 10:05 (heure de l'Est)",
+    )
   })
 })
 
@@ -209,7 +233,23 @@ describe("formatCompactDateTime", () => {
     const timestamp = new Date("2024-03-15T14:05:00Z").getTime()
     const result = formatCompactDateTime(timestamp)
     expect(result).toContain("15/03/2024")
-    expect(result).toContain("14:05")
+    expect(result).toContain("10:05")
+  })
+})
+
+describe("formatPaddedMediumDate", () => {
+  it("préfixe le jour d'un zéro", () => {
+    expect(formatPaddedMediumDate(new Date("2024-07-03T12:00:00Z"))).toBe(
+      "03 juil. 2024",
+    )
+  })
+})
+
+describe("formatWeekdayLongDate", () => {
+  it("inclut le jour de la semaine en français", () => {
+    expect(formatWeekdayLongDate(new Date("2024-03-15T12:00:00Z"))).toBe(
+      "vendredi 15 mars 2024",
+    )
   })
 })
 
@@ -218,20 +258,60 @@ describe("formatTimeOnly", () => {
     const timestamp = new Date("2024-03-15T14:30:00Z").getTime()
     const result = formatTimeOnly(timestamp)
 
-    expect(result).toBe("14:30")
+    expect(result).toBe("10:30")
   })
 
   it("gère minuit", () => {
-    const timestamp = new Date("2024-03-15T00:00:00Z").getTime()
+    const timestamp = new Date("2024-03-15T04:00:00Z").getTime()
     const result = formatTimeOnly(timestamp)
 
     expect(result).toBe("00:00")
   })
 
   it("gère midi", () => {
-    const timestamp = new Date("2024-03-15T12:00:00Z").getTime()
+    const timestamp = new Date("2024-03-15T16:00:00Z").getTime()
     const result = formatTimeOnly(timestamp)
 
     expect(result).toBe("12:00")
+  })
+})
+
+describe("invariant de fuseau", () => {
+  const originalTz = process.env.TZ
+
+  afterEach(() => {
+    process.env.TZ = originalTz
+  })
+
+  // Le mismatch d'hydratation vient de deux runtimes aux fuseaux différents qui
+  // rendent le même instant : on simule ici les deux côtés dans un seul process.
+  it("rend la même chaîne quel que soit le fuseau du runtime", () => {
+    const instant = new Date("2026-07-27T02:30:00Z").getTime()
+
+    const rendus = [
+      "UTC",
+      "America/Toronto",
+      "Asia/Tokyo",
+      "Pacific/Kiritimati",
+    ]
+      .map((tz) => {
+        process.env.TZ = tz
+        return formatFullDateTime(instant)
+      })
+      .filter((v, _i, all) => v === all[0])
+
+    expect(rendus).toHaveLength(4)
+    expect(rendus[0]).toContain("26 juillet 2026")
+    expect(rendus[0]).toContain("à 22:30")
+  })
+
+  it("applique l'heure avancée de l'Est en été comme en hiver", () => {
+    // -5 h en janvier (EST), -4 h en juillet (EDT).
+    expect(formatTimeOnly(new Date("2026-01-15T17:00:00Z").getTime())).toBe(
+      "12:00",
+    )
+    expect(formatTimeOnly(new Date("2026-07-15T16:00:00Z").getTime())).toBe(
+      "12:00",
+    )
   })
 })


### PR DESCRIPTION
## Problème

Issue Sentry [NOMAQBANQ-5](https://khimera-9h.sentry.io/issues/NOMAQBANQ-5) — **109 events / 29 utilisateurs**, statut `regressed`, encore active sur la release courante.

`format()` de date-fns rend dans le fuseau du **runtime**. En production le serveur tourne en UTC et le navigateur en heure locale (`America/Toronto` dans les events) : le même instant sortait donc différemment au SSR et à l''hydratation.

```
SSR (UTC)        → « 27 juillet 2026 à 03:59 »
Hydratation (TO) → « 26 juillet 2026 à 23:59 »   ← mismatch
```

Décalage **systématique** de 4-5 h, et de jour entier près de minuit. Chaque carte d''examen portant une date cassait l''hydratation.

## Correctif

Central dans `lib/format.ts` : les 10 formateurs ancrent l''instant sur `America/Toronto` via `TZDate` (`@date-fns/tz`). Les patterns date-fns sont inchangés → sortie identique, au fuseau près. Ça corrige d''un coup les **26 fichiers** consommateurs.

Deux `format()` inline qui contournaient le module ont été rapatriés (liste des examens blancs, dashboard admin).

Ajout de `formatDeadline`, suffixé « (heure de l''Est) », sur les 5 bornes de fenêtre d''examen. Sans cette mention, le correctif échangeait un bug d''hydratation contre une échéance trompeuse : un étudiant à Vancouver ou au Cameroun lit l''heure dans son propre fuseau et se trompe sur la fermeture.

`formatTimeRemaining` reste volontairement non ancré — un écart entre deux instants ne dépend pas du fuseau.

## Validation

- `bun run check` → exit 0 · `bun run test` → **977/977**
- Les tests existants **encodaient le bug** (assertions en UTC) : réalignés sur Toronto, plus la bascule de jour, l''invariance de fuseau (UTC/Toronto/Tokyo/Kiritimati) et EST vs EDT. Comme vitest force `TZ=UTC`, un formateur qui retomberait sur le fuseau du runtime fait échouer la suite.
- **E2E avec contrôle négatif** sur `/tableau-de-bord/examen-blanc` : 22 cartes, dates strictement identiques entre un navigateur Tokyo et un navigateur Toronto, 0 erreur console. Le correctif retiré, React lève bien le mismatch attendu (`+ à 15:34` / `- à 02:34`) en citant lui-même « Date formatting in a user''s locale which doesn''t match the server ». Le test discrimine donc réellement.
- Revue adversariale passée en session séparée : 5 constats, tous traités sauf un laissé hors périmètre (ci-dessous).

## Choix assumés

- **Changement de comportement visible** : les échéances s''affichent désormais en heure de l''Est pour tout le monde, avec l''étiquette. Pour une plateforme d''examens c''est le bon choix — une deadline désigne le même instant pour tous.
- Laissés en heure locale après vérification : les date pickers admin (`exam-form`, `users-filter-bar`, cohérents avec le calendrier que l''admin vient de cliquer) et `revenue-chart-content` (`parseISO` sur du date-only, rendu identique partout).

## Suite connue (hors périmètre)

Le filtre `dateFrom`/`dateTo` de `users-manager.tsx:91-92` envoie des bornes à minuit **local navigateur** alors que la liste affiche des dates Toronto — incohérent pour un admin hors Est. Non traité ici : ça change la sémantique d''une requête, pas un affichage, et mérite son propre test.