### PR TITLE
fix(ui): utiliser la forme canonique du décalage vertical de l'icône d'alerte

### DIFF
--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:-translate-y-0.75 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Contexte

`eslint-plugin-tailwind-canonical-classes 1.4.1` (bumpé par la PR Dependabot #126) reconnaît un cas de plus qu'en `1.3.3`. Avec `--max-warnings 0`, `bun run lint` échoue :

```
components/ui/alert.tsx
  6:3  warning  Class '[&>svg+div]:translate-y-[-3px]'
                should be '[&>svg+div]:-translate-y-0.75'
```

C'est le dernier verrou de #126 : son type check et son build Vercel sont déjà repassés au vert depuis le merge de #128.

## Changement

`[&>svg+div]:translate-y-[-3px]` → `[&>svg+div]:-translate-y-0.75`.

Strictement équivalent au rendu : `0.75 × 0.25rem = 0.1875rem = 3px`. Aucun test ne dépend de cette classe.

## Compatibilité

`bun run check` passe sur `main` avec le plugin `1.3.3` actuel — le correctif peut donc être mergé avant #126.

## Note

`components/ui/alert.tsx` est du shadcn stock : un futur `shadcn add alert` réintroduirait la forme non canonique, et donc ce warning.