### PR TITLE
fix: hydratation — ancrer sur le fuseau du Québec les branchements sur l'heure (NOMAQBANQ-5)

### DIFF
--- a/app/(dashboard)/tableau-de-bord/_components/dashboard-hero.tsx
+++ b/app/(dashboard)/tableau-de-bord/_components/dashboard-hero.tsx
@@ -3,6 +3,7 @@
 import { Clock, Shield, Sparkles } from "lucide-react"
 import { motion } from "motion/react"
 import { useState } from "react"
+import { getAppZoneHour } from "@/lib/format"
 import { cn } from "@/lib/utils"
 import { ProgressRing } from "./progress-ring"
 
@@ -19,7 +20,7 @@ interface DashboardHeroProps {
 }
 
 const getGreetingValue = () => {
-  const hour = new Date().getHours()
+  const hour = getAppZoneHour(Date.now())
   if (hour < 12) return "Bonjour"
   if (hour < 18) return "Bon après-midi"
   return "Bonsoir"

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -9,9 +9,12 @@ import {
 import { Mail, MapPin, Phone, Stethoscope } from "lucide-react"
 import Link from "next/link"
 import { FOOTER_LEGAL_LINKS, FOOTER_QUICK_LINKS } from "@/constants"
+import { getAppZoneYear } from "@/lib/format"
 
-// Constante module-level pour éviter new Date() à chaque render (pureté React 19)
-const CURRENT_YEAR = new Date().getFullYear()
+// Constante module-level pour éviter new Date() à chaque render (pureté React 19).
+// Année ancrée sur le fuseau de la plateforme : `getFullYear()` sur l'heure du
+// runtime fait diverger serveur (UTC) et client le 31 décembre au soir.
+const CURRENT_YEAR = getAppZoneYear(Date.now())
 
 export default function Footer() {
   return (

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -27,6 +27,20 @@ const inAppZone = (d: Date | number | string) =>
 export const APP_TIME_ZONE_LABEL = "heure de l'Est"
 
 /**
+ * Heure du jour (0-23) dans le fuseau de la plateforme. Brancher sur
+ * `new Date().getHours()` lit l'heure du RUNTIME — serveur en UTC vs navigateur
+ * en heure locale — et fait diverger un texte conditionnel entre le SSR et
+ * l'hydratation (post-mortem NOMAQBANQ-5 : salutation du tableau de bord, qui
+ * cassait l'hydratation 12 h sur 24 en heure avancée).
+ */
+export const getAppZoneHour = (d: Date | number | string): number =>
+  inAppZone(d).getHours()
+
+/** Année civile dans le fuseau de la plateforme — même piège que `getAppZoneHour`. */
+export const getAppZoneYear = (d: Date | number | string): number =>
+  inAppZone(d).getFullYear()
+
+/**
  * Formate un montant en cents vers une devise lisible
  * XAF: pas de décimales, symbole après le montant
  * CAD: format standard canadien-français

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -13,6 +13,8 @@ import {
   formatTimeOnly,
   formatTimeRemaining,
   formatWeekdayLongDate,
+  getAppZoneHour,
+  getAppZoneYear,
 } from "@/lib/format"
 
 // Ces suites tournent sous TZ=UTC (vitest.config.ts) et assertent des valeurs
@@ -273,6 +275,29 @@ describe("formatTimeOnly", () => {
     const result = formatTimeOnly(timestamp)
 
     expect(result).toBe("12:00")
+  })
+})
+
+describe("getAppZoneHour", () => {
+  it("rend l'heure de Toronto, pas celle du runtime", () => {
+    // Horodatage exact de l'event NOMAQBANQ-5 du 2026-07-28 : 03:03 UTC, soit
+    // 23:03 à Toronto. Le serveur lisait 3 (« Bonjour ») et le client 23
+    // (« Bonsoir ») → texte divergent, hydratation cassée.
+    expect(getAppZoneHour(new Date("2026-07-28T03:03:05Z"))).toBe(23)
+  })
+
+  it("reste du bon côté des seuils de salutation", () => {
+    // 16:00 UTC = 12:00 à Toronto : « Bon après-midi » des deux côtés.
+    expect(getAppZoneHour(new Date("2026-07-15T16:00:00Z"))).toBe(12)
+    // 15:59 UTC = 11:59 : encore « Bonjour ».
+    expect(getAppZoneHour(new Date("2026-07-15T15:59:00Z"))).toBe(11)
+  })
+})
+
+describe("getAppZoneYear", () => {
+  it("rend l'année de Toronto le soir du 31 décembre", () => {
+    // Déjà 2027 en UTC, encore 2026 à Toronto (21:00 le 31/12).
+    expect(getAppZoneYear(new Date("2027-01-01T02:00:00Z"))).toBe(2026)
   })
 })
 


### PR DESCRIPTION
## Contexte

[NOMAQBANQ-5](https://khimera-9h.sentry.io/issues/NOMAQBANQ-5) s''est rouverte en `regressed` le 28/07 à 03h03 UTC, sur la release `9a39c90` — qui **contient déjà** le correctif de formatage de la #127 (`e3645fd`, mergé la veille à 11h50). Le culprit a changé : `/tableau-de-bord`, et non plus `/examen-blanc`.

La cause restante n''est pas un formatage de date mais un **branchement sur l''heure du runtime**, hors du périmètre de `lib/format.ts`.

## Cause racine

`dashboard-hero.tsx` calculait la salutation ainsi, dans un initialiseur paresseux de `useState` — donc évalué **au SSR et à l''hydratation** :

```js
const hour = new Date().getHours()   // ← heure du RUNTIME
if (hour < 12) return "Bonjour"
if (hour < 18) return "Bon après-midi"
return "Bonsoir"
```

À l''horodatage exact de l''event (`03:03:05Z`, navigateur `America/Toronto`) : serveur UTC → `hour = 3` → « Bonjour » ; client → `23:03`, `hour = 23` → « Bonsoir ». Texte divergent, hydratation cassée.

**Ce n''est pas un cas limite.** Avec des seuils à 12 h et 18 h et un décalage fixe de 4 h, la salutation diverge pour les tranches client 8h-11h, 14h-17h et 20h-23h — soit **12 heures sur 24 en heure avancée, 15 sur 24 en heure normale**, pour chaque visiteur du tableau de bord.

## Correctif

`getAppZoneHour` et `getAppZoneYear` dans `lib/format.ts`, ancrés sur `America/Toronto` — ce qui garde `@date-fns/tz` et la constante de fuseau centralisés, conformément à la règle posée en #127.

- **dashboard-hero** : salutation calculée sur l''heure de l''Est. Serveur et client lisent la même heure, donc rendent le même texte.
- **footer** : `new Date().getFullYear()` ancré aussi — même mécanisme, fenêtre de divergence le 31 décembre entre 19 h et minuit.

Choix assumé : la salutation suit désormais l''heure du Québec. Un utilisateur au Cameroun à 9 h du matin lira « Bonsoir ». C''est un texte cosmétique, alors que le bug cassait l''hydratation de la page d''accueil pour tout le monde la moitié du temps.

## Validation

- `bun run check` → exit 0
- `tests/lib/format.test.ts` → **36/36**, dont l''horodatage exact de l''incident (`2026-07-28T03:03:05Z` doit donner `23`, pas `3`), les deux bords de seuil (11 h / 12 h) et la Saint-Sylvestre. La suite tournant sous `TZ=UTC`, un helper qui retomberait sur le fuseau du runtime échouerait ici.

## Hors périmètre

- Deux infobulles admin (`users-table.tsx:255`, `question-browser-table.tsx:290`) utilisent `toLocaleDateString` **sans `timeZone`**. Rendues au survol dans un portail Radix → aucun risque d''hydratation, mais elles affichent l''heure locale du navigateur à côté de colonnes désormais en heure de Toronto. Incohérence pour un admin hors Est.
- `components/ui/chart.tsx:273` : `toLocaleString()` sans locale, ce que proscrit `.claude/rules/data-layer.md`. Composant shadcn stock, rendu au survol.
- **Flake pré-existant** : `tests/components/admin/question-browser.test.tsx` dépasse le `testTimeout` de 5 s en suite complète mais passe en isolation. Vérifié sur un arbre propre : présent avant cette branche, non introduit ici.