### PR TITLE
fix(admin): accepter un label ReactNode dans le tooltip du graphe de revenus

### DIFF
--- a/components/admin/dashboard/revenue-chart-content.tsx
+++ b/components/admin/dashboard/revenue-chart-content.tsx
@@ -217,9 +217,13 @@ export function RevenueChartContent({ data }: RevenueChartContentProps) {
                   }}
                   labelFormatter={(label) => {
                     try {
-                      return format(parseISO(label), "EEEE d MMMM yyyy", {
-                        locale: fr,
-                      })
+                      return format(
+                        parseISO(String(label)),
+                        "EEEE d MMMM yyyy",
+                        {
+                          locale: fr,
+                        },
+                      )
                     } catch {
                       return label
                     }


### PR DESCRIPTION
## Contexte

`recharts 3.10.1` (bumpé par la PR Dependabot #126) élargit le type du paramètre `label` de `labelFormatter` à `ReactNode`. `parseISO(label)` ne compile plus, ce qui casse le type check **et** le build Vercel de #126 :

```
components/admin/dashboard/revenue-chart-content.tsx(220,46):
error TS2345: Argument of type 'ReactNode' is not assignable to parameter of type 'string'.
```

## Changement

`parseISO(String(label))`. Le `try/catch` existant couvre déjà le cas d'un label non parsable (`parseISO` rend une date invalide, `format` lève, on retombe sur le label brut).

Le correctif est rétro-compatible : `bun run check` passe sur `main` avec `recharts 3.9.2` **et** débloque `3.10.1`.

## Suite

Une fois mergé, relancer `@dependabot rebase` sur #126 pour que son CI repasse au vert.