### PR TITLE
P1-A — Révision ciblée en entraînement (ratées / non vues / marquées)

### DIFF
--- a/.claude/CLAUDE-GUIDELINES.md
+++ b/.claude/CLAUDE-GUIDELINES.md
@@ -8,7 +8,7 @@ Ce document définit les règles à suivre pour maintenir le fichier `CLAUDE.md`
 
 ### 1. Concision Absolue
 
-- **Cible root** : < 100 lignes (actuellement ~80). Les patterns spécialisés vont dans `.claude/rules/`
+- **Cible root** : < 150 lignes (actuellement ~110, dans `AGENTS.md` importé par `CLAUDE.md`). Les patterns spécialisés vont dans `.claude/rules/`
 - **Raison** : Le CLAUDE.md consomme du contexte. Chaque ligne inutile réduit la capacité de travail
 - **Règle** : Si une info est trouvable ailleurs (package.json, schema.ts, .env.example), ne pas la dupliquer
 
@@ -57,8 +57,6 @@ Voir `lib/auth-guards.ts:requireRole()`
 ```
 ````
 
-````
-
 ---
 
 ## Format des Règles Critiques
@@ -67,7 +65,7 @@ Utiliser le format suivant pour les règles qui causent des bugs si ignorées :
 
 ```markdown
 **IMPORTANT - [Nom Court]** : Description concise. Voir `fichier:fonction()`.
-````
+```
 
 Exemples :
 
@@ -109,7 +107,7 @@ Avant de modifier CLAUDE.md, vérifier :
 
 ## Organisation Actuelle
 
-### Root `CLAUDE.md` (~80 lignes)
+### Root `CLAUDE.md` → `AGENTS.md` (~110 lignes)
 
 1. **Header** - Nom + description 1 ligne
 2. **Stack** - Technologies (1 ligne)
@@ -122,17 +120,21 @@ Avant de modifier CLAUDE.md, vérifier :
 
 ### `.claude/rules/` (chargés automatiquement par path)
 
-| Fichier         | Scope                                   | Contenu                                          |
-| --------------- | --------------------------------------- | ------------------------------------------------ |
-| `data-layer.md` | `features/**`, `app/**`                 | DAL Drizzle, Server Actions, tests d'intégration |
-| `admin-ui.md`   | `app/(admin)/**`, `components/admin/**` | Master-detail, stat cards, filtres               |
-| `seo.md`        | `app/(marketing)/**`, SEO files         | Metadata, pages marketing                        |
+| Fichier          | Scope                                      | Contenu                                                    |
+| ---------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `data-layer.md`  | `features/**`, `app/**`                    | DAL Drizzle, Server Actions, tests d'intégration           |
+| `loading-ui.md`  | `app/**`, `components/**`                  | États de chargement, socle Spinner/Skeleton, `loading.tsx` |
+| `admin-ui.md`    | `app/(admin)/**`, `components/admin/**`    | Master-detail, stat cards, filtres                         |
+| `seo.md`         | `app/(marketing)/**`, SEO files            | Metadata, pages marketing, claims éditoriaux               |
+| `e2e-testing.md` | `e2e/**`, `components/quiz/**`, Playwright | Suite E2E, sélecteurs, comptes de test                     |
 
 ### Où ajouter un nouveau pattern ?
 
 - Pattern data layer / backend → `.claude/rules/data-layer.md`
+- Pattern états de chargement → `.claude/rules/loading-ui.md`
 - Pattern admin UI → `.claude/rules/admin-ui.md`
 - Pattern SEO/marketing → `.claude/rules/seo.md`
+- Pattern E2E/Playwright → `.claude/rules/e2e-testing.md`
 - Pattern universel/gotcha → root `CLAUDE.md`
 - Nouveau domaine → créer un nouveau fichier dans `.claude/rules/` avec `paths:` frontmatter
 

--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -58,6 +58,24 @@ storagePath,order}` pour rester assignable aux composants partagés
   (`saveExamAnswer` refuse au-delà de `startedAt + completionTime + grâce`), pas
   seulement à la finalisation (`isAutoSubmit` vient du client). `updateExam` et
   `startExam` prennent un `FOR UPDATE` commun sur la ligne `exams`.
+- **Révision ciblée — le verrou s'applique à la SÉLECTION** : tout canal qui
+  compose un lot de questions à partir de l'historique d'un étudiant (corpus de
+  révision, `features/training/revision.ts`) DOIT retrancher
+  `getUserOpenExamLockedQuestionIds` — du lot **et** des compteurs affichés.
+  Masquer la correction ne suffit pas : l'appartenance d'une question au lot
+  « mes ratées » dit déjà « tu t'es trompé », donc triche pendant qu'un examen
+  est ouvert, sans jamais voir la clé. `getOpenExamLockedQuestionIds` n'est
+  qu'une restriction du même jeu — une seule définition de la règle.
+  `pickRevisionQuestionIds` prend les identifiants verrouillés en paramètre
+  **requis** : ils se résolvent AVANT d'ouvrir la transaction (voir la règle
+  suivante), et un oubli casse la compilation au lieu du silence.
+- **Jamais d'appel au `db` global depuis une fonction exécutée dans une
+  transaction** : le pool est à `max: 5` **sans** `connectionTimeoutMillis`
+  (`db/index.ts`), donc réclamer une 2ᵉ connexion pendant qu'on en détient une
+  fige la requête indéfiniment — et cinq transactions concurrentes figent
+  l'application entière, pas seulement la fonctionnalité fautive. Ce qu'une
+  transaction doit lire ailleurs se résout avant de l'ouvrir et se passe en
+  paramètre (`hasAccess` et `resolveRevisionLock` dans `createTrainingSession`).
 - **Narrowing TS** : renvoyer la valeur DEPUIS le callback de transaction
   (`const r = await db.transaction(async tx => { … return v })`), PAS via un
   `let` capturé dans la closure — TS ne le narrow pas après un garde `if (!r)`

--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -118,6 +118,9 @@ interactif (quiz, **F2 audience**, etc.) doit recevoir un `data-testid` stable.
   ET paragraphe → `getByRole("heading", { name })`.
 - **Stats marketing dynamiques** : matcher le suffixe par regex, ne pas hardcoder
   les nombres.
+- **Simuler l'offline** : `context.setOffline(true)` PEND indéfiniment en dev
+  Turbopack — utiliser `page.route(..., route => route.abort())` sur les POST
+  ciblés à la place.
 - **Formulaire question admin** (`/admin/questions/nouvelle`) : le Select de domaine
   (shadcn/Radix) garde un `<select>` natif caché → `getByText(domaine)` matche 2×
   (l'`<option>` native + l'item Radix) → scoper `getByRole("listbox").getByText(...)`.

--- a/.claude/rules/seo.md
+++ b/.claude/rules/seo.md
@@ -11,6 +11,8 @@ paths:
 
 **IMPORTANT - Metadata Server Components** : `metadata` et `generateMetadata` uniquement dans Server Components. Pages avec `"use client"` -> extraire le contenu dans `_components/*-page-client.tsx`.
 
+**IMPORTANT - Claims éditoriaux** : taux de réussite / note → JAMAIS en dur dans le JSX ou les metadata. Source unique `MARKETING_CLAIMS` (`constants/index.tsx`) ; le taux affiché est calculé par `resolveSuccessRate` (`features/marketing/lib.ts`, bascule éditorial/calculé selon seuils de volume) et servi via `useMarketingStats`.
+
 | Fichier          | Role                                                             |
 | ---------------- | ---------------------------------------------------------------- |
 | `app/robots.ts`  | Regles crawl (bloque `/admin/`, `/tableau-de-bord/`, pages auth) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ components/ui/             # shadcn/ui
 components/quiz/           # Quiz: question-card, calculator, session/
 components/admin/          # Dashboard admin, modals, question-browser
 components/shared/payments # Composants paiement
-hooks/                     # useCurrentUser, useCalculator, use-mobile, use-media-query
+hooks/                     # useCurrentUser, useCalculator, useMarketingStats, use-mobile, use-media-query
 constants/index.tsx        # Routes centralisees, MEDICAL_DOMAINS
 ```
 
@@ -70,7 +70,7 @@ constants/index.tsx        # Routes centralisees, MEDICAL_DOMAINS
 
 ## Tests
 
-- Seuil coverage: 75%
+- Seuil coverage: 80% (statements/branches/functions/lines — `vitest.config.ts`)
 - Frontend: `tests/` (happy-dom) — Integration DAL/Actions: `tests/integration/` (node, vraie branche Neon ephemere via `bun run test:integration`)
 - E2E: `e2e/tests/` (Playwright + auth Better Auth) — POMs dans `e2e/pages/` ; support reset/cleanup via `app/api/e2e`
 - Config: `vitest.config.ts` (exclut `e2e/**`) — `playwright.config.ts` — env `TZ=UTC`
@@ -81,6 +81,7 @@ constants/index.tsx        # Routes centralisees, MEDICAL_DOMAINS
 - **Icons** : `lucide-react` (primaire — utilisé partout), `@tabler/icons-react` (secondaire — surtout admin/dashboard et profil)
 - **Auth** : Better Auth (`lib/auth.ts`, route `app/api/auth/[...all]`) ; client `authClient` (`lib/auth-client.ts`)
 - **Webhooks** : Stripe -> `app/api/stripe/webhook` (signature verifiee, 500 sur erreur -> retry)
+- **Stripe en dev** : mode TEST (profil CLI `nomaqbanq`) ; webhooks locaux via `stripe listen --forward-to localhost:3000/api/stripe/webhook`. Base dev : seul `exam_access` pointe sur un prix test — les 4 autres produits portent des price IDs LIVE → créer le prix test + UPDATE `products.stripe_price_id` avant de tester leur achat. Code promo test −100 % : `E2EPROMO100`
 - **Routes centralisees** : Modifier `constants/index.tsx` pour ajouter/changer URLs
 - **Hauteur uniforme cards** : Utiliser `h-full` + reserver espace pour elements optionnels
 - **URL state** : Deriver l'etat de l'URL, pas useState+useEffect
@@ -91,7 +92,7 @@ constants/index.tsx        # Routes centralisees, MEDICAL_DOMAINS
 - **Image domains** : pexels.com, \*.cloudfront.net, cdn.nomaqbanq.ca (next.config.ts)
 - **Uploads médias** : presigned POST direct navigateur→S3 (`lib/aws.ts` + `lib/storage.ts`) ; rate-limit + validation à l'étape presign ; jamais via Server Action proxy
 - **ESM** : `"type": "module"` — pas de `__dirname`, utiliser `fileURLToPath(import.meta.url)`
-- **Env** : valide via zod (`lib/env/schema.ts`) ; nouvelles vars optionnelles + erreur claire a l'usage
+- **Env** : valide via zod (`lib/env/schema.ts`) ; nouvelles vars optionnelles + erreur claire a l'usage. `.env.local` est GÉNÉRÉ (`bun run env:sync` depuis le scope Vercel Development) : nouvelle var = `vercel env add <KEY> development` d'abord, pas d'édition manuelle durable
 - **data-testid** : Obligatoire sur composants quiz interactifs (`components/quiz/`). Convention : `answer-option-{index}`, `btn-next`, `btn-previous`, `btn-flag`, `btn-finish`
 
 ## Instruction Routing
@@ -103,7 +104,7 @@ Regles specialisees dans `.claude/rules/`:
 | `data-layer.md`  | `features/**`, `app/**`, `components/**`, `tests/integration/**` | DAL Drizzle, Server Actions, forme-pont quiz, PII/frontiere client, gotchas ESLint/SonarLint, cleanup tests |
 | `loading-ui.md`  | `app/**`, `components/**`                                        | Doctrine des états de chargement, socle Spinner/Skeleton, `loading.tsx` par segment                         |
 | `admin-ui.md`    | `app/(admin)/**`, `components/admin/**`                          | Master-detail, stat cards, filtres                                                                          |
-| `seo.md`         | `app/(marketing)/**`, `app/robots.ts`, `app/sitemap.ts`          | Metadata, pages marketing                                                                                   |
+| `seo.md`         | `app/(marketing)/**`, `app/robots.ts`, `app/sitemap.ts`          | Metadata, pages marketing, claims éditoriaux                                                                |
 | `e2e-testing.md` | `e2e/**`, `playwright.config.ts`, `components/quiz/**`           | Playwright, data-testid, auth Better Auth, selectors                                                        |
 
 Ajouter les nouveaux patterns au fichier rules correspondant, pas ici.

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
@@ -356,8 +356,10 @@ export const TrainingConfigForm = ({
 
           {revisionFilters.length > 0 && (
             <p className="text-sm text-gray-500 dark:text-gray-400">
-              La session prendra jusqu&apos;à {questionCount} questions parmi
-              celles qui correspondent — moins s&apos;il y en a moins.
+              {/* Phrase en littéral : en texte JSX, la coupure de ligne après
+                  l'interpolation supprime l'espace au rendu Turbopack (« 20questions »),
+                  et Prettier réécrit le {" "} qui la corrigerait. */}
+              {`La session prendra jusqu'à ${questionCount} questions parmi celles qui correspondent — moins s'il y en a moins.`}
             </p>
           )}
         </div>

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
@@ -85,14 +85,17 @@ export const TrainingConfigForm = ({
 
   // Clé stable : `selectedObjectifs` change d'identité à chaque `setState`, et
   // chaque exécution coûte un balayage complet de la banque de questions.
-  const objectifsKey = selectedObjectifs.join("|")
+  // Sérialisation JSON et non `join("|")` : un objectif CMC est un champ libre
+  // côté admin, un `|` dedans découperait la liste au mauvais endroit.
+  const objectifsKey = JSON.stringify(selectedObjectifs)
 
   useEffect(() => {
     startCountsLoad(async () => {
       try {
+        const objectifsCMCs = JSON.parse(objectifsKey) as string[]
         const counts = await loadRevisionCounts({
           domain: selectedDomain === "all" ? undefined : selectedDomain,
-          objectifsCMCs: objectifsKey ? objectifsKey.split("|") : undefined,
+          objectifsCMCs: objectifsCMCs.length > 0 ? objectifsCMCs : undefined,
         })
         setRevisionCounts(counts)
       } catch {

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx
@@ -21,7 +21,14 @@ import { Spinner } from "@/components/ui/spinner"
 import {
   createTrainingSession,
   loadAvailableObjectifsCMC,
+  loadRevisionCounts,
 } from "@/features/training/actions"
+import {
+  REVISION_CRITERIA,
+  REVISION_CRITERION_LABELS,
+  type RevisionCriterion,
+} from "@/features/training/schemas"
+import { callAction } from "@/lib/safe-action"
 import { cn } from "@/lib/utils"
 import { ObjectifsCMCMultiSelect } from "./objectifs-cmc-multi-select"
 
@@ -43,6 +50,13 @@ export const TrainingConfigForm = ({
   const [selectedDomain, setSelectedDomain] = useState<string>("all")
   const [selectedObjectifs, setSelectedObjectifs] = useState<string[]>([])
   const [trainingMode, setTrainingMode] = useState<"tutor" | "test">("test")
+  const [revisionFilters, setRevisionFilters] = useState<RevisionCriterion[]>(
+    [],
+  )
+  const [revisionCounts, setRevisionCounts] = useState<
+    Record<RevisionCriterion, number>
+  >({ failed: 0, unseen: 0, bookmarked: 0 })
+  const [isCountsLoading, startCountsLoad] = useTransition()
 
   // Objectifs filtrés par domaine via Server Action (remplace useQuery réactif).
   // Initialisés avec la prop (tous domaines = état initial). setState seulement
@@ -69,6 +83,35 @@ export const TrainingConfigForm = ({
     })
   }, [selectedDomain])
 
+  // Clé stable : `selectedObjectifs` change d'identité à chaque `setState`, et
+  // chaque exécution coûte un balayage complet de la banque de questions.
+  const objectifsKey = selectedObjectifs.join("|")
+
+  useEffect(() => {
+    startCountsLoad(async () => {
+      try {
+        const counts = await loadRevisionCounts({
+          domain: selectedDomain === "all" ? undefined : selectedDomain,
+          objectifsCMCs: objectifsKey ? objectifsKey.split("|") : undefined,
+        })
+        setRevisionCounts(counts)
+      } catch {
+        // Sans ça, les puces resteraient à 0 en silence — l'étudiant croirait
+        // n'avoir aucun historique.
+        toast.error(
+          "Impossible de charger vos compteurs de révision. Vérifiez votre réseau.",
+        )
+      }
+    })
+  }, [selectedDomain, objectifsKey])
+
+  const toggleRevisionFilter = (criterion: RevisionCriterion) =>
+    setRevisionFilters((current) =>
+      current.includes(criterion)
+        ? current.filter((c) => c !== criterion)
+        : [...current, criterion],
+    )
+
   const selectedDomainQuestions =
     selectedDomain === "all"
       ? totalQuestions
@@ -94,31 +137,32 @@ export const TrainingConfigForm = ({
   const [, submitAction, isPending] = useActionState(async () => {
     if (!isValidCount) return null
 
-    try {
-      const result = await createTrainingSession({
+    // `callAction` ne throw jamais : un rejet réseau devient `success: false` au
+    // lieu de contourner le garde ci-dessous.
+    const result = await callAction(() =>
+      createTrainingSession({
         questionCount,
         domain: selectedDomain === "all" ? undefined : selectedDomain,
         objectifsCMCs:
           selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
         mode: trainingMode,
-      })
+        revisionFilters:
+          revisionFilters.length > 0 ? revisionFilters : undefined,
+      }),
+    )
 
-      if (!result.success) {
-        toast.error("Erreur", { description: result.error })
-        return null
-      }
-
-      toast.success("Session créée !", {
-        description: `${questionCount} questions sélectionnées`,
-      })
-
-      router.push(`/tableau-de-bord/entrainement/${result.sessionId}`)
-    } catch (error) {
-      toast.error("Erreur", {
-        description:
-          error instanceof Error ? error.message : "Une erreur est survenue",
-      })
+    if (!result.success) {
+      toast.error("Erreur", { description: result.error })
+      return null
     }
+
+    // Le nombre annoncé est celui RETENU par le serveur : en révision, le corpus
+    // peut être plus court que la demande.
+    toast.success("Session créée !", {
+      description: `${result.questionCount} questions sélectionnées`,
+    })
+
+    router.push(`/tableau-de-bord/entrainement/${result.sessionId}`)
 
     return null
   }, null)
@@ -272,6 +316,49 @@ export const TrainingConfigForm = ({
               {availableQuestions} question{availableQuestions > 1 ? "s" : ""}{" "}
               disponible{availableQuestions > 1 ? "s" : ""} pour ces objectifs
             </motion.p>
+          )}
+        </div>
+
+        {/* Filtres de révision */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Target className="h-4 w-4 text-gray-500" />
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Réviser (optionnel)
+            </label>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {REVISION_CRITERIA.map((criterion) => {
+              const isActive = revisionFilters.includes(criterion)
+              return (
+                <button
+                  key={criterion}
+                  type="button"
+                  data-testid={`revision-${criterion}`}
+                  aria-pressed={isActive}
+                  onClick={() => toggleRevisionFilter(criterion)}
+                  className={cn(
+                    "flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                    isActive
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:border-emerald-600 dark:bg-emerald-900/20 dark:text-emerald-300"
+                      : "border-gray-200 bg-white/60 text-gray-700 hover:border-emerald-300 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-300",
+                  )}
+                >
+                  <span>{REVISION_CRITERION_LABELS[criterion]}</span>
+                  <span className="rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                    {isCountsLoading ? "…" : revisionCounts[criterion]}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+
+          {revisionFilters.length > 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              La session prendra jusqu&apos;à {questionCount} questions parmi
+              celles qui correspondent — moins s&apos;il y en a moins.
+            </p>
           )}
         </div>
 

--- a/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx
+++ b/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button"
 import {
   completeTrainingSession,
   saveTrainingAnswer,
+  setQuestionBookmark,
 } from "@/features/training/actions"
 import type { TrainingSessionView } from "@/features/training/dal"
 import { callAction } from "@/lib/safe-action"
@@ -131,8 +132,17 @@ export const TrainingSessionClient = ({
           : undefined,
       }
     },
-    // Flags d'entraînement restent locaux — no-op serveur
-    onFlag: async () => ({ ok: true }),
+    onFlag: async (questionId, isFlagged) => {
+      const res = await callAction(
+        () => setQuestionBookmark({ questionId, isBookmarked: isFlagged }),
+        { retries: 1 }, // état voulu (pas une bascule) → reprise sans effet de bord
+      )
+      if (!res.success) {
+        toast.error("Marquage non enregistré, réessayez.")
+        return { ok: false }
+      }
+      return { ok: true }
+    },
     onFinish: async () => {
       const res = await callAction(() => completeTrainingSession({ sessionId }))
       if (!res.success) {
@@ -152,6 +162,7 @@ export const TrainingSessionClient = ({
     <QuizRunner
       questions={mappedQuestions}
       initialAnswers={initialAnswers}
+      initialFlags={new Set(initialData.bookmarkedIds)}
       initialRevealed={initialRevealed}
       mode={mode}
       callbacks={callbacks}

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth"
 export * from "./enums"
 export * from "./questions"
+export * from "./revision"
 export * from "./exams"
 export * from "./training"
 export * from "./payments"

--- a/db/schema/revision.ts
+++ b/db/schema/revision.ts
@@ -1,0 +1,36 @@
+import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core"
+import { createId } from "@/lib/ids"
+import { user } from "./auth"
+import { questions } from "./questions"
+
+// Signet durable (utilisateur × question), indépendant des sessions : alimente
+// le critère « marquées » du corpus de révision.
+//
+// `onDelete: cascade` sur `question_id`, à rebours des autres FK vers
+// `questions` (toutes en `restrict`) : `deleteQuestion` TENTE le hard delete et
+// laisse Postgres arbitrer (23001 → repli en soft delete). En `restrict`, un
+// seul signet suffirait à transformer tout hard delete en soft delete.
+export const questionBookmarks = pgTable(
+  "question_bookmarks",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    questionId: text("question_id")
+      .notNull()
+      .references(() => questions.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => [
+    unique("question_bookmarks_user_question_unique").on(
+      t.userId,
+      t.questionId,
+    ),
+    index("question_bookmarks_user_id_idx").on(t.userId),
+  ],
+)

--- a/docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md
+++ b/docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md
@@ -1,0 +1,1974 @@
+# Révision ciblée en entraînement (P1-A) — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettre à un étudiant de composer une session d'entraînement à partir de son propre historique — questions ratées, jamais vues, ou marquées — sans jamais divulguer la correction d'un examen encore ouvert.
+
+**Architecture:** Une table neuve `question_bookmarks` (signet durable utilisateur × question) ; un module `features/training/revision.ts` qui calcule le corpus de révision à la volée en une requête SQL (union des historiques entraînement + examens, `DISTINCT ON` pour la dernière tentative) ; `createTrainingSession` accepte un filtre de révision et **borne** le nombre demandé au corpus au lieu de refuser. Le verrou anti-triche des examens ouverts, aujourd'hui appliqué à la révélation, est étendu à la **sélection** du corpus et aux **compteurs**.
+
+**Tech Stack:** Next.js 16 (App Router), Drizzle ORM + Neon Postgres, zod v4, Vitest (happy-dom + intégration Neon éphémère), Tailwind v4 / shadcn.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md`
+
+---
+
+## Structure des fichiers
+
+| Fichier                                   | Responsabilité                                                       |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| `db/schema/revision.ts` (créer)           | Table `question_bookmarks` (accueillera les notes de P1-B)           |
+| `db/schema/index.ts` (modifier)           | Ré-export du nouveau module                                          |
+| `features/exams/dal.shared.ts` (modifier) | Source **unique** du verrou : jeu complet + restriction dérivée      |
+| `features/training/revision.ts` (créer)   | Corpus de révision : compteurs + tirage (server-only)                |
+| `features/training/schemas.ts` (modifier) | Critères de révision, schéma du signet, `MIN_QUESTIONS` conditionnel |
+| `features/training/actions.ts` (modifier) | `setQuestionBookmark`, `loadRevisionCounts`, `createTrainingSession` |
+| `features/training/dal.ts` (modifier)     | `getBookmarkedQuestionIds` + `bookmarkedIds` sur la vue de session   |
+| `training-config-form.tsx` (modifier)     | Puces « Réviser » + compteurs                                        |
+| `training-session-client.tsx` (modifier)  | Marquage persistant (fin du no-op `onFlag`)                          |
+
+**Ordre imposé.** Les tâches 4 et 5 se suivent : la 4 construit le corpus **sans** le verrou, la 5 l'ajoute en test-first. Rien n'est exposé entre les deux (aucun appelant avant la tâche 6), mais **elles doivent atterrir dans la même PR** — la 4 seule serait un trou anti-triche.
+
+---
+
+### Task 1: Table `question_bookmarks`
+
+**Files:**
+
+- Create: `db/schema/revision.ts`
+- Modify: `db/schema/index.ts`
+- Test: `tests/integration/question-bookmarks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Créer `tests/integration/question-bookmarks.test.ts` :
+
+```ts
+import { eq, inArray } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { questionBookmarks, questions, user } from "@/db/schema"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const DOMAIN = `QB-${suffix}`
+const qIds = Array.from({ length: 3 }, () => createId())
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: "IT bookmarks",
+    email: `qb-${suffix}@test.invalid`,
+  })
+  await db.insert(questions).values(
+    qIds.map((id, i) => ({
+      id,
+      question: `QB Q${i} ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj QB ${suffix}`,
+      domain: DOMAIN,
+    })),
+  )
+})
+
+afterAll(async () => {
+  await db
+    .delete(questionBookmarks)
+    .where(eq(questionBookmarks.userId, USER_ID))
+  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("table question_bookmarks", () => {
+  it("refuse un doublon (utilisateur, question)", async () => {
+    await db
+      .insert(questionBookmarks)
+      .values({ userId: USER_ID, questionId: qIds[0] })
+
+    await expect(
+      db.insert(questionBookmarks).values({
+        userId: USER_ID,
+        questionId: qIds[0],
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("la suppression d'une question emporte ses signets (cascade)", async () => {
+    const doomedQuestionId = createId()
+    await db.insert(questions).values({
+      id: doomedQuestionId,
+      question: `QB doomed ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj QB ${suffix}`,
+      domain: DOMAIN,
+    })
+    await db
+      .insert(questionBookmarks)
+      .values({ userId: USER_ID, questionId: doomedQuestionId })
+
+    await db.delete(questions).where(eq(questions.id, doomedQuestionId))
+
+    const rows = await db
+      .select({ id: questionBookmarks.id })
+      .from(questionBookmarks)
+      .where(eq(questionBookmarks.questionId, doomedQuestionId))
+    expect(rows).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- -t "table question_bookmarks"`
+Expected: FAIL — `questionBookmarks` n'est pas exporté de `@/db/schema` (erreur TypeScript / `undefined`).
+
+- [ ] **Step 3: Create the schema module**
+
+Créer `db/schema/revision.ts` :
+
+```ts
+import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core"
+import { createId } from "@/lib/ids"
+import { user } from "./auth"
+import { questions } from "./questions"
+
+// Signet durable (utilisateur × question), indépendant des sessions : alimente
+// le critère « marquées » du corpus de révision.
+//
+// `onDelete: cascade` sur `question_id`, à rebours des autres FK vers
+// `questions` (toutes en `restrict`) : `deleteQuestion` TENTE le hard delete et
+// laisse Postgres arbitrer (23001 → repli en soft delete). En `restrict`, un
+// seul signet suffirait à transformer tout hard delete en soft delete.
+export const questionBookmarks = pgTable(
+  "question_bookmarks",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    questionId: text("question_id")
+      .notNull()
+      .references(() => questions.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => [
+    unique("question_bookmarks_user_question_unique").on(
+      t.userId,
+      t.questionId,
+    ),
+    index("question_bookmarks_user_id_idx").on(t.userId),
+  ],
+)
+```
+
+Modifier `db/schema/index.ts` — ajouter la ligne après `export * from "./questions"` :
+
+```ts
+export * from "./revision"
+```
+
+- [ ] **Step 4: Generate and apply the migration**
+
+Run: `bun run db:generate`
+Expected: un nouveau fichier `drizzle/NNNN_*.sql` créé, contenant `CREATE TABLE "question_bookmarks"` avec la contrainte unique et les deux FK.
+
+Run: `bun run db:migrate`
+Expected: `migrations applied` sans erreur.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun run test:integration -- -t "table question_bookmarks"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/schema/revision.ts db/schema/index.ts drizzle tests/integration/question-bookmarks.test.ts
+git commit -m "feat(revision): table question_bookmarks (signet durable utilisateur x question)"
+```
+
+---
+
+### Task 2: Source unique du verrou anti-triche
+
+Le corpus de révision doit exclure les questions verrouillées **avant** le tirage, donc sans liste de candidats à narrower. Plutôt que d'écrire une deuxième requête (deux définitions de la règle = exactement ce que la spec interdit), on extrait le jeu complet et `getOpenExamLockedQuestionIds` en devient une restriction.
+
+**Files:**
+
+- Modify: `features/exams/dal.shared.ts`
+- Test: `tests/integration/exam-lock-source.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Créer `tests/integration/exam-lock-source.test.ts` (fixtures autonomes — ce test ne doit dépendre d'aucun autre fichier) :
+
+```ts
+import { eq, inArray } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import {
+  examParticipations,
+  examQuestions,
+  exams,
+  questions,
+  user,
+} from "@/db/schema"
+import {
+  getOpenExamLockedQuestionIds,
+  getUserOpenExamLockedQuestionIds,
+} from "@/features/exams/dal.shared"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const OPEN_EXAM_ID = createId()
+const CLOSED_EXAM_ID = createId()
+// 0-1 = examen ouvert · 2 = examen clos · 3 = hors examen
+const qIds = Array.from({ length: 4 }, () => createId())
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: "IT verrou",
+    email: `lock-${suffix}@test.invalid`,
+  })
+  await db.insert(questions).values(
+    qIds.map((id, i) => ({
+      id,
+      question: `LOCK Q${i} ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj LOCK ${suffix}`,
+      domain: `LOCK-${suffix}`,
+    })),
+  )
+  await db.insert(exams).values([
+    {
+      id: OPEN_EXAM_ID,
+      title: `LOCK ouvert ${suffix}`,
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2099-01-01T00:00:00Z"),
+      completionTime: 3600,
+      createdBy: USER_ID,
+    },
+    {
+      id: CLOSED_EXAM_ID,
+      title: `LOCK clos ${suffix}`,
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-02T00:00:00Z"),
+      completionTime: 3600,
+      createdBy: USER_ID,
+    },
+  ])
+  await db.insert(examQuestions).values([
+    { examId: OPEN_EXAM_ID, questionId: qIds[0], position: 0 },
+    { examId: OPEN_EXAM_ID, questionId: qIds[1], position: 1 },
+    { examId: CLOSED_EXAM_ID, questionId: qIds[2], position: 0 },
+  ])
+  await db.insert(examParticipations).values([
+    {
+      id: createId(),
+      examId: OPEN_EXAM_ID,
+      userId: USER_ID,
+      status: "in_progress",
+      startedAt: new Date("2026-01-01T01:00:00Z"),
+    },
+    {
+      id: createId(),
+      examId: CLOSED_EXAM_ID,
+      userId: USER_ID,
+      status: "completed",
+      startedAt: new Date("2026-01-01T01:00:00Z"),
+    },
+  ])
+})
+
+afterAll(async () => {
+  await db
+    .delete(examParticipations)
+    .where(inArray(examParticipations.examId, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db
+    .delete(examQuestions)
+    .where(inArray(examQuestions.examId, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db
+    .delete(exams)
+    .where(inArray(exams.id, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("verrou anti-triche — source unique", () => {
+  it("le jeu complet ne dépend d'aucune liste de candidats", async () => {
+    const all = await getUserOpenExamLockedQuestionIds(USER_ID)
+
+    expect(all.has(qIds[0])).toBe(true)
+    expect(all.has(qIds[1])).toBe(true)
+    expect(all.has(qIds[2])).toBe(false) // examen clos
+    expect(all.has(qIds[3])).toBe(false) // hors examen
+  })
+
+  it("la version restreinte est un sous-ensemble du jeu complet", async () => {
+    const all = await getUserOpenExamLockedQuestionIds(USER_ID)
+    const narrowed = await getOpenExamLockedQuestionIds(USER_ID, [
+      qIds[0],
+      qIds[3],
+    ])
+
+    expect([...narrowed]).toEqual([qIds[0]])
+    for (const id of narrowed) expect(all.has(id)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- tests/integration/exam-lock-source.test.ts`
+Expected: FAIL — `getUserOpenExamLockedQuestionIds` n'est pas exporté de `dal.shared`.
+
+- [ ] **Step 3: Implement**
+
+Dans `features/exams/dal.shared.ts`, remplacer le corps de `getOpenExamLockedQuestionIds` par ceci (garder le commentaire de doc existant au-dessus de la fonction restreinte) :
+
+```ts
+/**
+ * TOUTES les questions verrouillées pour `userId` : celles d'un examen OUVERT
+ * (`endDate` future) où il a une participation, quel que soit son statut.
+ *
+ * Source unique de la règle. Le corpus de révision s'en sert pour exclure AVANT
+ * le tirage : l'appartenance d'une question au lot « mes ratées » est elle-même
+ * un oracle sur les réponses de l'examen en cours, même sans voir la clé.
+ * Borné par les examens auxquels l'utilisateur participe.
+ */
+export const getUserOpenExamLockedQuestionIds = async (
+  userId: string,
+): Promise<Set<string>> => {
+  const rows = await db
+    .selectDistinct({ questionId: examQuestions.questionId })
+    .from(examQuestions)
+    .innerJoin(exams, eq(exams.id, examQuestions.examId))
+    .innerJoin(
+      examParticipations,
+      eq(examParticipations.examId, examQuestions.examId),
+    )
+    .where(
+      and(eq(examParticipations.userId, userId), gt(exams.endDate, new Date())),
+    )
+  return new Set(rows.map((r) => r.questionId))
+}
+
+export const getOpenExamLockedQuestionIds = async (
+  userId: string,
+  questionIds: string[],
+): Promise<Set<string>> => {
+  if (questionIds.length === 0) return new Set()
+  const locked = await getUserOpenExamLockedQuestionIds(userId)
+  return new Set(questionIds.filter((id) => locked.has(id)))
+}
+```
+
+`inArray` peut devenir un import inutilisé dans ce fichier — le retirer si `bun run lint` le signale.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test:integration -- tests/integration/exam-lock-source.test.ts tests/integration/passation-anti-cheat.test.ts tests/integration/exam-runner.test.ts`
+Expected: PASS — le nouveau fichier **et** les suites existantes qui exercent la restriction (ce sont elles qui prouvent que son comportement n'a pas bougé).
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/exams/dal.shared.ts tests/integration/exam-lock-source.test.ts
+git commit -m "refactor(exams): verrou anti-triche - jeu complet comme source unique"
+```
+
+---
+
+### Task 3: Signet — action idempotente et lecture
+
+`setQuestionBookmark` prend l'**état voulu**, pas une bascule : `callAction` peut la retenter sans inverser deux fois (une bascule retentée annulerait le marquage).
+
+**Files:**
+
+- Modify: `features/training/schemas.ts`
+- Modify: `features/training/actions.ts`
+- Modify: `features/training/dal.ts`
+- Test: `tests/integration/question-bookmarks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Ajouter à `tests/integration/question-bookmarks.test.ts` — compléter les imports en tête :
+
+```ts
+import { setQuestionBookmark } from "@/features/training/actions"
+import { getBookmarkedQuestionIds } from "@/features/training/dal"
+import { getCurrentSession } from "@/lib/dal"
+```
+
+et le mock (à côté des autres `vi.mock`) :
+
+```ts
+vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
+```
+
+puis, dans `beforeAll`, après l'insertion des questions :
+
+```ts
+vi.mocked(getCurrentSession).mockResolvedValue({
+  user: { id: USER_ID, role: "admin" },
+} as never)
+```
+
+et le nouveau bloc de tests :
+
+```ts
+describe("setQuestionBookmark", () => {
+  it("pose le signet, puis le retire", async () => {
+    const posed = await setQuestionBookmark({
+      questionId: qIds[1],
+      isBookmarked: true,
+    })
+    expect(posed.success).toBe(true)
+    expect(await getBookmarkedQuestionIds([qIds[1]])).toEqual([qIds[1]])
+
+    const removed = await setQuestionBookmark({
+      questionId: qIds[1],
+      isBookmarked: false,
+    })
+    expect(removed.success).toBe(true)
+    expect(await getBookmarkedQuestionIds([qIds[1]])).toEqual([])
+  })
+
+  it("est idempotente : deux poses successives ne cassent rien", async () => {
+    await setQuestionBookmark({ questionId: qIds[2], isBookmarked: true })
+    const again = await setQuestionBookmark({
+      questionId: qIds[2],
+      isBookmarked: true,
+    })
+    expect(again.success).toBe(true)
+    expect(await getBookmarkedQuestionIds([qIds[2]])).toEqual([qIds[2]])
+  })
+
+  it("refuse proprement une question inexistante", async () => {
+    const res = await setQuestionBookmark({
+      questionId: "question-qui-n-existe-pas",
+      isBookmarked: true,
+    })
+    expect(res.success).toBe(false)
+    expect(res.error).toBe("Question introuvable.")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- -t "setQuestionBookmark"`
+Expected: FAIL — `setQuestionBookmark` et `getBookmarkedQuestionIds` n'existent pas.
+
+- [ ] **Step 3: Add the schema**
+
+Dans `features/training/schemas.ts`, à la fin du fichier :
+
+```ts
+export const setQuestionBookmarkSchema = z.object({
+  questionId: z.string().min(1),
+  isBookmarked: z.boolean(),
+})
+export type SetQuestionBookmarkInput = z.infer<typeof setQuestionBookmarkSchema>
+```
+
+- [ ] **Step 4: Add the DAL read**
+
+Dans `features/training/dal.ts` — ajouter `questionBookmarks` à l'import depuis `@/db/schema`, puis, après `getTrainingStats` :
+
+```ts
+/**
+ * Signets de **l'utilisateur courant** parmi `questionIds`. Un admin qui
+ * consulte la session d'un étudiant voit donc ses propres signets, pas ceux de
+ * l'étudiant : c'est un état personnel, pas une donnée de la session.
+ */
+export const getBookmarkedQuestionIds = async (
+  questionIds: string[],
+): Promise<string[]> => {
+  const session = await getCurrentSession()
+  if (!session?.user || questionIds.length === 0) return []
+
+  const rows = await db
+    .select({ questionId: questionBookmarks.questionId })
+    .from(questionBookmarks)
+    .where(
+      and(
+        eq(questionBookmarks.userId, session.user.id),
+        inArray(questionBookmarks.questionId, questionIds),
+      ),
+    )
+  return rows.map((r) => r.questionId)
+}
+```
+
+- [ ] **Step 5: Add the action**
+
+Dans `features/training/actions.ts` — ajouter `questionBookmarks` à l'import `@/db/schema`, `getPgErrorCode` à un nouvel import `@/lib/db-errors`, et les types du schéma ; puis, après `saveTrainingAnswer` :
+
+```ts
+/**
+ * [Auth] Pose ou retire le signet de révision d'une question. Idempotente :
+ * l'état voulu est passé en entrée (pas une bascule), donc une reprise réseau
+ * de `callAction` ne l'inverse pas. Aucun `revalidatePath` : l'état vit dans le
+ * runner côté client.
+ */
+export const setQuestionBookmark = async (
+  input: SetQuestionBookmarkInput,
+): Promise<{ success: boolean; error?: string }> => {
+  const session = await requireSession()
+  const parsed = setQuestionBookmarkSchema.safeParse(input)
+  if (!parsed.success) {
+    return fail(parsed.error.issues[0]?.message ?? "Données invalides")
+  }
+  const { questionId, isBookmarked } = parsed.data
+  const userId = session.user.id
+
+  try {
+    if (isBookmarked) {
+      await db
+        .insert(questionBookmarks)
+        .values({ userId, questionId })
+        .onConflictDoNothing()
+    } else {
+      await db
+        .delete(questionBookmarks)
+        .where(
+          and(
+            eq(questionBookmarks.userId, userId),
+            eq(questionBookmarks.questionId, questionId),
+          ),
+        )
+    }
+    return { success: true }
+  } catch (error) {
+    // 23503 = FK violation : le client a envoyé un identifiant de question qui
+    // n'existe pas. Erreur métier mappée → pas de capture Sentry.
+    if (getPgErrorCode(error) === "23503") return fail("Question introuvable.")
+    captureServerError("[setQuestionBookmark]", error, { userId })
+    return fail("Erreur serveur. Réessayez.")
+  }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun run test:integration -- tests/integration/question-bookmarks.test.ts`
+Expected: PASS (5 tests).
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add features/training/schemas.ts features/training/actions.ts features/training/dal.ts tests/integration/question-bookmarks.test.ts
+git commit -m "feat(revision): setQuestionBookmark idempotente + lecture des signets"
+```
+
+---
+
+### Task 4: Corpus de révision — compteurs et tirage
+
+Le calcul vit dans **une** requête SQL brute par usage. C'est une entorse assumée au tout-query-builder du projet : l'union des deux historiques suivie d'un `DISTINCT ON` n'est pas exprimable proprement avec le builder, et une sous-requête `.as()` mono-table y déqualifie silencieusement ses colonnes (piège déjà rencontré sur ce repo). Tous les fragments restent **paramétrés** via le template `sql` — aucun `sql.raw`, jamais de valeur client concaténée.
+
+**Files:**
+
+- Create: `features/training/revision.ts`
+- Modify: `features/training/schemas.ts`
+- Test: `tests/integration/revision-corpus.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Créer `tests/integration/revision-corpus.test.ts` :
+
+```ts
+import { eq, inArray } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import {
+  questionBookmarks,
+  questions,
+  trainingSessionItems,
+  trainingSessions,
+  user,
+} from "@/db/schema"
+import {
+  getRevisionCounts,
+  pickRevisionQuestionIds,
+} from "@/features/training/revision"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const OTHER_USER_ID = createId()
+const DOMAIN = `RC-${suffix}`
+const OBJ = `Obj RC ${suffix}`
+
+// 0 = ratée · 1 = ratée puis réussie · 2 = réussie · 3 = marquée (jamais vue)
+// 4 = jamais vue · 5 = ratée par l'AUTRE utilisateur
+const qIds = Array.from({ length: 6 }, () => createId())
+const SESSION_ID = createId()
+const OTHER_SESSION_ID = createId()
+
+const seedSession = async (
+  sessionId: string,
+  userId: string,
+  items: { questionId: string; isCorrect: boolean; answeredAt: Date }[],
+) => {
+  await db.insert(trainingSessions).values({
+    id: sessionId,
+    userId,
+    status: "completed",
+    mode: "test",
+    questionCount: items.length,
+    startedAt: new Date("2026-01-01T00:00:00Z"),
+    expiresAt: new Date("2026-01-02T00:00:00Z"),
+  })
+  await db.insert(trainingSessionItems).values(
+    items.map((it, position) => ({
+      sessionId,
+      questionId: it.questionId,
+      position,
+      selectedAnswer: it.isCorrect ? "A" : "B",
+      isCorrect: it.isCorrect,
+      answeredAt: it.answeredAt,
+    })),
+  )
+}
+
+beforeAll(async () => {
+  await db.insert(user).values([
+    { id: USER_ID, name: "IT revision", email: `rc-${suffix}@test.invalid` },
+    {
+      id: OTHER_USER_ID,
+      name: "IT revision autre",
+      email: `rc-other-${suffix}@test.invalid`,
+    },
+  ])
+  await db.insert(questions).values(
+    qIds.map((id, i) => ({
+      id,
+      question: `RC Q${i} ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: OBJ,
+      domain: DOMAIN,
+    })),
+  )
+
+  await seedSession(SESSION_ID, USER_ID, [
+    {
+      questionId: qIds[0],
+      isCorrect: false,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+    {
+      questionId: qIds[1],
+      isCorrect: false,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+    {
+      questionId: qIds[2],
+      isCorrect: true,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+  ])
+  // Reprise plus tardive de q1 : réussie → elle doit SORTIR des ratées.
+  await seedSession(createId(), USER_ID, [
+    {
+      questionId: qIds[1],
+      isCorrect: true,
+      answeredAt: new Date("2026-01-05T10:00:00Z"),
+    },
+  ])
+  await seedSession(OTHER_SESSION_ID, OTHER_USER_ID, [
+    {
+      questionId: qIds[5],
+      isCorrect: false,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+  ])
+
+  await db
+    .insert(questionBookmarks)
+    .values({ userId: USER_ID, questionId: qIds[3] })
+})
+
+afterAll(async () => {
+  await db
+    .delete(questionBookmarks)
+    .where(eq(questionBookmarks.userId, USER_ID))
+  await db
+    .delete(trainingSessions)
+    .where(inArray(trainingSessions.userId, [USER_ID, OTHER_USER_ID]))
+  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db.delete(user).where(inArray(user.id, [USER_ID, OTHER_USER_ID]))
+})
+
+describe("corpus de révision", () => {
+  it("« ratée » = dernière tentative fausse (une réussite ultérieure la retire)", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).toEqual([qIds[0]])
+  })
+
+  it("« non vue » = jamais répondue", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect([...ids].sort()).toEqual([qIds[3], qIds[4], qIds[5]].sort())
+  })
+
+  it("les critères s'unissent en OU", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed", "bookmarked"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect([...ids].sort()).toEqual([qIds[0], qIds[3]].sort())
+  })
+
+  it("borne le tirage à la limite demandée", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      limit: 2,
+    })
+    expect(ids).toHaveLength(2)
+  })
+
+  it("n'emprunte jamais l'historique d'un autre étudiant", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).not.toContain(qIds[5])
+  })
+
+  it("les compteurs décrivent le même corpus que le tirage", async () => {
+    const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+    expect(counts).toEqual({ failed: 1, unseen: 3, bookmarked: 1 })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- tests/integration/revision-corpus.test.ts`
+Expected: FAIL — le module `@/features/training/revision` n'existe pas.
+
+- [ ] **Step 3: Add the criteria to the schema module**
+
+Dans `features/training/schemas.ts`, avant `createTrainingSessionSchema` :
+
+```ts
+export const REVISION_CRITERIA = ["failed", "unseen", "bookmarked"] as const
+export type RevisionCriterion = (typeof REVISION_CRITERIA)[number]
+export const revisionCriterionSchema = z.enum(REVISION_CRITERIA)
+
+export const REVISION_CRITERION_LABELS: Record<RevisionCriterion, string> = {
+  failed: "Ratées",
+  unseen: "Non vues",
+  bookmarked: "Marquées",
+}
+```
+
+- [ ] **Step 4: Implement the corpus module**
+
+Créer `features/training/revision.ts` :
+
+```ts
+import { type SQL, sql } from "drizzle-orm"
+import "server-only"
+import type { Db } from "@/db"
+import { db } from "@/db"
+import type { RevisionCriterion } from "./schemas"
+
+// `db` ou une transaction : le tirage doit pouvoir vivre dans la transaction
+// qui insère la session.
+type Executor = Pick<Db, "execute">
+
+export type RevisionCounts = Record<RevisionCriterion, number>
+
+export type RevisionScope = {
+  userId: string
+  domain?: string
+  objectifsCMCs?: string[]
+}
+
+// Historique unifié entraînement + examens de l'utilisateur, réduit à sa
+// DERNIÈRE tentative par question. `exam_answers.created_at` vaut « début de la
+// tentative » (les lignes sont pré-créées au démarrage de l'examen) : sans
+// conséquence, les réponses d'un même examen sont simultanées par nature.
+const historyCte = (userId: string): SQL => sql`
+  attempts as (
+    select i.question_id, i.is_correct, i.answered_at as at
+      from training_session_items i
+      join training_sessions s on s.id = i.session_id
+     where s.user_id = ${userId} and i.selected_answer is not null
+    union all
+    select a.question_id, a.is_correct, a.created_at as at
+      from exam_answers a
+      join exam_participations p on p.id = a.participation_id
+     where p.user_id = ${userId} and a.selected_answer is not null
+  ),
+  last_attempt as (
+    select distinct on (question_id) question_id, is_correct
+      from attempts
+     order by question_id, at desc
+  ),
+  marked as (
+    select question_id from question_bookmarks where user_id = ${userId}
+    union
+    select a.question_id
+      from exam_answers a
+      join exam_participations p on p.id = a.participation_id
+     where p.user_id = ${userId} and a.is_flagged
+  )
+`
+
+// Le marquage se lit hors agrégat : une question marquée mais jamais répondue
+// compte comme marquée.
+const CRITERION_PREDICATE: Record<RevisionCriterion, SQL> = {
+  failed: sql`q.id in (select question_id from last_attempt where is_correct = false)`,
+  bookmarked: sql`q.id in (select question_id from marked)`,
+  unseen: sql`not exists (select 1 from attempts a2 where a2.question_id = q.id)`,
+}
+
+const corpusWhere = ({ domain, objectifsCMCs }: RevisionScope): SQL => {
+  const parts: SQL[] = [sql`q.deleted_at is null`]
+  if (domain && domain !== "all") parts.push(sql`q.domain = ${domain}`)
+
+  const objectifs =
+    objectifsCMCs?.map((o) => o.trim().toLowerCase()).filter(Boolean) ?? []
+  if (objectifs.length > 0) {
+    parts.push(
+      sql`lower(q.objectif_cmc) in (${sql.join(
+        objectifs.map((o) => sql`${o}`),
+        sql`, `,
+      )})`,
+    )
+  }
+  return sql.join(parts, sql` and `)
+}
+
+/** Compteur par critère, sur le corpus filtré (domaine + objectifs). */
+export const getRevisionCounts = async (
+  userId: string,
+  scope: Omit<RevisionScope, "userId"> = {},
+): Promise<RevisionCounts> => {
+  const res = await db.execute(sql`
+    with ${historyCte(userId)}
+    select
+      (count(*) filter (where ${CRITERION_PREDICATE.failed}))::int as failed,
+      (count(*) filter (where ${CRITERION_PREDICATE.unseen}))::int as unseen,
+      (count(*) filter (where ${CRITERION_PREDICATE.bookmarked}))::int as bookmarked
+      from questions q
+     where ${corpusWhere({ userId, ...scope })}
+  `)
+  // Le cast `::int` est indispensable : sans lui, `count(*)` remonte en bigint,
+  // que le driver pg rend en `string`.
+  const row = res.rows[0] as Partial<RevisionCounts> | undefined
+  return {
+    failed: Number(row?.failed ?? 0),
+    unseen: Number(row?.unseen ?? 0),
+    bookmarked: Number(row?.bookmarked ?? 0),
+  }
+}
+
+/**
+ * Tirage aléatoire dans le corpus de révision. Les critères s'unissent en OU,
+ * le tout intersecté avec domaine + objectifs. Renvoie moins que `limit` quand
+ * le corpus est plus court — l'appelant démarre avec ce qu'il obtient.
+ */
+export const pickRevisionQuestionIds = async (
+  exec: Executor,
+  {
+    criteria,
+    limit,
+    ...scope
+  }: RevisionScope & { criteria: RevisionCriterion[]; limit: number },
+): Promise<string[]> => {
+  const unique = [...new Set(criteria)]
+  if (unique.length === 0 || limit <= 0) return []
+
+  const anyCriterion = sql.join(
+    unique.map((c) => CRITERION_PREDICATE[c]),
+    sql` or `,
+  )
+  const res = await exec.execute(sql`
+    with ${historyCte(scope.userId)}
+    select q.id
+      from questions q
+     where ${corpusWhere(scope)} and (${anyCriterion})
+     order by random()
+     limit ${limit}
+  `)
+  return res.rows.map((r) => String(r.id))
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun run test:integration -- tests/integration/revision-corpus.test.ts`
+Expected: PASS (6 tests).
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/training/revision.ts features/training/schemas.ts tests/integration/revision-corpus.test.ts
+git commit -m "feat(revision): corpus de revision (compteurs + tirage) sur historique unifie"
+```
+
+---
+
+### Task 5: Anti-triche — exclusion à la sélection ET aux compteurs
+
+**C'est l'invariante centrale de la spec.** Sans elle, un filtre « mes ratées » dit à l'étudiant quelles réponses sont fausses pendant que son examen est encore ouvert — triche directe, sans jamais voir la clé.
+
+**Files:**
+
+- Modify: `features/training/revision.ts`
+- Test: `tests/integration/revision-corpus.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Compléter les imports de `tests/integration/revision-corpus.test.ts` :
+
+```ts
+import { examParticipations, examQuestions, exams } from "@/db/schema"
+```
+
+Déclarer l'identifiant au scope du module, à côté de `SESSION_ID` :
+
+```ts
+const OPEN_EXAM_ID = createId()
+```
+
+Dans `beforeAll`, après l'insertion du signet, monter un examen OUVERT contenant `qIds[0]` (la ratée) et `qIds[3]` (la marquée), avec une participation de `USER_ID`. `completionTime` est en **secondes** et `createdBy` est obligatoire (FK `restrict` vers `user`) :
+
+```ts
+await db.insert(exams).values({
+  id: OPEN_EXAM_ID,
+  title: `RC examen ouvert ${suffix}`,
+  startDate: new Date("2026-01-01T00:00:00Z"),
+  endDate: new Date("2099-01-01T00:00:00Z"),
+  completionTime: 3600,
+  createdBy: USER_ID,
+})
+await db.insert(examQuestions).values([
+  { examId: OPEN_EXAM_ID, questionId: qIds[0], position: 0 },
+  { examId: OPEN_EXAM_ID, questionId: qIds[3], position: 1 },
+])
+await db.insert(examParticipations).values({
+  id: createId(),
+  examId: OPEN_EXAM_ID,
+  userId: USER_ID,
+  status: "in_progress",
+  startedAt: new Date("2026-01-01T01:00:00Z"),
+})
+```
+
+Nettoyer dans `afterAll`, **avant** la suppression des questions (`exam_questions` les référence en `restrict`) et avant celle des utilisateurs (`exams.created_by` en `restrict`) :
+
+```ts
+await db
+  .delete(examParticipations)
+  .where(eq(examParticipations.examId, OPEN_EXAM_ID))
+await db.delete(examQuestions).where(eq(examQuestions.examId, OPEN_EXAM_ID))
+await db.delete(exams).where(eq(exams.id, OPEN_EXAM_ID))
+```
+
+Ajouter les deux tests :
+
+```ts
+describe("corpus de révision — verrou examen ouvert", () => {
+  it("exclut du TIRAGE les questions d'un examen ouvert où l'étudiant participe", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed", "bookmarked", "unseen"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).not.toContain(qIds[0])
+    expect(ids).not.toContain(qIds[3])
+  })
+
+  it("exclut aussi des COMPTEURS (sinon le compteur redevient l'oracle)", async () => {
+    const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+    expect(counts.failed).toBe(0)
+    expect(counts.bookmarked).toBe(0)
+  })
+})
+```
+
+Les tests de la tâche 4 restent valides : `qIds[1]`, `qIds[2]`, `qIds[4]`, `qIds[5]` ne sont pas dans l'examen. **Adapter les attentes des tests de la tâche 4** touchées par le verrou : `failed` attend désormais `[]`, `unseen` attend `[qIds[4], qIds[5]]`, l'union OU attend `[]`, et `getRevisionCounts` attend `{ failed: 0, unseen: 2, bookmarked: 0 }`. C'est le comportement voulu : la tâche 4 décrivait un monde sans examen ouvert.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- tests/integration/revision-corpus.test.ts`
+Expected: FAIL — le tirage contient encore `qIds[0]` et `qIds[3]`, `counts.failed` vaut 1.
+
+- [ ] **Step 3: Implement the exclusion**
+
+Dans `features/training/revision.ts` — importer le verrou :
+
+```ts
+import { getUserOpenExamLockedQuestionIds } from "../exams/dal.shared"
+```
+
+Étendre `corpusWhere` pour accepter les identifiants verrouillés :
+
+```ts
+const corpusWhere = (
+  { domain, objectifsCMCs }: RevisionScope,
+  lockedIds: string[],
+): SQL => {
+  const parts: SQL[] = [sql`q.deleted_at is null`]
+  if (domain && domain !== "all") parts.push(sql`q.domain = ${domain}`)
+
+  const objectifs =
+    objectifsCMCs?.map((o) => o.trim().toLowerCase()).filter(Boolean) ?? []
+  if (objectifs.length > 0) {
+    parts.push(
+      sql`lower(q.objectif_cmc) in (${sql.join(
+        objectifs.map((o) => sql`${o}`),
+        sql`, `,
+      )})`,
+    )
+  }
+
+  // Verrou anti-triche appliqué à la SÉLECTION, pas seulement à la révélation :
+  // l'appartenance d'une question au lot est elle-même un oracle sur les
+  // réponses d'un examen encore ouvert.
+  if (lockedIds.length > 0) {
+    parts.push(
+      sql`q.id not in (${sql.join(
+        lockedIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})`,
+    )
+  }
+  return sql.join(parts, sql` and `)
+}
+```
+
+Dans `getRevisionCounts`, avant la requête :
+
+```ts
+const lockedIds = [...(await getUserOpenExamLockedQuestionIds(userId))]
+```
+
+et passer `corpusWhere({ userId, ...scope }, lockedIds)`.
+
+Dans `pickRevisionQuestionIds`, avant la requête :
+
+```ts
+const lockedIds = [...(await getUserOpenExamLockedQuestionIds(scope.userId))]
+```
+
+et passer `corpusWhere(scope, lockedIds)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test:integration -- tests/integration/revision-corpus.test.ts`
+Expected: PASS (8 tests).
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/training/revision.ts tests/integration/revision-corpus.test.ts
+git commit -m "fix(revision): exclure les questions d'examen ouvert du tirage ET des compteurs"
+```
+
+---
+
+### Task 6: `createTrainingSession` accepte un filtre de révision
+
+Deux changements de règles quand un filtre est actif : le nombre demandé est **borné** au corpus (au lieu du refus `NOT_ENOUGH`) et `MIN_QUESTIONS` ne s'applique plus. L'action renvoie le nombre **réel** de questions retenues — sans quoi l'UI annoncerait 20 questions pour une session qui en compte 7.
+
+**Files:**
+
+- Modify: `features/training/schemas.ts`
+- Modify: `features/training/actions.ts`
+- Test: `tests/integration/revision-corpus.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Ajouter à `tests/integration/revision-corpus.test.ts` (importer `createTrainingSession` et `abandonTrainingSession` depuis `@/features/training/actions`, `getCurrentSession` depuis `@/lib/dal`, et ajouter les mocks `vi.mock("next/cache", …)` et `vi.mock("@/lib/dal", …)` en tête comme dans `training-mode.test.ts`) :
+
+```ts
+describe("createTrainingSession en révision", () => {
+  it("démarre avec un corpus plus court que demandé, sous MIN_QUESTIONS", async () => {
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: USER_ID, role: "admin" },
+    } as never)
+
+    const res = await createTrainingSession({
+      questionCount: 20,
+      domain: DOMAIN,
+      revisionFilters: ["unseen"],
+    })
+    expect(res.success).toBe(true)
+    if (!res.success) return
+
+    try {
+      expect(res.questionCount).toBe(2)
+      const items = await db
+        .select({ id: trainingSessionItems.id })
+        .from(trainingSessionItems)
+        .where(eq(trainingSessionItems.sessionId, res.sessionId))
+      expect(items).toHaveLength(2)
+    } finally {
+      await abandonTrainingSession({ sessionId: res.sessionId })
+    }
+  })
+
+  it("refuse explicitement un corpus vide", async () => {
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: USER_ID, role: "admin" },
+    } as never)
+
+    const res = await createTrainingSession({
+      questionCount: 10,
+      domain: DOMAIN,
+      revisionFilters: ["failed"],
+    })
+    expect(res.success).toBe(false)
+    if (res.success) return
+    expect(res.error).toContain("Aucune question")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- -t "createTrainingSession en révision"`
+Expected: FAIL — `revisionFilters` est rejeté par le schéma et `questionCount` n'existe pas sur la réponse.
+
+- [ ] **Step 3: Update the schema**
+
+Dans `features/training/schemas.ts`, remplacer `createTrainingSessionSchema` par :
+
+```ts
+export const createTrainingSessionSchema = z
+  .object({
+    questionCount: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_QUESTIONS, `Au plus ${MAX_QUESTIONS} questions`),
+    domain: z.string().trim().min(1).optional(),
+    objectifsCMCs: z.array(z.string().trim().min(1)).max(50).optional(),
+    mode: z.enum(["tutor", "test"]).optional().default("test"),
+    revisionFilters: z.array(revisionCriterionSchema).max(3).optional(),
+  })
+  // Le plancher de 5 questions n'a de sens que pour un tirage aléatoire : trois
+  // questions ratées font une session de révision légitime.
+  .superRefine((value, ctx) => {
+    const isRevision = (value.revisionFilters?.length ?? 0) > 0
+    if (!isRevision && value.questionCount < MIN_QUESTIONS) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Au moins ${MIN_QUESTIONS} questions`,
+        path: ["questionCount"],
+      })
+    }
+  })
+```
+
+- [ ] **Step 4: Update the action**
+
+Dans `features/training/actions.ts` :
+
+Importer le tirage :
+
+```ts
+import { pickRevisionQuestionIds } from "./revision"
+```
+
+Élargir le type de retour :
+
+```ts
+export type CreateTrainingSessionResult =
+  | { success: true; sessionId: string; questionCount: number }
+  | { success: false; error: string }
+```
+
+Après la destructuration de `parsed.data`, ajouter `revisionFilters` et le drapeau :
+
+```ts
+const { questionCount, domain, objectifsCMCs, mode, revisionFilters } =
+  parsed.data
+const criteria = revisionFilters ?? []
+const isRevision = criteria.length > 0
+```
+
+Dans la transaction, remplacer le bloc `avail` + `picked` par :
+
+```ts
+let picked: { id: string }[]
+if (isRevision) {
+  const ids = await pickRevisionQuestionIds(tx, {
+    userId,
+    criteria,
+    domain,
+    objectifsCMCs,
+    limit: questionCount,
+  })
+  if (ids.length === 0) throw new Error("EMPTY_REVISION")
+  picked = ids.map((id) => ({ id }))
+} else {
+  const [avail] = await tx
+    .select({ n: sql<number>`count(*)`.mapWith(Number) })
+    .from(questions)
+    .where(where)
+  if ((avail?.n ?? 0) < questionCount) {
+    throw new Error(`NOT_ENOUGH:${avail?.n ?? 0}`)
+  }
+  picked = await tx
+    .select({ id: questions.id })
+    .from(questions)
+    .where(where)
+    .orderBy(sql`random()`)
+    .limit(questionCount)
+}
+```
+
+L'insertion de la session doit porter le nombre **réel** — sinon le score final se calcule sur un dénominateur faux :
+
+```ts
+await tx.insert(trainingSessions).values({
+  id: sessionId,
+  userId,
+  status: "in_progress",
+  mode,
+  domain: domain && domain !== "all" ? domain : null,
+  objectifCmc: null,
+  questionCount: picked.length,
+  startedAt: now,
+  expiresAt,
+})
+```
+
+Le nombre retenu doit être **renvoyé depuis le callback de transaction**, pas capturé dans un `let` extérieur (règle projet : TS ne narrow pas une closure) :
+
+```ts
+const selectedCount = await db.transaction(async (tx) => {
+  // … verrou de ligne, rate-limit, session active, sélection, inserts …
+  return picked.length
+})
+```
+
+puis, après `revalidatePath` :
+
+```ts
+return { success: true, sessionId, questionCount: selectedCount }
+```
+
+Enfin, mapper la nouvelle erreur dans le `catch`, à côté de `NOT_ENOUGH` :
+
+```ts
+if (error.message === "EMPTY_REVISION") {
+  return fail(
+    "Aucune question ne correspond à ces critères de révision. Élargissez la sélection.",
+  )
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun run test:integration -- tests/integration/revision-corpus.test.ts tests/integration/training.test.ts tests/integration/training-mode.test.ts tests/integration/training-concurrency.test.ts`
+Expected: PASS — y compris les tests d'entraînement existants (aucune régression du tirage aléatoire).
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/training/schemas.ts features/training/actions.ts tests/integration/revision-corpus.test.ts
+git commit -m "feat(revision): createTrainingSession accepte un filtre de revision (borne au corpus)"
+```
+
+---
+
+### Task 7: Action de lecture des compteurs
+
+**Files:**
+
+- Modify: `features/training/actions.ts`
+- Test: `tests/integration/revision-corpus.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Ajouter à `tests/integration/revision-corpus.test.ts` :
+
+```ts
+describe("loadRevisionCounts", () => {
+  it("compte pour l'utilisateur de la session, pas celui passé en argument", async () => {
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: OTHER_USER_ID, role: "user" },
+    } as never)
+
+    const counts = await loadRevisionCounts({ domain: DOMAIN })
+    expect(counts.failed).toBe(1) // la ratée de l'AUTRE utilisateur (qIds[5])
+  })
+})
+```
+
+Importer `loadRevisionCounts` depuis `@/features/training/actions`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:integration -- -t "loadRevisionCounts"`
+Expected: FAIL — `loadRevisionCounts` n'est pas exporté.
+
+- [ ] **Step 3: Implement**
+
+Dans `features/training/actions.ts`, à la suite de `loadAvailableObjectifsCMC` :
+
+```ts
+/** [Auth] Compteurs de révision de l'utilisateur courant (formulaire). */
+export const loadRevisionCounts = async (args: {
+  domain?: string
+  objectifsCMCs?: string[]
+}): Promise<RevisionCounts> => {
+  const session = await requireSession()
+  return getRevisionCounts(session.user.id, args)
+}
+```
+
+Compléter l'import du module de révision :
+
+```ts
+import {
+  type RevisionCounts,
+  getRevisionCounts,
+  pickRevisionQuestionIds,
+} from "./revision"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:integration -- -t "loadRevisionCounts"`
+Expected: PASS.
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/training/actions.ts tests/integration/revision-corpus.test.ts
+git commit -m "feat(revision): action loadRevisionCounts (compteurs du formulaire)"
+```
+
+---
+
+### Task 8: Formulaire — puces « Réviser » et compteurs
+
+**Décision d'UI, écart assumé avec la spec §5** : le curseur **n'est pas** borné par les compteurs. L'union de plusieurs critères n'est pas la somme de leurs compteurs (une question peut être à la fois ratée et marquée) — un plafond client mentirait. Les compteurs sont indicatifs, le serveur borne, et le toast annonce le nombre réel renvoyé par l'action.
+
+**Files:**
+
+- Modify: `app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx`
+- Test: `tests/components/TrainingConfigForm.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Créer `tests/components/TrainingConfigForm.test.tsx` :
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { TrainingConfigForm } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form"
+import { motionMockFactory } from "@/tests/helpers/motion-mock"
+
+const {
+  push,
+  toastError,
+  toastSuccess,
+  createTrainingSession,
+  loadAvailableObjectifsCMC,
+  loadRevisionCounts,
+} = vi.hoisted(() => ({
+  push: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  createTrainingSession: vi.fn(),
+  loadAvailableObjectifsCMC: vi.fn(),
+  loadRevisionCounts: vi.fn(),
+}))
+
+vi.mock("motion/react", () => motionMockFactory)
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}))
+vi.mock("@/features/training/actions", () => ({
+  createTrainingSession,
+  loadAvailableObjectifsCMC,
+  loadRevisionCounts,
+}))
+
+const props = {
+  domains: [{ domain: "Cardiologie", count: 120 }],
+  totalQuestions: 3000,
+  objectifs: [{ objectif: "Obj A", count: 40 }],
+}
+
+describe("TrainingConfigForm — révision", () => {
+  it("affiche les compteurs de révision", async () => {
+    loadAvailableObjectifsCMC.mockResolvedValue({ objectifs: props.objectifs })
+    loadRevisionCounts.mockResolvedValue({
+      failed: 7,
+      unseen: 812,
+      bookmarked: 3,
+    })
+
+    render(<TrainingConfigForm {...props} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("revision-failed")).toHaveTextContent("7")
+    })
+    expect(screen.getByTestId("revision-bookmarked")).toHaveTextContent("3")
+  })
+
+  it("transmet les critères cochés à la création de session", async () => {
+    loadAvailableObjectifsCMC.mockResolvedValue({ objectifs: props.objectifs })
+    loadRevisionCounts.mockResolvedValue({
+      failed: 7,
+      unseen: 812,
+      bookmarked: 3,
+    })
+    createTrainingSession.mockResolvedValue({
+      success: true,
+      sessionId: "s1",
+      questionCount: 7,
+    })
+
+    render(<TrainingConfigForm {...props} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    await userEvent.click(screen.getByTestId("revision-failed"))
+    await userEvent.click(
+      screen.getByRole("button", { name: /Commencer l'entraînement/i }),
+    )
+
+    await waitFor(() => {
+      expect(createTrainingSession).toHaveBeenCalledWith(
+        expect.objectContaining({ revisionFilters: ["failed"] }),
+      )
+    })
+    // Le toast annonce le nombre RÉEL renvoyé par le serveur, pas la demande.
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Session créée !",
+      expect.objectContaining({ description: expect.stringContaining("7") }),
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- tests/components/TrainingConfigForm.test.tsx`
+Expected: FAIL — `loadRevisionCounts` n'est pas importé par le composant, `revision-failed` introuvable.
+
+- [ ] **Step 3: Implement**
+
+Dans `training-config-form.tsx` :
+
+Compléter les imports :
+
+```ts
+import {
+  createTrainingSession,
+  loadAvailableObjectifsCMC,
+  loadRevisionCounts,
+} from "@/features/training/actions"
+import {
+  REVISION_CRITERIA,
+  REVISION_CRITERION_LABELS,
+  type RevisionCriterion,
+} from "@/features/training/schemas"
+```
+
+Ajouter l'état, sous `trainingMode` :
+
+```ts
+const [revisionFilters, setRevisionFilters] = useState<RevisionCriterion[]>([])
+const [revisionCounts, setRevisionCounts] = useState<
+  Record<RevisionCriterion, number>
+>({ failed: 0, unseen: 0, bookmarked: 0 })
+const [isCountsLoading, startCountsLoad] = useTransition()
+```
+
+Charger les compteurs sur le même modèle que les objectifs (même dépendance de domaine ; `setState` uniquement dans le callback de transition) :
+
+```ts
+useEffect(() => {
+  startCountsLoad(async () => {
+    try {
+      const counts = await loadRevisionCounts({
+        domain: selectedDomain === "all" ? undefined : selectedDomain,
+        objectifsCMCs:
+          selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
+      })
+      setRevisionCounts(counts)
+    } catch {
+      // Compteurs indisponibles : les puces resteraient à 0 en silence, ce qui
+      // ferait croire à un historique vide.
+      toast.error(
+        "Impossible de charger vos compteurs de révision. Vérifiez votre réseau.",
+      )
+    }
+  })
+}, [selectedDomain, selectedObjectifs])
+```
+
+Ajouter la bascule :
+
+```ts
+const toggleRevisionFilter = (criterion: RevisionCriterion) =>
+  setRevisionFilters((current) =>
+    current.includes(criterion)
+      ? current.filter((c) => c !== criterion)
+      : [...current, criterion],
+  )
+```
+
+Transmettre le filtre et annoncer le nombre réel, dans `submitAction` :
+
+```ts
+const result = await createTrainingSession({
+  questionCount,
+  domain: selectedDomain === "all" ? undefined : selectedDomain,
+  objectifsCMCs: selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
+  mode: trainingMode,
+  revisionFilters: revisionFilters.length > 0 ? revisionFilters : undefined,
+})
+
+if (!result.success) {
+  toast.error("Erreur", { description: result.error })
+  return null
+}
+
+toast.success("Session créée !", {
+  description: `${result.questionCount} questions sélectionnées`,
+})
+```
+
+Insérer le bloc d'UI entre le sélecteur d'objectifs CMC et le mode d'entraînement :
+
+```tsx
+{
+  /* Filtres de révision */
+}
+;<div className="space-y-3">
+  <div className="flex items-center gap-2">
+    <Target className="h-4 w-4 text-gray-500" />
+    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+      Réviser (optionnel)
+    </label>
+  </div>
+
+  <div className="flex flex-wrap gap-2">
+    {REVISION_CRITERIA.map((criterion) => {
+      const isActive = revisionFilters.includes(criterion)
+      return (
+        <button
+          key={criterion}
+          type="button"
+          data-testid={`revision-${criterion}`}
+          aria-pressed={isActive}
+          onClick={() => toggleRevisionFilter(criterion)}
+          className={cn(
+            "flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+            isActive
+              ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:border-emerald-600 dark:bg-emerald-900/20 dark:text-emerald-300"
+              : "border-gray-200 bg-white/60 text-gray-700 hover:border-emerald-300 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-300",
+          )}
+        >
+          <span>{REVISION_CRITERION_LABELS[criterion]}</span>
+          <span className="rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {isCountsLoading ? "…" : revisionCounts[criterion]}
+          </span>
+        </button>
+      )
+    })}
+  </div>
+
+  {revisionFilters.length > 0 && (
+    <p className="text-sm text-gray-500 dark:text-gray-400">
+      La session prendra jusqu&apos;à {questionCount} questions parmi celles qui
+      correspondent — moins s&apos;il y en a moins.
+    </p>
+  )}
+</div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test -- tests/components/TrainingConfigForm.test.tsx`
+Expected: PASS (2 tests).
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx" tests/components/TrainingConfigForm.test.tsx
+git commit -m "feat(revision): puces de revision + compteurs dans le formulaire d'entrainement"
+```
+
+---
+
+### Task 9: Runner — marquage persistant
+
+**Files:**
+
+- Modify: `features/training/dal.ts`
+- Modify: `app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx`
+- Test: `tests/integration/training.test.ts`, `tests/components/quiz/TrainingSessionClient.test.tsx`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Ajouter à `tests/integration/training.test.ts` (importer `questionBookmarks` et `setQuestionBookmark`) :
+
+```ts
+it("la vue de session expose les signets de l'utilisateur", async () => {
+  const created = await createTrainingSession({
+    questionCount: 5,
+    domain: DOMAIN,
+  })
+  expect(created.success).toBe(true)
+  if (!created.success) return
+
+  try {
+    const before = await getTrainingSessionById(created.sessionId)
+    const questionId = before!.questions[0]._id
+    await setQuestionBookmark({ questionId, isBookmarked: true })
+
+    const after = await getTrainingSessionById(created.sessionId)
+    expect(after!.bookmarkedIds).toContain(questionId)
+  } finally {
+    await abandonTrainingSession({ sessionId: created.sessionId })
+    await db
+      .delete(questionBookmarks)
+      .where(eq(questionBookmarks.userId, USER_ID))
+  }
+})
+```
+
+Le fichier fournit déjà `USER_ID`, `DOMAIN` et le helper `asAdmin()` — appeler `asAdmin()` en tête du test, comme les autres cas du fichier. Ajouter `questionBookmarks` à l'import `@/db/schema` et le supprimer dans l'`afterAll` du fichier, **avant** la suppression des questions.
+
+- [ ] **Step 2: Write the failing component test**
+
+Créer `tests/components/quiz/TrainingSessionClient.test.tsx` :
+
+```tsx
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { TrainingSessionClient } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client"
+
+const { setQuestionBookmark, runnerProps } = vi.hoisted(() => ({
+  setQuestionBookmark: vi.fn(),
+  runnerProps: { current: null as Record<string, unknown> | null },
+}))
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock("@/features/training/actions", () => ({
+  saveTrainingAnswer: vi.fn(),
+  completeTrainingSession: vi.fn(),
+  setQuestionBookmark,
+}))
+// Le runner complet (timers, Radix, motion) est hors sujet : on capture ses props.
+vi.mock("@/components/quiz/runner/quiz-runner", () => ({
+  QuizRunner: (props: Record<string, unknown>) => {
+    runnerProps.current = props
+    return <div data-testid="runner-stub" />
+  },
+}))
+
+const initialData = {
+  session: {
+    id: "s1",
+    questionCount: 1,
+    status: "in_progress" as const,
+    mode: "test" as const,
+    domain: null,
+    startedAt: 0,
+    completedAt: null,
+    expiresAt: Date.now() + 3_600_000,
+    score: null,
+  },
+  questions: [
+    {
+      _id: "q1",
+      _creationTime: 0,
+      question: "Q1 ?",
+      options: ["A", "B"],
+      objectifCMC: "Obj",
+      domain: "Cardiologie",
+      images: [],
+    },
+  ],
+  answers: {},
+  bookmarkedIds: ["q1"],
+  isExpired: false,
+}
+
+describe("TrainingSessionClient — marquage", () => {
+  it("hydrate les signets et persiste la bascule", async () => {
+    setQuestionBookmark.mockResolvedValue({ success: true })
+
+    render(<TrainingSessionClient sessionId="s1" initialData={initialData} />)
+
+    const props = runnerProps.current as {
+      initialFlags: Set<string>
+      callbacks: {
+        onFlag: (id: string, flagged: boolean) => Promise<{ ok: boolean }>
+      }
+    }
+    expect(props.initialFlags.has("q1")).toBe(true)
+
+    const res = await props.callbacks.onFlag("q1", false)
+    expect(res.ok).toBe(true)
+    expect(setQuestionBookmark).toHaveBeenCalledWith({
+      questionId: "q1",
+      isBookmarked: false,
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bun run test -- tests/components/quiz/TrainingSessionClient.test.tsx`
+Expected: FAIL — `bookmarkedIds` n'existe pas sur le type, `initialFlags` est `undefined`.
+
+- [ ] **Step 4: Expose the bookmarks from the DAL**
+
+Dans `features/training/dal.ts`, ajouter le champ au type :
+
+```ts
+export type TrainingSessionView = {
+  session: {/* inchangé */}
+  questions: TrainingSessionQuestion[]
+  answers: TrainingAnswerRecord
+  /** Signets de l'utilisateur courant parmi les questions de la session. */
+  bookmarkedIds: string[]
+  isExpired: boolean
+} | null
+```
+
+Dans `getTrainingSessionById`, joindre la lecture existante des images et du verrou :
+
+```ts
+const [imgMap, lockedIds, bookmarkedIds] = await Promise.all([
+  fetchImages(sessionQuestionIds),
+  session.user.role === "admin"
+    ? new Set<string>()
+    : getOpenExamLockedQuestionIds(session.user.id, sessionQuestionIds),
+  getBookmarkedQuestionIds(sessionQuestionIds),
+])
+```
+
+et l'ajouter au retour, à côté de `answers` :
+
+```ts
+return {
+  session: {/* inchangé */},
+  questions: questionsView,
+  answers,
+  bookmarkedIds,
+  isExpired: s.expiresAt.getTime() < Date.now(),
+}
+```
+
+- [ ] **Step 5: Wire the runner**
+
+Dans `training-session-client.tsx`, compléter l'import des actions :
+
+```ts
+import {
+  completeTrainingSession,
+  saveTrainingAnswer,
+  setQuestionBookmark,
+} from "@/features/training/actions"
+```
+
+Remplacer le no-op :
+
+```ts
+onFlag: async (questionId, isFlagged) => {
+  const res = await callAction(
+    () => setQuestionBookmark({ questionId, isBookmarked: isFlagged }),
+    { retries: 1 }, // état voulu (pas une bascule) → reprise sans effet de bord
+  )
+  if (!res.success) {
+    toast.error("Marquage non enregistré, réessayez.")
+    return { ok: false }
+  }
+  return { ok: true }
+},
+```
+
+et hydrater le runner :
+
+```tsx
+<QuizRunner
+  questions={mappedQuestions}
+  initialAnswers={initialAnswers}
+  initialFlags={new Set(initialData.bookmarkedIds)}
+  initialRevealed={initialRevealed}
+  mode={mode}
+  callbacks={callbacks}
+/>
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun run test -- tests/components/quiz/TrainingSessionClient.test.tsx`
+Expected: PASS.
+
+Run: `bun run test:integration -- tests/integration/training.test.ts`
+Expected: PASS.
+
+Run: `bun run check`
+Expected: exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add features/training/dal.ts "app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client.tsx" tests/integration/training.test.ts tests/components/quiz/TrainingSessionClient.test.tsx
+git commit -m "feat(revision): marquage persistant dans le runner d'entrainement"
+```
+
+---
+
+### Task 10: Règle documentée et clôture
+
+**Files:**
+
+- Modify: `.claude/rules/data-layer.md`
+- Modify: `docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md`
+
+- [ ] **Step 1: Document the invariant**
+
+Dans `.claude/rules/data-layer.md`, à la suite du paragraphe « Passation d'examen — invariante d'accès », ajouter :
+
+```markdown
+- **Révision ciblée — le verrou s'applique à la SÉLECTION** : tout canal qui
+  compose un lot de questions à partir de l'historique d'un étudiant (corpus de
+  révision : `features/training/revision.ts`) DOIT retrancher
+  `getUserOpenExamLockedQuestionIds` — du lot **et** des compteurs affichés.
+  Masquer la correction ne suffit pas : l'appartenance d'une question au lot
+  « mes ratées » dit déjà « tu t'es trompé », donc triche pendant qu'un examen
+  est ouvert, sans jamais voir la clé. `getOpenExamLockedQuestionIds` n'est
+  qu'une restriction du même jeu — une seule définition de la règle.
+```
+
+- [ ] **Step 2: Update the spec status and the UI decision**
+
+Dans l'en-tête du spec, remplacer la ligne de statut par :
+
+```markdown
+- **Statut** : IMPLÉMENTÉ le 2026-08-01 (branche `feat/p1-qbank-engagement`)
+```
+
+Dans la section « 5. UI », remplacer « Le curseur de nombre se borne au corpus filtré. » par :
+
+```markdown
+Les compteurs sont **indicatifs** : le curseur n'est pas plafonné par eux, car
+l'union de plusieurs critères n'est pas la somme de leurs compteurs (une même
+question peut être ratée **et** marquée) — un plafond client mentirait. Le
+serveur borne au corpus et `createTrainingSession` renvoie le nombre réellement
+retenu, que le toast annonce.
+```
+
+Dans la section « 4. Server Actions », remplacer le nom `toggleQuestionBookmark(questionId)` par :
+
+```markdown
+- `setQuestionBookmark({ questionId, isBookmarked })` — prend l'**état voulu**
+  et non une bascule, ce qui la rend idempotente : `callAction` peut la retenter
+  sans inverser deux fois le marquage. Renvoie le succès et rien d'autre.
+```
+
+- [ ] **Step 3: Run the full gates**
+
+Run: `bun run check`
+Expected: exit 0.
+
+Run: `bun run test`
+Expected: PASS, couverture ≥ 80 %.
+
+Run: `bun run test:integration`
+Expected: PASS (suite complète).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/rules/data-layer.md docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
+git commit -m "docs(revision): invariante verrou a la selection + statut du spec"
+```
+
+---
+
+## Vérification manuelle avant revue
+
+À faire dans le navigateur (serveur de dev lancé par l'utilisateur), une fois les dix tâches passées :
+
+1. `/tableau-de-bord/entrainement` — les trois puces affichent des compteurs cohérents ; changer de domaine les met à jour.
+2. Cocher « Ratées » avec un historique de 3 échecs, demander 20 questions : la session démarre avec 3, et le toast annonce 3.
+3. Dans une session, marquer une question, quitter, revenir : le marquage est toujours là.
+4. **Le test qui compte** : participer à un examen blanc **ouvert**, rater volontairement une question, puis retourner à l'entraînement — le compteur « Ratées » ne doit **pas** l'inclure, et aucun filtre ne doit la faire apparaître. Après la clôture de l'examen, elle réapparaît.

--- a/docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md
+++ b/docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md
@@ -28,6 +28,11 @@
 
 **Ordre imposé.** Les tâches 4 et 5 se suivent : la 4 construit le corpus **sans** le verrou, la 5 l'ajoute en test-first. Rien n'est exposé entre les deux (aucun appelant avant la tâche 6), mais **elles doivent atterrir dans la même PR** — la 4 seule serait un trou anti-triche.
 
+**Deux contraintes à ne pas contourner** (issues de la revue de design du 2026-08-01) :
+
+- **Jamais d'accès au `db` global depuis une fonction appelée dans une transaction.** Le pool est à `max: 5` sans `connectionTimeoutMillis` (`db/index.ts`) : réclamer une 2ᵉ connexion pendant qu'on en détient une fige la requête, et cinq créations concurrentes figent l'application entière. C'est pourquoi `pickRevisionQuestionIds` reçoit les identifiants verrouillés en **paramètre requis** au lieu de les calculer lui-même — l'appelant les résout AVANT d'ouvrir la transaction.
+- **`mode` est requis à l'appel de `createTrainingSession`.** `CreateTrainingSessionInput` est le type de **sortie** de zod : le `.default("test")` ne rend pas le champ optionnel à l'entrée du type. Les 13 appels existants le passent tous explicitement — tout nouvel appel doit le faire aussi, sinon `tsc` échoue.
+
 ---
 
 ### Task 1: Table `question_bookmarks`
@@ -631,6 +636,9 @@ const USER_ID = createId()
 const OTHER_USER_ID = createId()
 const DOMAIN = `RC-${suffix}`
 const OBJ = `Obj RC ${suffix}`
+// Deuxième objectif, porté par la seule question d'index 4 : exerce la branche
+// « filtre objectifs » du SQL brut, qu'aucun autre test ne traverse.
+const OBJ_ALT = `Obj RC alt ${suffix}`
 
 // 0 = ratée · 1 = ratée puis réussie · 2 = réussie · 3 = marquée (jamais vue)
 // 4 = jamais vue · 5 = ratée par l'AUTRE utilisateur
@@ -679,7 +687,7 @@ beforeAll(async () => {
       question: `RC Q${i} ${suffix}?`,
       correctAnswer: "A",
       options: ["A", "B", "C", "D"],
-      objectifCmc: OBJ,
+      objectifCmc: i === 4 ? OBJ_ALT : OBJ,
       domain: DOMAIN,
     })),
   )
@@ -782,6 +790,23 @@ describe("corpus de révision", () => {
       limit: 20,
     })
     expect(ids).not.toContain(qIds[5])
+  })
+
+  it("intersecte avec le filtre d'objectifs CMC", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      objectifsCMCs: [OBJ_ALT],
+      limit: 20,
+    })
+    expect(ids).toEqual([qIds[4]])
+
+    const counts = await getRevisionCounts(USER_ID, {
+      domain: DOMAIN,
+      objectifsCMCs: [OBJ_ALT],
+    })
+    expect(counts.unseen).toBe(1)
   })
 
   it("les compteurs décrivent le même corpus que le tirage", async () => {
@@ -981,10 +1006,12 @@ Compléter les imports de `tests/integration/revision-corpus.test.ts` :
 import { examParticipations, examQuestions, exams } from "@/db/schema"
 ```
 
-Déclarer l'identifiant au scope du module, à côté de `SESSION_ID` :
+Déclarer les identifiants au scope du module, à côté de `SESSION_ID` :
 
 ```ts
 const OPEN_EXAM_ID = createId()
+const CLOSED_EXAM_ID = createId()
+const CLOSED_PARTICIPATION_ID = createId()
 ```
 
 Dans `beforeAll`, après l'insertion du signet, monter un examen OUVERT contenant `qIds[0]` (la ratée) et `qIds[3]` (la marquée), avec une participation de `USER_ID`. `completionTime` est en **secondes** et `createdBy` est obligatoire (FK `restrict` vers `user`) :
@@ -1010,6 +1037,44 @@ await db.insert(examParticipations).values({
   startedAt: new Date("2026-01-01T01:00:00Z"),
 })
 ```
+
+Monter aussi un examen **CLOS** portant `qIds[5]`, avec une réponse **marquée mais
+jamais répondue**. Ce fixture couvre deux choses qu'aucun autre test ne traverse :
+la branche `is_flagged` du SQL brut, et le fait que l'exclusion vise les examens
+**ouverts** seulement.
+
+```ts
+await db.insert(exams).values({
+  id: CLOSED_EXAM_ID,
+  title: `RC examen clos ${suffix}`,
+  startDate: new Date("2026-01-01T00:00:00Z"),
+  endDate: new Date("2026-01-02T00:00:00Z"),
+  completionTime: 3600,
+  createdBy: USER_ID,
+})
+await db
+  .insert(examQuestions)
+  .values({ examId: CLOSED_EXAM_ID, questionId: qIds[5], position: 0 })
+await db.insert(examParticipations).values({
+  id: CLOSED_PARTICIPATION_ID,
+  examId: CLOSED_EXAM_ID,
+  userId: USER_ID,
+  status: "completed",
+  startedAt: new Date("2026-01-01T01:00:00Z"),
+})
+await db.insert(examAnswers).values({
+  participationId: CLOSED_PARTICIPATION_ID,
+  questionId: qIds[5],
+  selectedAnswer: null,
+  isCorrect: null,
+  isFlagged: true,
+})
+```
+
+Ajouter `examAnswers` à l'import `@/db/schema`. Les réponses partent en cascade
+avec leur participation — rien à nettoyer de plus, à condition que les
+participations soient supprimées avant les questions (`exam_answers.question_id`
+est en `restrict`).
 
 Nettoyer dans `afterAll`, **avant** la suppression des questions (`exam_questions` les référence en `restrict`) et avant celle des utilisateurs (`exams.created_by` en `restrict`) :
 
@@ -1038,13 +1103,31 @@ describe("corpus de révision — verrou examen ouvert", () => {
 
   it("exclut aussi des COMPTEURS (sinon le compteur redevient l'oracle)", async () => {
     const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
-    expect(counts.failed).toBe(0)
-    expect(counts.bookmarked).toBe(0)
+    expect(counts.failed).toBe(0) // la seule ratée est dans l'examen ouvert
+  })
+
+  it("un examen CLOS ne verrouille rien : sa question marquée reste révisable", async () => {
+    const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+    expect(counts.bookmarked).toBe(1) // qIds[5], marquée via l'examen clos
+
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["bookmarked"],
+      domain: DOMAIN,
+      limit: 20,
+      lockedIds: await resolveRevisionLock(USER_ID),
+    })
+    expect(ids).toEqual([qIds[5]])
   })
 })
 ```
 
-Les tests de la tâche 4 restent valides : `qIds[1]`, `qIds[2]`, `qIds[4]`, `qIds[5]` ne sont pas dans l'examen. **Adapter les attentes des tests de la tâche 4** touchées par le verrou : `failed` attend désormais `[]`, `unseen` attend `[qIds[4], qIds[5]]`, l'union OU attend `[]`, et `getRevisionCounts` attend `{ failed: 0, unseen: 2, bookmarked: 0 }`. C'est le comportement voulu : la tâche 4 décrivait un monde sans examen ouvert.
+**Adapter les attentes des tests de la tâche 4**, qui décrivaient un monde sans
+examen : ajouter `lockedIds: await resolveRevisionLock(USER_ID)` à chaque appel de
+`pickRevisionQuestionIds`, puis `failed` attend `[]`, `unseen` attend
+`[qIds[4], qIds[5]]`, l'union OU attend `[qIds[5]]` (marquée via l'examen **clos**,
+donc non verrouillée), le filtre d'objectifs reste `[qIds[4]]`, et
+`getRevisionCounts` attend `{ failed: 0, unseen: 2, bookmarked: 1 }`.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1095,21 +1178,54 @@ const corpusWhere = (
 }
 ```
 
-Dans `getRevisionCounts`, avant la requête :
+Exposer le résolveur, pour que l'appelant utilise la même source que le module :
 
 ```ts
-const lockedIds = [...(await getUserOpenExamLockedQuestionIds(userId))]
+/**
+ * Identifiants à exclure du corpus. À résoudre AVANT d'ouvrir une transaction :
+ * le pool pg est à `max: 5` sans timeout d'acquisition, donc réclamer une 2ᵉ
+ * connexion pendant qu'on en détient une fige la requête — et cinq créations
+ * concurrentes figent l'application.
+ */
+export const resolveRevisionLock = async (
+  userId: string,
+): Promise<string[]> => [...(await getUserOpenExamLockedQuestionIds(userId))]
+```
+
+Dans `getRevisionCounts` (jamais appelée dans une transaction), avant la requête :
+
+```ts
+const lockedIds = await resolveRevisionLock(userId)
 ```
 
 et passer `corpusWhere({ userId, ...scope }, lockedIds)`.
 
-Dans `pickRevisionQuestionIds`, avant la requête :
+`pickRevisionQuestionIds` **reçoit** les identifiants verrouillés — elle ne les
+calcule pas, parce qu'elle s'exécute dans la transaction de création de session.
+Le paramètre est **requis** : un oubli casse la compilation au lieu de rouvrir le
+trou anti-triche en silence.
 
 ```ts
-const lockedIds = [...(await getUserOpenExamLockedQuestionIds(scope.userId))]
+export const pickRevisionQuestionIds = async (
+  exec: Executor,
+  {
+    criteria,
+    limit,
+    lockedIds,
+    ...scope
+  }: RevisionScope & {
+    criteria: RevisionCriterion[]
+    limit: number
+    /** Résolus par `resolveRevisionLock` HORS transaction (voir ci-dessus). */
+    lockedIds: string[]
+  },
+): Promise<string[]> => {
 ```
 
-et passer `corpusWhere(scope, lockedIds)`.
+et dans son corps, passer `corpusWhere(scope, lockedIds)`.
+
+Les appels de la tâche 4 doivent être complétés en conséquence :
+`pickRevisionQuestionIds(db, { …, lockedIds: await resolveRevisionLock(USER_ID) })`.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -1152,6 +1268,7 @@ describe("createTrainingSession en révision", () => {
     const res = await createTrainingSession({
       questionCount: 20,
       domain: DOMAIN,
+      mode: "test",
       revisionFilters: ["unseen"],
     })
     expect(res.success).toBe(true)
@@ -1177,6 +1294,7 @@ describe("createTrainingSession en révision", () => {
     const res = await createTrainingSession({
       questionCount: 10,
       domain: DOMAIN,
+      mode: "test",
       revisionFilters: ["failed"],
     })
     expect(res.success).toBe(false)
@@ -1226,10 +1344,10 @@ export const createTrainingSessionSchema = z
 
 Dans `features/training/actions.ts` :
 
-Importer le tirage :
+Importer le tirage et le résolveur de verrou :
 
 ```ts
-import { pickRevisionQuestionIds } from "./revision"
+import { pickRevisionQuestionIds, resolveRevisionLock } from "./revision"
 ```
 
 Élargir le type de retour :
@@ -1251,6 +1369,15 @@ const isRevision = criteria.length > 0
 
 Dans la transaction, remplacer le bloc `avail` + `picked` par :
 
+Résoudre le verrou **avant** `db.transaction` (une fonction appelée dans la
+transaction ne doit jamais réclamer une 2ᵉ connexion au pool) :
+
+```ts
+const lockedIds = isRevision ? await resolveRevisionLock(userId) : []
+```
+
+Puis, dans la transaction, remplacer le bloc `avail` + `picked` par :
+
 ```ts
 let picked: { id: string }[]
 if (isRevision) {
@@ -1260,6 +1387,7 @@ if (isRevision) {
     domain,
     objectifsCMCs,
     limit: questionCount,
+    lockedIds,
   })
   if (ids.length === 0) throw new Error("EMPTY_REVISION")
   picked = ids.map((id) => ({ id }))
@@ -1584,25 +1712,36 @@ const toggleRevisionFilter = (criterion: RevisionCriterion) =>
   )
 ```
 
-Transmettre le filtre et annoncer le nombre réel, dans `submitAction` :
+Dans `submitAction`, remplacer **tout le bloc `try`** (surtout pas seulement l'appel : le `router.push` et le `catch` existants doivent survivre) :
 
 ```ts
-const result = await createTrainingSession({
-  questionCount,
-  domain: selectedDomain === "all" ? undefined : selectedDomain,
-  objectifsCMCs: selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
-  mode: trainingMode,
-  revisionFilters: revisionFilters.length > 0 ? revisionFilters : undefined,
-})
+try {
+  const result = await createTrainingSession({
+    questionCount,
+    domain: selectedDomain === "all" ? undefined : selectedDomain,
+    objectifsCMCs: selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
+    mode: trainingMode,
+    revisionFilters: revisionFilters.length > 0 ? revisionFilters : undefined,
+  })
 
-if (!result.success) {
-  toast.error("Erreur", { description: result.error })
-  return null
+  if (!result.success) {
+    toast.error("Erreur", { description: result.error })
+    return null
+  }
+
+  // Le nombre annoncé est celui RETENU par le serveur, pas celui demandé : en
+  // révision, le corpus peut être plus court.
+  toast.success("Session créée !", {
+    description: `${result.questionCount} questions sélectionnées`,
+  })
+
+  router.push(`/tableau-de-bord/entrainement/${result.sessionId}`)
+} catch (error) {
+  toast.error("Erreur", {
+    description:
+      error instanceof Error ? error.message : "Une erreur est survenue",
+  })
 }
-
-toast.success("Session créée !", {
-  description: `${result.questionCount} questions sélectionnées`,
-})
 ```
 
 Insérer le bloc d'UI entre le sélecteur d'objectifs CMC et le mode d'entraînement :
@@ -1685,9 +1824,11 @@ Ajouter à `tests/integration/training.test.ts` (importer `questionBookmarks` et
 
 ```ts
 it("la vue de session expose les signets de l'utilisateur", async () => {
+  asAdmin()
   const created = await createTrainingSession({
     questionCount: 5,
     domain: DOMAIN,
+    mode: "test",
   })
   expect(created.success).toBe(true)
   if (!created.success) return

--- a/docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md
+++ b/docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md
@@ -388,7 +388,7 @@ export const getOpenExamLockedQuestionIds = async (
 }
 ```
 
-`inArray` peut devenir un import inutilisé dans ce fichier — le retirer si `bun run lint` le signale.
+Ne pas toucher aux imports : `inArray` reste utilisé ailleurs dans le fichier (`fetchImages`, `countQuestionsByExam`, `getOpenExamQuestionIds`).
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -470,6 +470,19 @@ describe("setQuestionBookmark", () => {
     })
     expect(again.success).toBe(true)
     expect(await getBookmarkedQuestionIds([qIds[2]])).toEqual([qIds[2]])
+  })
+
+  it("ne lit jamais les signets d'un autre étudiant", async () => {
+    await setQuestionBookmark({ questionId: qIds[0], isBookmarked: true })
+
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: createId(), role: "user" },
+    } as never)
+    expect(await getBookmarkedQuestionIds([qIds[0]])).toEqual([])
+
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: USER_ID, role: "admin" },
+    } as never)
   })
 
   it("refuse proprement une question inexistante", async () => {
@@ -792,6 +805,33 @@ describe("corpus de révision", () => {
     expect(ids).not.toContain(qIds[5])
   })
 
+  it("une question servie mais jamais répondue reste « non vue »", async () => {
+    // Session abandonnée : l'item existe, `selected_answer` est nul.
+    const orphanSessionId = createId()
+    await db.insert(trainingSessions).values({
+      id: orphanSessionId,
+      userId: USER_ID,
+      status: "abandoned",
+      mode: "test",
+      questionCount: 1,
+      startedAt: new Date("2026-01-03T00:00:00Z"),
+      expiresAt: new Date("2026-01-04T00:00:00Z"),
+    })
+    await db.insert(trainingSessionItems).values({
+      sessionId: orphanSessionId,
+      questionId: qIds[4],
+      position: 0,
+    })
+
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).toContain(qIds[4])
+  })
+
   it("intersecte avec le filtre d'objectifs CMC", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
@@ -862,8 +902,9 @@ export type RevisionScope = {
 
 // Historique unifié entraînement + examens de l'utilisateur, réduit à sa
 // DERNIÈRE tentative par question. `exam_answers.created_at` vaut « début de la
-// tentative » (les lignes sont pré-créées au démarrage de l'examen) : sans
-// conséquence, les réponses d'un même examen sont simultanées par nature.
+// tentative » (lignes pré-créées au démarrage de l'examen, jamais réhorodatées) :
+// un entraînement intercalé pendant un examen long peut donc être classé à tort
+// comme la tentative la plus récente. Limite assumée, documentée dans le spec.
 const historyCte = (userId: string): SQL => sql`
   attempts as (
     select i.question_id, i.is_correct, i.answered_at as at
@@ -1319,7 +1360,7 @@ export const createTrainingSessionSchema = z
     questionCount: z
       .number()
       .int()
-      .min(1)
+      .min(1, "Au moins une question")
       .max(MAX_QUESTIONS, `Au plus ${MAX_QUESTIONS} questions`),
     domain: z.string().trim().min(1).optional(),
     objectifsCMCs: z.array(z.string().trim().min(1)).max(50).optional(),
@@ -1678,16 +1719,17 @@ const [revisionCounts, setRevisionCounts] = useState<
 const [isCountsLoading, startCountsLoad] = useTransition()
 ```
 
-Charger les compteurs sur le même modèle que les objectifs (même dépendance de domaine ; `setState` uniquement dans le callback de transition) :
+Charger les compteurs sur le même modèle que les objectifs (`setState` uniquement dans le callback de transition). La dépendance passe par une **clé stable** : `selectedObjectifs` est un tableau dont l'identité change à chaque `setState`, et chaque exécution coûte un balayage complet de la banque (`not exists` corrélé) :
 
 ```ts
+const objectifsKey = selectedObjectifs.join("|")
+
 useEffect(() => {
   startCountsLoad(async () => {
     try {
       const counts = await loadRevisionCounts({
         domain: selectedDomain === "all" ? undefined : selectedDomain,
-        objectifsCMCs:
-          selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
+        objectifsCMCs: objectifsKey ? objectifsKey.split("|") : undefined,
       })
       setRevisionCounts(counts)
     } catch {
@@ -1698,7 +1740,7 @@ useEffect(() => {
       )
     }
   })
-}, [selectedDomain, selectedObjectifs])
+}, [selectedDomain, objectifsKey])
 ```
 
 Ajouter la bascule :
@@ -1712,86 +1754,96 @@ const toggleRevisionFilter = (criterion: RevisionCriterion) =>
   )
 ```
 
-Dans `submitAction`, remplacer **tout le bloc `try`** (surtout pas seulement l'appel : le `router.push` et le `catch` existants doivent survivre) :
+Dans `submitAction`, remplacer **tout le bloc `try`/`catch`** — pas seulement l'appel. Le `router.push` doit survivre, et l'`await` nu passe à `callAction` comme l'exige `.claude/rules/data-layer.md` (un rejet réseau contourne le garde `if (!result.success)`). `callAction` ne throw jamais, donc le `try`/`catch` disparaît :
 
 ```ts
-try {
-  const result = await createTrainingSession({
+const result = await callAction(() =>
+  createTrainingSession({
     questionCount,
     domain: selectedDomain === "all" ? undefined : selectedDomain,
     objectifsCMCs: selectedObjectifs.length > 0 ? selectedObjectifs : undefined,
     mode: trainingMode,
     revisionFilters: revisionFilters.length > 0 ? revisionFilters : undefined,
-  })
+  }),
+)
 
-  if (!result.success) {
-    toast.error("Erreur", { description: result.error })
-    return null
-  }
-
-  // Le nombre annoncé est celui RETENU par le serveur, pas celui demandé : en
-  // révision, le corpus peut être plus court.
-  toast.success("Session créée !", {
-    description: `${result.questionCount} questions sélectionnées`,
-  })
-
-  router.push(`/tableau-de-bord/entrainement/${result.sessionId}`)
-} catch (error) {
-  toast.error("Erreur", {
-    description:
-      error instanceof Error ? error.message : "Une erreur est survenue",
-  })
+if (!result.success) {
+  toast.error("Erreur", { description: result.error })
+  return null
 }
+
+// Le nombre annoncé est celui RETENU par le serveur, pas celui demandé : en
+// révision, le corpus peut être plus court.
+toast.success("Session créée !", {
+  description: `${result.questionCount} questions sélectionnées`,
+})
+
+router.push(`/tableau-de-bord/entrainement/${result.sessionId}`)
+return null
+```
+
+Ajouter l'import : `import { callAction } from "@/lib/safe-action"`. **Pas** de `retries` — la création de session n'est pas idempotente.
+
+Le test du formulaire doit alors mocker `next/navigation` en **complet** (`callAction` importe `unstable_isUnrecognizedActionError`) :
+
+```ts
+vi.mock("next/navigation", async (orig) => ({
+  ...(await orig<typeof import("next/navigation")>()),
+  useRouter: () => ({ push }),
+}))
 ```
 
 Insérer le bloc d'UI entre le sélecteur d'objectifs CMC et le mode d'entraînement :
 
 ```tsx
-{
-  /* Filtres de révision */
-}
-;<div className="space-y-3">
-  <div className="flex items-center gap-2">
-    <Target className="h-4 w-4 text-gray-500" />
-    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-      Réviser (optionnel)
-    </label>
-  </div>
+<>
+  {/* Filtres de révision */}
+  <div className="space-y-3">
+    <div className="flex items-center gap-2">
+      <Target className="h-4 w-4 text-gray-500" />
+      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        Réviser (optionnel)
+      </label>
+    </div>
 
-  <div className="flex flex-wrap gap-2">
-    {REVISION_CRITERIA.map((criterion) => {
-      const isActive = revisionFilters.includes(criterion)
-      return (
-        <button
-          key={criterion}
-          type="button"
-          data-testid={`revision-${criterion}`}
-          aria-pressed={isActive}
-          onClick={() => toggleRevisionFilter(criterion)}
-          className={cn(
-            "flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-            isActive
-              ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:border-emerald-600 dark:bg-emerald-900/20 dark:text-emerald-300"
-              : "border-gray-200 bg-white/60 text-gray-700 hover:border-emerald-300 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-300",
-          )}
-        >
-          <span>{REVISION_CRITERION_LABELS[criterion]}</span>
-          <span className="rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-            {isCountsLoading ? "…" : revisionCounts[criterion]}
-          </span>
-        </button>
-      )
-    })}
-  </div>
+    <div className="flex flex-wrap gap-2">
+      {REVISION_CRITERIA.map((criterion) => {
+        const isActive = revisionFilters.includes(criterion)
+        return (
+          <button
+            key={criterion}
+            type="button"
+            data-testid={`revision-${criterion}`}
+            aria-pressed={isActive}
+            onClick={() => toggleRevisionFilter(criterion)}
+            className={cn(
+              "flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+              isActive
+                ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:border-emerald-600 dark:bg-emerald-900/20 dark:text-emerald-300"
+                : "border-gray-200 bg-white/60 text-gray-700 hover:border-emerald-300 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-300",
+            )}
+          >
+            <span>{REVISION_CRITERION_LABELS[criterion]}</span>
+            <span className="rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+              {isCountsLoading ? "…" : revisionCounts[criterion]}
+            </span>
+          </button>
+        )
+      })}
+    </div>
 
-  {revisionFilters.length > 0 && (
-    <p className="text-sm text-gray-500 dark:text-gray-400">
-      La session prendra jusqu&apos;à {questionCount} questions parmi celles qui
-      correspondent — moins s&apos;il y en a moins.
-    </p>
-  )}
-</div>
+    {revisionFilters.length > 0 && (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        La session prendra jusqu&apos;à {questionCount} questions parmi celles
+        qui correspondent — moins s&apos;il y en a moins.
+      </p>
+    )}
+  </div>
+</>
 ```
+
+> Le fragment `<>…</>` n'est là que pour rendre l'extrait valide isolément :
+> insérer son **contenu** dans l'arbre JSX existant, pas le fragment.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -1860,13 +1912,20 @@ import { render } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { TrainingSessionClient } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client"
 
-const { setQuestionBookmark, runnerProps } = vi.hoisted(() => ({
+const { setQuestionBookmark, toastError, runnerProps } = vi.hoisted(() => ({
   setQuestionBookmark: vi.fn(),
+  toastError: vi.fn(),
   runnerProps: { current: null as Record<string, unknown> | null },
 }))
 
-vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
-vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+// Mock COMPLET : `callAction` importe `unstable_isUnrecognizedActionError` de
+// `next/navigation` — un mock partiel casse le chemin d'échec avec une erreur
+// cryptique (piège documenté dans `.claude/rules/data-layer.md`).
+vi.mock("next/navigation", async (orig) => ({
+  ...(await orig<typeof import("next/navigation")>()),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock("sonner", () => ({ toast: { error: toastError, success: vi.fn() } }))
 vi.mock("@/features/training/actions", () => ({
   saveTrainingAnswer: vi.fn(),
   completeTrainingSession: vi.fn(),
@@ -1929,6 +1988,25 @@ describe("TrainingSessionClient — marquage", () => {
       isBookmarked: false,
     })
   })
+
+  it("signale un échec de marquage au lieu de mentir", async () => {
+    setQuestionBookmark.mockRejectedValue(new Error("Failed to fetch"))
+
+    render(<TrainingSessionClient sessionId="s1" initialData={initialData} />)
+    const props = runnerProps.current as {
+      callbacks: {
+        onFlag: (id: string, flagged: boolean) => Promise<{ ok: boolean }>
+      }
+    }
+
+    // `callAction` convertit le rejet réseau en `{ success: false }` — le garde
+    // doit le voir passer, pas le laisser filer en rejet non géré.
+    const res = await props.callbacks.onFlag("q1", true)
+    expect(res.ok).toBe(false)
+    expect(toastError).toHaveBeenCalledWith(
+      "Marquage non enregistré, réessayez.",
+    )
+  })
 })
 ```
 
@@ -1955,12 +2033,15 @@ export type TrainingSessionView = {
 Dans `getTrainingSessionById`, joindre la lecture existante des images et du verrou :
 
 ```ts
+const isOwner = s.userId === session.user.id
 const [imgMap, lockedIds, bookmarkedIds] = await Promise.all([
   fetchImages(sessionQuestionIds),
   session.user.role === "admin"
     ? new Set<string>()
     : getOpenExamLockedQuestionIds(session.user.id, sessionQuestionIds),
-  getBookmarkedQuestionIds(sessionQuestionIds),
+  // Un signet est personnel : un admin qui inspecte la session d'un étudiant
+  // verrait les SIENS, donc des drapeaux incohérents avec ce qu'il regarde.
+  isOwner ? getBookmarkedQuestionIds(sessionQuestionIds) : [],
 ])
 ```
 

--- a/docs/superpowers/reviews/2026-08-02-revision-ciblee-implementation-review.md
+++ b/docs/superpowers/reviews/2026-08-02-revision-ciblee-implementation-review.md
@@ -1,0 +1,395 @@
+# Revue adversariale — Révision ciblée en entraînement (P1-A)
+
+- **Date** : 2026-08-02
+- **Périmètre** : `git diff main...HEAD` sur `feat/p1-qbank-engagement` (15 commits,
+  27 fichiers, +7084 / −68). Spec `docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md`,
+  plan `docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md`.
+- **Méthode** : lecture seule, posture hostile. Chaque constat est prouvé par une
+  référence `fichier:ligne` lue dans l'arbre, jamais par le message de commit.
+  Chaque suspicion a subi une tentative de réfutation ; celles qui sont tombées
+  sont consignées en §4.
+- **Gate** : `bun run check` → **exit 0** (`prettier --check` + `tsc --noEmit` +
+  `eslint --max-warnings 0`, tous verts).
+- **Tests exécutés** : `bun run test:coverage` → **exit 0**.
+  Statements 83.68 % · **Branches 80.26 %** · Functions 81.88 % · Lines 84.56 %
+  (seuil 80 % partout). Aucune commande de base de données n'a été lancée : la
+  suite `tests/integration/**` (dont tout le SQL brut) n'a **pas** été rejouée ici,
+  le SQL de `features/training/revision.ts` n'a donc été audité que statiquement.
+
+---
+
+## 1. Tableau des constats
+
+| #   | Sév | Fichier:ligne                             | Problème                                                                                                                                                                              | Régression ?                                                  |
+| --- | --- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| 1   | 🟠  | `features/training/revision.ts:26-30`     | Le CTE `attempts` n'exclut pas les sessions `in_progress` → les compteurs dérivent `is_correct` d'une session **mode test** encore ouverte, ce que 3 gardes interdisent explicitement | NON (surface neuve) — mais contredit une invariante existante |
+| 2   | 🟡  | `features/exams/dal.shared.ts:121-136`    | `getUserOpenExamLockedQuestionIds` est une lecture **non bornée** (aucun `.limit`), désormais exécutée intégralement à **chaque** réponse en mode tuteur                              | OUI (profil de charge ; résultat identique)                   |
+| 3   | 🟡  | `features/training/actions.ts:60-67`      | `loadRevisionCounts` n'a **aucun** `zod.safeParse` ; `objectifsCMCs` non borné alors que le schéma de création le plafonne à 50                                                       | NON                                                           |
+| 4   | 🟡  | `…/training-config-form.tsx:88,95`        | `objectifsKey.split("\|")` casse si un objectif CMC contient un `\|` (champ libre admin) → compteurs faux, en silence                                                                 | NON                                                           |
+| 5   | ℹ️  | `features/training/revision.ts:97-99,106` | Asymétrie admin : le verrou de **sélection** ne saute pas pour `role === "admin"` alors que les 3 gardes de **révélation** le sautent                                                 | NON (restrictif seulement)                                    |
+| 6   | ℹ️  | `scripts/test-integration.ts:21-23,36-37` | Passe-plat d'arguments vers `spawnSync(..., { shell: true })` : les guillemets sont perdus, `-t "deux mots"` se disloque                                                              | NON (CI n'utilise aucun argument)                             |
+| 7   | ℹ️  | `features/training/actions.ts:398-431`    | `setQuestionBookmark` accepte n'importe quel `questionId`, sans plafond ni limite de débit ; distingue « existe » de « n'existe pas »                                                 | NON                                                           |
+| 8   | ℹ️  | `vitest.config.ts:106-111` (mesuré)       | La couverture **branches** est à 80.26 % pour un seuil de 80 % — 0,26 pt de marge sur le gate CI                                                                                      | NON                                                           |
+
+---
+
+## 2. Détail par constat
+
+### 🟠 1 — Les compteurs de révision lisent une session `in_progress` en mode test
+
+**Code**
+
+- `features/training/revision.ts:26-30` — branche entraînement du CTE `attempts` :
+  ```
+  from training_session_items i
+  join training_sessions s on s.id = i.session_id
+  where s.user_id = ${userId} and i.selected_answer is not null
+  ```
+  Aucun filtre sur `s.status`.
+- `features/training/revision.ts:36-40` — `last_attempt` en dérive ;
+  `features/training/revision.ts:54` — `failed` = `is_correct = false` sur `last_attempt` ;
+  `features/training/revision.ts:56` — `unseen` = absence de `attempts`.
+- L'invariante contredite est écrite trois fois dans le code d'origine :
+  - `features/training/actions.ts:383-384` — « Mode test : ne pas exposer `isCorrect`
+    sur le fil réseau (anti-triche) » ;
+  - `features/training/dal.ts:607` — `revealAnswers = isCompleted || isTutor` ;
+  - `features/training/dal.ts:610-618` — `isCorrect` omis sinon.
+
+**Pourquoi c'est un vrai bug.** En mode test, la correction est délibérément
+retenue jusqu'à la clôture de la session. Les compteurs, eux, sont recalculés à
+la volée sur un historique qui inclut la session ouverte. Déclencheur concret :
+session test en cours, `loadRevisionCounts` appelée entre deux réponses.
+Répondre A à Q1 fait monter `Ratées` de 1 si et seulement si A est fausse ;
+rebasculer sur B fait redescendre le compteur si et seulement si B est juste.
+Quatre options ⇒ au plus trois sondages pour extraire la clé, sans jamais la
+voir — exactement l'oracle que la spec §3 dit fermer côté examen, laissé ouvert
+côté entraînement. `saveTrainingAnswer` autorise bien la ré-écriture d'un item
+tant que la session est `in_progress` (`features/training/actions.ts:348-351`,
+aucun garde d'immuabilité).
+
+**Ce qui limite la portée, et qu'il faut dire.** Il n'y a **pas de chemin UI** :
+`app/(dashboard)/tableau-de-bord/entrainement/_components/entrainement-client.tsx:129`
+ne monte `TrainingConfigForm` que si `!activeSession?.canResume`, donc le
+formulaire — seul appelant de `loadRevisionCounts` — est absent tant qu'une
+session est reprenable. L'exploitation demande de rejouer la Server Action
+directement (son identifiant est stable pour un build donné et lisible dans le
+bundle d'une page où le formulaire est rendu). C'est une protection par rendu
+conditionnel, pas une garde serveur — précisément ce que « Jamais confiance au
+client » (AGENTS.md) proscrit.
+
+**Régression ?** NON au sens strict : aucun comportement antérieur ne change,
+la surface est neuve. Mais elle ouvre un canal latéral autour d'une invariante
+qui tenait avant la branche.
+
+**Correction suggérée.** Une ligne dans la branche entraînement du CTE :
+`and s.status <> 'in_progress'`. Sémantiquement cohérent avec « dernière
+tentative » (une session non close n'est pas une tentative arrêtée), et sans
+effet sur les tests existants (`tests/integration/revision-corpus.test.ts` seede
+des sessions `completed`/`abandoned`). Ajouter un test d'intégration : session
+test en cours + réponse fausse ⇒ `failed` inchangé.
+
+---
+
+### 🟡 2 — Le verrou anti-triche est devenu une lecture non bornée, sur un chemin chaud
+
+**Code**
+
+- `features/exams/dal.shared.ts:121-136` — `getUserOpenExamLockedQuestionIds` :
+  `selectDistinct` sur `exam_questions ⋈ exams ⋈ exam_participations`, filtré sur
+  `userId` + `endDate > now()`. **Aucun `.limit()`**.
+- `features/exams/dal.shared.ts:102-109` — `getOpenExamLockedQuestionIds` charge
+  ce jeu complet puis filtre en TS (`questionIds.filter(id => locked.has(id))`).
+- Avant la branche (`git show main:features/exams/dal.shared.ts`, l. 113-120), le
+  `inArray(examQuestions.questionId, questionIds)` était **dans le `WHERE`**.
+- Appelants du chemin chaud : `features/training/actions.ts:358-362`
+  (`saveTrainingAnswer`, mode tuteur, **une fois par réponse**, avec un seul
+  candidat), `features/training/dal.ts:575`, `features/training/dal.ts:718`,
+  `features/exams/dal.student.ts:586,704`.
+- Règle violée : AGENTS.md, « **IMPORTANT - Reads bornes** : Toujours limiter
+  (`.limit(n)` / pagination keyset). Max ~1000 lignes par requete. »
+
+**Pourquoi c'est un vrai bug.** Le résultat est identique (§4 le prouve), mais le
+coût ne l'est plus. Une requête auparavant ultra-sélective (index
+`exam_questions_question_id_idx` sur un identifiant unique) devient un balayage
+des questions de tous les examens ouverts où l'utilisateur participe — plusieurs
+centaines de lignes, ×20 réponses dans une session tuteur. Sur un étudiant
+inscrit à trois examens de 150 questions, c'est ~450 lignes agrégées à chaque
+clic de réponse au lieu d'une. Rien ne borne ce jeu : le plafond dépend
+uniquement du contenu de la banque d'examens.
+
+**Régression ?** **OUI** — profil de charge uniquement, sémantique inchangée.
+
+**Correction suggérée.** Garder la source unique **et** la sélectivité : passer un
+`questionIds?: string[]` optionnel à `getUserOpenExamLockedQuestionIds`, réinjecté
+en `inArray` quand il est fourni (`getOpenExamLockedQuestionIds` le fournit,
+`resolveRevisionLock` non). La règle reste définie une seule fois. À défaut,
+mémoïser par requête avec `cache()` de React, ce qui amortit au moins les appels
+multiples d'un même rendu — mais pas les 20 appels de `saveTrainingAnswer`, qui
+sont 20 requêtes distinctes.
+
+---
+
+### 🟡 3 — `loadRevisionCounts` : Server Action sans `zod.safeParse`, tableau non borné
+
+**Code**
+
+- `features/training/actions.ts:60-67` :
+  ```ts
+  export const loadRevisionCounts = async (args: {
+    domain?: string
+    objectifsCMCs?: string[]
+  }): Promise<RevisionCounts> => {
+    const session = await requireSession()
+    return getRevisionCounts(session.user.id, args)
+  }
+  ```
+- Consommation directe : `features/training/revision.ts:66-75` mappe chaque entrée
+  en paramètre lié dans un `in (…)`.
+- Le même champ est plafonné côté écriture : `features/training/schemas.ts:24` —
+  `z.array(z.string().trim().min(1)).max(50).optional()`.
+- Règle violée : `.claude/rules/data-layer.md`, « Server Actions : `"use server"` →
+  guard → `zod.safeParse` (early `fail(message)`) ».
+
+**Pourquoi c'est un vrai bug.** Le garde d'authentification est bien là (l'IDOR
+est fermé, cf. §4), mais rien ne borne l'entrée. Un client authentifié peut
+poster `objectifsCMCs` de plusieurs dizaines de milliers d'entrées ; chacune
+devient un paramètre lié d'un `IN` greffé sur une requête qui balaie déjà les
+3 000+ questions et tout l'historique de l'utilisateur. Il n'y a pas de
+limitation de débit sur ce point d'entrée. Le précédent invoqué
+(`loadAvailableObjectifsCMC`, `features/training/actions.ts:70-75`) ne prend
+qu'une chaîne — le tableau est l'amplificateur nouveau.
+
+**Régression ?** NON (surface neuve).
+
+**Correction suggérée.** Un schéma zod dédié —
+`z.object({ domain: z.string().trim().min(1).optional(), objectifsCMCs: z.array(z.string().trim().min(1)).max(50).optional() })`
+— avec `safeParse` et repli sur `{ failed: 0, unseen: 0, bookmarked: 0 }` en cas
+d'échec, pour ne pas faire remonter un throw jusqu'au `catch` du formulaire.
+
+---
+
+### 🟡 4 — `objectifsKey.split("|")` : un objectif CMC contenant `|` fausse les compteurs
+
+**Code**
+
+- `app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form.tsx:88`
+  — `const objectifsKey = selectedObjectifs.join("|")`
+- même fichier `:95` — `objectifsCMCs: objectifsKey ? objectifsKey.split("|") : undefined`
+- Le champ est du texte libre, sans restriction de jeu de caractères :
+  `features/questions/schemas.ts:14` — `objectifCMC: z.string().trim().min(1, …)` ;
+  `db/schema/questions.ts:21` — `text("objectif_cmc").notNull()`. Le formulaire admin
+  permet d'en **créer** un à la volée (combobox « Sélectionner ou créer… »,
+  cf. `.claude/rules/e2e-testing.md`).
+
+**Pourquoi c'est un vrai bug.** `join` puis `split` n'est réversible que si le
+séparateur est absent des valeurs. Un objectif nommé `Douleur thoracique | angor`
+part vers le serveur en deux fragments dont aucun ne correspond à une valeur en
+base → les trois compteurs tombent à 0. La création de session, elle, envoie
+`selectedObjectifs` **directement** (`:146-147`) et reste correcte : l'étudiant
+voit donc « Ratées 0 » puis démarre une session de révision non vide. La
+divergence est silencieuse, sans erreur ni journal.
+
+**Régression ?** NON.
+
+**Correction suggérée.** Ne pas re-dériver la valeur depuis la clé : garder
+`objectifsKey` comme **seule** dépendance de l'effet et envoyer
+`selectedObjectifs` (lu au moment de l'appel), ou utiliser
+`JSON.stringify(selectedObjectifs)` comme clé et `JSON.parse` pour la valeur.
+
+---
+
+### ℹ️ 5 — Asymétrie admin entre verrou de sélection et verrou de révélation
+
+**Code**
+
+- Révélation, bypass admin explicite : `features/training/dal.ts:573-575`
+  (`session.user.role === "admin" ? new Set<string>() : …`),
+  `features/training/dal.ts:716-718`, `features/training/actions.ts:358`.
+- Sélection, **aucun** bypass : `features/training/revision.ts:106`
+  (`getRevisionCounts`) et `features/training/actions.ts:133`
+  (`createTrainingSession`) appellent `resolveRevisionLock(userId)`
+  inconditionnellement.
+
+**Pourquoi c'est un constat et pas un bug.** L'asymétrie va dans le sens
+restrictif : un admin qui participe à un examen ouvert obtient un corpus de
+révision **amputé** de ces questions, alors qu'il peut déjà en lire la clé par
+les canaux de révélation. Aucune fuite, aucun contournement — seulement une
+incohérence qui produira un « pourquoi mon compteur est-il à 0 ? » un jour.
+
+**Régression ?** NON.
+
+**Correction suggérée.** Trancher explicitement et l'écrire : soit aligner
+(`isAdmin ? [] : await resolveRevisionLock(userId)`), soit documenter en une
+ligne dans `revision.ts` que le verrou de sélection est volontairement
+universel. Ne pas laisser le lecteur deviner.
+
+---
+
+### ℹ️ 6 — Le passe-plat d'arguments perd les guillemets (`shell: true`)
+
+**Code**
+
+- `scripts/test-integration.ts:21-23` — `vitestArgs` = `process.argv.slice(2)`
+  moins `--keep` et `--`.
+- `scripts/test-integration.ts:36-37` — `spawnSync(command, args, { …, shell: true })`.
+- `scripts/test-integration.ts:55-59` — `[..., ...vitestArgs]`.
+
+**Pourquoi c'est un constat.** Avec `shell: true`, Node concatène les arguments
+en une ligne de commande sans les re-citer. `bun run test:integration -- -t "verrou anti-triche"`
+arrive à vitest comme `-t verrou anti-triche` : deux positionnels parasites, donc
+un filtre de fichiers vide et « No test files found ». Les chemins simples
+(`tests/integration/revision-corpus.test.ts`) passent, ce qui masque le problème.
+**La CI n'est pas exposée** : `.github/workflows/ci.yml:85` invoque
+`bun run test:integration` sans aucun argument, et `process.argv.slice(2)` vaut
+alors `[]` — le comportement d'origine est strictement préservé.
+
+**Régression ?** NON.
+
+**Correction suggérée.** Retirer `shell: true` (les binaires `bun`/`bunx` sont
+résolus sans shell sous Windows via `spawnSync` + `.cmd` géré par Node ≥ 18), ou
+documenter dans l'en-tête du script que seuls des arguments sans espace sont
+supportés.
+
+---
+
+### ℹ️ 7 — `setQuestionBookmark` : aucune borne, et un oracle d'existence
+
+**Code** — `features/training/actions.ts:398-431` :
+
+- `:412-416` — insert `onConflictDoNothing` sur un `questionId` arbitraire, sans
+  vérifier ni `deleted_at`, ni un quelconque rattachement à une session de
+  l'utilisateur ;
+- `:427` — `if (getPgErrorCode(error) === "23503") return fail("Question introuvable.")`
+  distingue un identifiant existant d'un identifiant inexistant.
+
+**Pourquoi c'est un constat.** Un compte authentifié peut marquer les 3 000+
+questions de la banque (une requête par question, sans limitation de débit),
+ce qui gonfle la table et rend son propre critère « marquées » égal à la banque
+entière — nuisance auto-infligée, mais stockage non borné côté serveur. La
+distinction 23503 / succès est un oracle d'existence ; les identifiants étant
+des cuid2 (`lib/ids.ts`), il n'est pas énumérable, la valeur pratique est nulle.
+
+**Régression ?** NON.
+
+**Correction suggérée.** Plafonner le nombre de signets par utilisateur
+(`count(*)` gardé dans la même transaction, ex. 500) si le stockage devient un
+sujet. Rien à faire sur l'oracle.
+
+---
+
+### ℹ️ 8 — Marge de 0,26 point sur le seuil de couverture des branches
+
+**Mesure** (`bun run test:coverage` sur `HEAD`, exit 0) :
+Statements 83.68 % · **Branches 80.26 %** · Functions 81.88 % · Lines 84.56 %,
+contre un seuil de 80 % partout (`vitest.config.ts:106-111`).
+
+**Pourquoi c'est un constat.** La branche fait entrer trois composants dans le
+rapport (`…entrainement/_components/*` apparaissent bien dans la table v8 ;
+`training-config-form.tsx` à 69.09 % de branches). Le résultat passe, mais le
+prochain composant ajouté sans test fera tomber le job `Tests with coverage` de
+la CI. C'est une information à connaître avant d'empiler P1-B, pas un défaut de
+cette branche.
+
+**Correction suggérée.** Aucune ici. À garder en tête pour la campagne suivante.
+
+---
+
+## 3. Ce que le code tient bien (vérifié, pas supposé)
+
+Ces points étaient les plus susceptibles de casser ; ils ont été lus ligne à ligne
+et ils tiennent.
+
+- **Le verrou à la sélection est réellement appliqué**, au tirage
+  (`revision.ts:159` via `corpusWhere`) **et** aux compteurs (`revision.ts:114`),
+  sur les trois critères sans exception — c'est bien l'invariante centrale de la
+  spec §3, et `tests/integration/revision-corpus.test.ts:326-355` la garde.
+- **`resolveRevisionLock` est résolu hors transaction** (`actions.ts:133`, avant
+  le `db.transaction` de `:139`), conformément à la contrainte du pool `max: 5`
+  sans `connectionTimeoutMillis` (`db/index.ts:9`). Le paramètre `lockedIds` est
+  **requis** (`revision.ts:145`), donc un oubli casse la compilation.
+- **Le chemin non-révision est strictement inchangé** : `actions.ts:197-212`
+  reproduit à l'identique le `count` + `NOT_ENOUGH` + `random()/limit` de
+  `git show main:features/training/actions.ts`. Seule l'indentation bouge.
+- **Aucune injection SQL** : chaque valeur du SQL brut passe par la liaison de
+  paramètres du template `sql` (`revision.ts:29,42,47,64,71,84,161`) ; aucun
+  identifiant n'est interpolé.
+- **Aucun `sql.join` sur tableau vide** : les trois sites sont gardés
+  (`revision.ts:68`, `:80`, `:149`).
+- **Passation d'examen et quiz marketing public intouchés** :
+  `getOpenExamQuestionIds` (`dal.shared.ts:146-161`) n'est pas modifié, et aucun
+  fichier de `features/exams/actions.ts` / `app/(dashboard)/…/examen-blanc` n'est
+  au diff.
+
+---
+
+## 4. Faux positifs écartés
+
+| Suspecté                                                                                                                    | Écarté par                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getOpenExamLockedQuestionIds` change de sémantique (filtre TS au lieu de SQL)                                              | `dal.shared.ts:106` conserve le retour anticipé sur liste vide ; `new Set(questionIds.filter(id => locked.has(id)))` est équivalent au `IN` SQL, doublons compris (le `Set` déduplique dans les deux versions). `tests/integration/exam-lock-source.test.ts:109-119` assert l'inclusion.                                                           |
+| `questionCount: picked.length` fausse le score, l'historique, le dashboard                                                  | Les 7 lecteurs (`dal.ts:175,256,291,390,624,756`, `cron.ts:59-60`, `actions.ts:501`) utilisent tous cette colonne comme **dénominateur du nombre d'items**. `picked.length` est maintenant la valeur exacte ; auparavant elle ne pouvait qu'égaler la demande. C'est un durcissement, pas un biais.                                                |
+| Le `superRefine` rend un champ obligatoire pour un appelant existant                                                        | `mode` était **déjà** requis dans le type de sortie avant la branche (`.default("test")` sur `z.infer`, cf. `git show main:features/training/schemas.ts:13`). `revisionFilters` est `.optional()`. Seuls appelants : le formulaire et les tests ; `tsc --noEmit` vert.                                                                             |
+| `EMPTY_REVISION` consomme un jeton du rate-limit `MAX_SESSIONS_PER_HOUR`                                                    | Le `throw` de `actions.ts:195` remonte hors du `db.transaction` de `:139` → rollback complet, aucune ligne `training_sessions` insérée. Or le compteur est un `count(*)` sur cette table (`actions.ts:148-156`). Quota intact.                                                                                                                     |
+| Le motif d'espacement JSX corrigé par `848072a` subsiste ailleurs (« Seulement {n} question… »)                             | `training-config-form.tsx:284-288` : l'interpolation est suivie de texte **sur la même ligne** (`{availableQuestions} question`), et la coupure tombe **après** le texte — la concaténation `question` + `{"s"}` est exactement l'effet voulu. Couvert par les tests `:190` et `:208`.                                                             |
+| Un `answered_at` NULL gagne le `DISTINCT ON` (`ORDER BY … DESC` ⇒ NULLS FIRST) et fige un « raté »                          | Un seul écrivain de la colonne dans tout le repo, `actions.ts:350`, qui écrit toujours `selectedAnswer` + `answeredAt` ensemble ; le CTE filtre `selected_answer is not null` (`revision.ts:29`). Réserve honnête : d'éventuelles lignes héritées de la migration Convex ne sont pas vérifiables ici.                                              |
+| IDOR sur `loadRevisionCounts` (userId depuis les arguments)                                                                 | `actions.ts:66` passe `session.user.id`, jamais `args`. `tests/integration/revision-corpus.test.ts:396-402` le vérifie explicitement.                                                                                                                                                                                                              |
+| Un admin inspectant la session d'un étudiant voit **ses propres** signets                                                   | `features/training/dal.ts:570` (`isOwner`) et `:578` (`isOwner ? … : []`). Couvert indirectement par `tests/integration/question-bookmarks.test.ts:121-131`.                                                                                                                                                                                       |
+| Le passe-plat d'arguments casse la CI                                                                                       | `.github/workflows/ci.yml:85` → `bun run test:integration` sans argument ⇒ `process.argv.slice(2)` vaut `[]` ⇒ ligne de commande identique à avant.                                                                                                                                                                                                |
+| Les trois composants ne sont pas réellement entrés dans le rapport de couverture (`coverage.include` ne liste pas `app/**`) | Réfuté **empiriquement** : la table v8 de `bun run test:coverage` liste bien `…nt/_components` avec `…nfig-form.tsx`, `…on-client.tsx` et `…ti-select.tsx`. La revendication de `aff61da` est exacte.                                                                                                                                              |
+| `revisionFilters` dupliqué (`["failed","failed"]`) casse le `OR`                                                            | `revision.ts:148` — `[...new Set(criteria)]`.                                                                                                                                                                                                                                                                                                      |
+| Les tests de composants ne testent que de quoi passer la barre                                                              | Lus : `TrainingSessionClient.test.tsx:102-128` (hydratation + persistance + échec réseau via `callAction`), `:157-228` (révélation tuteur, échec de réponse, redirection, non-redirection) ; `TrainingConfigForm.test.tsx:73-151` (transmission des critères, décochage, corpus vide). Ce sont des assertions de comportement, pas du remplissage. |
+| Le corpus peut inclure des questions supprimées                                                                             | `revision.ts:63` — `q.deleted_at is null` est le premier prédicat, inconditionnel.                                                                                                                                                                                                                                                                 |
+
+**Non vérifiable dans ce périmètre** (à ne pas confondre avec un feu vert) : la
+validité et le plan d'exécution réels du SQL brut de `revision.ts` — notamment
+`count(*) filter (where <sous-requête corrélée>)` (`:110-112`) et le
+`DISTINCT ON` sur un `UNION ALL` (`:37-39`) — n'ont pas été éprouvés, la
+consigne interdisant toute commande de base de données. `tests/integration/revision-corpus.test.ts`
+couvre ces chemins ; **exiger un run vert de `bun run test:integration` avant le
+merge**, c'est le seul garde-fou de cette partie.
+
+---
+
+## 5. Verdict
+
+> **Est-il sûr de pousser cette branche et d'ouvrir la PR vers `main` ? — OUI.**
+
+Aucun constat bloquant : pas de fuite de clé de réponse par un canal réellement
+atteignable depuis l'interface, pas d'IDOR, pas de corruption de données, pas de
+contrôle d'accès cassé, et le chemin d'entraînement classique est bit à bit
+inchangé. Le verrou anti-triche à la sélection — le cœur de la spec — est
+réellement appliqué au tirage **et** aux compteurs, et il est gardé par des tests.
+
+Le constat **#1** doit être corrigé **avant le merge** : c'est une ligne de SQL,
+et il referme un canal latéral qui contredit une invariante que le code affirme
+trois fois. Il n'est pas bloquant pour la **poussée** de la branche.
+
+| Priorité                | Constat                                                                      | Effort  |
+| ----------------------- | ---------------------------------------------------------------------------- | ------- |
+| **Bloquant maintenant** | — (aucun)                                                                    | —       |
+| **Avant merge**         | #1 `and s.status <> 'in_progress'` dans le CTE + test d'intégration dédié    | ~15 min |
+| **Avant merge**         | Run vert de `bun run test:integration` (le SQL brut n'a pas été exécuté ici) | ~5 min  |
+| **Avant merge**         | #3 `zod.safeParse` sur `loadRevisionCounts` (règle projet explicite)         | ~10 min |
+| **Polish**              | #2 réintroduire la sélectivité `inArray` dans le verrou                      | ~20 min |
+| **Polish**              | #4 remplacer `join("\|")`/`split("\|")` par une clé non ambiguë              | ~5 min  |
+| **Polish**              | #5 trancher et documenter l'asymétrie admin                                  | ~5 min  |
+| **Polish**              | #6 retirer `shell: true` de `scripts/test-integration.ts`                    | ~5 min  |
+| **Backlog**             | #7 plafond de signets par utilisateur · #8 surveiller la marge de couverture | —       |
+
+---
+
+## 6. Confirmations de sûreté opérationnelle
+
+- **Lecture seule respectée.** Aucun fichier source modifié. Le seul fichier écrit
+  est ce rapport (`docs/superpowers/reviews/2026-08-02-revision-ciblee-implementation-review.md`),
+  non commité — artefact jetable.
+- **Aucune commande de base de données.** Ni `db:generate`, ni `db:migrate`, ni
+  `test:integration` : aucune branche Neon n'a été créée ni détruite. Aucun outil
+  MCP Neon appelé.
+- **Aucun serveur de développement lancé.** Ni `bun dev`, ni `bun run start`, ni
+  Playwright.
+- **Commandes exécutées** (les seules) : `git log` / `git diff` / `git show`,
+  `bun run check` (exit 0), `bun run test:coverage` (exit 0), plus des lectures et
+  recherches de fichiers.
+- **Aucun secret imprimé.** Aucun fichier `.env*` lu ni affiché.
+- **Aucune commande destructive ni de déploiement.**

--- a/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
+++ b/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
@@ -146,8 +146,28 @@ candidats)` pour les **trois** critères, uniformément — y compris `unseen`,
   dans le formulaire sont calculés sur exactement le même corpus filtré. Sans
   cela, le compteur redevient l'oracle que le lot n'est plus.
 - **Révélation** : les trois gardes existantes restent en place, inchangées.
-  Elles couvrent la course « je crée ma session filtrée, **puis** je rejoins
-  l'examen » : le verrou est réévalué à chaque lecture.
+  Réévaluées à chaque lecture, elles masquent la correction même pour une
+  session créée **avant** l'entrée dans l'examen.
+
+**Précision sur la course « je crée ma session filtrée, puis je rejoins
+l'examen »** (soulevée par la revue de design du 2026-08-01). Les gardes de
+révélation masquent la clé mais **ne retirent pas** la question du lot déjà
+constitué — le lot, lui, n'est pas recalculé. Ce n'est pourtant pas un trou, et
+la raison mérite d'être écrite parce qu'elle n'est pas évidente :
+
+> Pour que l'appartenance au lot dise quoi que ce soit sur les **réponses d'un
+> examen**, il faut que ces réponses existent. Elles n'existent qu'à partir
+> d'une participation — or c'est exactement ce qui active le verrou. Une session
+> filtrée créée avant toute participation ne peut donc encoder que l'historique
+> d'entraînement passé de l'étudiant, information qu'il lit déjà dans ses
+> propres résultats.
+
+Autrement dit : l'oracle craint porte sur les réponses de l'examen en cours, et
+celui-là est fermé à la source. L'invariante à préserver n'est pas « le lot est
+recalculé », c'est **« aucun lot ne se constitue pendant qu'une participation
+est ouverte sur ces questions »**. Si une évolution future permettait de
+recomposer ou d'étendre un lot existant, cette garantie tomberait et il faudrait
+alors persister les critères pour re-filtrer à la lecture.
 
 Autres chemins passés en revue :
 

--- a/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
+++ b/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
@@ -1,7 +1,9 @@
 # Spec — Révision ciblée en entraînement (P1-A)
 
 - **Date** : 2026-08-01
-- **Statut** : DESIGN VALIDÉ — à planifier (writing-plans)
+- **Statut** : IMPLÉMENTÉ le 2026-08-02 (branche `feat/p1-qbank-engagement`) —
+  revue adversariale de design passée (12 constats triés : 11 corrigés, 1
+  rétrogradé avec preuve). Gates verts.
 - **Branche** : `feat/p1-qbank-engagement` (empilée sur `main` ; porte aussi le
   commit `docs: notes en attente`)
 - **Origine** : issue [#115 « P1 — QBank : engagement étudiant »](https://github.com/RinKhimera/NOMAQbanq/issues/115),
@@ -221,8 +223,9 @@ insertion atomique session + items.
 
 Deux actions neuves :
 
-- `toggleQuestionBookmark(questionId)` — idempotente (insert `ON CONFLICT DO
-NOTHING` / delete), renvoie l'état du signet et rien d'autre.
+- `setQuestionBookmark({ questionId, isBookmarked })` — prend l'**état voulu** et
+  non une bascule, ce qui la rend idempotente : `callAction` peut la retenter
+  sans inverser deux fois le marquage. Renvoie le succès et rien d'autre.
 - `loadRevisionCounts(domain, objectifs)` — calqué sur
   `loadAvailableObjectifsCMC`, appelé via `callAction` quand l'étudiant change
   de domaine ou d'objectifs.
@@ -230,8 +233,12 @@ NOTHING` / delete), renvoie l'état du signet et rien d'autre.
 ### 5. UI
 
 - **`training-config-form.tsx`** : un groupe « Réviser » de trois puces
-  cochables, chacune avec son compteur live (« Ratées · 42 »). Le curseur de
-  nombre se borne au corpus filtré. Les compteurs se rafraîchissent au
+  cochables, chacune avec son compteur live (« Ratées · 42 »). Les compteurs
+  sont **indicatifs** : le curseur n'est pas plafonné par eux, car l'union de
+  plusieurs critères n'est pas la somme de leurs compteurs (une même question
+  peut être ratée **et** marquée) — un plafond client mentirait. Le serveur
+  borne au corpus et `createTrainingSession` renvoie le nombre réellement
+  retenu, que le toast annonce. Les compteurs se rafraîchissent au
   changement de domaine/objectifs, sur le mécanisme déjà en place pour les
   objectifs CMC.
 - **Runner d'entraînement** : le bouton « Marquer » existe déjà côté
@@ -253,10 +260,10 @@ Intégration (base réelle) — l'essentiel de la valeur :
 - corpus vide → refus explicite ;
 - IDOR : l'historique et les signets d'un autre étudiant n'entrent jamais dans
   le corpus ;
-- `toggleQuestionBookmark` idempotente sous appels répétés.
+- `setQuestionBookmark` idempotente sous appels répétés.
 
-Frontend : puces + bornes du curseur dans le formulaire ; persistance du
-marquage dans le runner (fin du no-op).
+Frontend : puces et compteurs dans le formulaire ; persistance du marquage dans
+le runner (fin du no-op), échec réseau compris.
 
 Nettoyage `afterAll` : `question_bookmarks` avant `questions` (FK), comme les
 autres tables enfants.

--- a/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
+++ b/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
@@ -113,8 +113,15 @@ avec domaine + objectifs CMC et `questions.deleted_at IS NULL`, puis
 
 `exam_answers.created_at` vaut « début de la tentative » et non « instant de la
 réponse » : les lignes sont pré-créées au démarrage de l'examen
-(`features/exams/actions.ts`). Sans conséquence — les réponses d'un même examen
-sont simultanées par nature, et l'ordre entre tentatives distinctes reste juste.
+(`features/exams/actions.ts`) et jamais réhorodatées à la réponse. Limite
+assumée, relevée par la revue de design : si un étudiant intercale une session
+d'entraînement **pendant** un examen long, sa réponse d'entraînement porte un
+horodatage postérieur à celle de l'examen même si l'examen a été répondu après —
+le `DISTINCT ON` retient alors la mauvaise « dernière tentative ». L'effet se
+borne à classer une question comme ratée ou non sur la base d'une de ses deux
+tentatives récentes, toutes deux de l'étudiant lui-même. Corriger demanderait un
+horodatage à l'écriture sur `exam_answers` : hors périmètre de P1-A, à ouvrir si
+le classement se révèle visiblement faux en usage.
 
 Volume borné : l'historique d'un étudiant vaut ses sessions × 20 items plus ses
 participations × N réponses ; `unseen` balaie la banque (3 000+ lignes) une fois

--- a/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
+++ b/docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md
@@ -1,0 +1,242 @@
+# Spec — Révision ciblée en entraînement (P1-A)
+
+- **Date** : 2026-08-01
+- **Statut** : DESIGN VALIDÉ — à planifier (writing-plans)
+- **Branche** : `feat/p1-qbank-engagement` (empilée sur `main` ; porte aussi le
+  commit `docs: notes en attente`)
+- **Origine** : issue [#115 « P1 — QBank : engagement étudiant »](https://github.com/RinKhimera/NOMAQbanq/issues/115),
+  issue de l'audit du 2026-07-13 (volet produit).
+
+L'issue #115 empile deux fonctionnalités indépendantes. Elle est découpée en
+deux specs :
+
+- **P1-A (ce document)** — filtre d'entraînement « ratées / non vues / marquées ».
+- **P1-B (à venir)** — notes personnelles sur les questions.
+
+## Problème
+
+Un étudiant qui rate une question n'a aucun moyen de la rejouer. Chaque session
+d'entraînement tire au hasard dans les 3 000+ questions ; l'historique
+(`training_session_items.is_correct`, `exam_answers.is_correct`) est écrit mais
+n'est jamais relu pour construire un lot de révision. Le seul ciblage disponible
+est thématique (domaine + objectifs CMC), pas personnel.
+
+Trois constats relevés à la source, dont deux contredisent l'issue :
+
+- **`is_correct` existe bien en entraînement** (`training_session_items`) et en
+  examen (`exam_answers`) — « ratées » est faisable par agrégation, comme
+  l'annonce l'issue.
+- **`is_flagged` n'existe QUE pour les examens** (`db/schema/exams.ts`). En
+  entraînement, le bouton « Marquer » du runner est branché sur un no-op
+  (`training-session-client.tsx` : `onFlag: async () => ({ ok: true })`) : le
+  marquage n'est **jamais** persisté. Le critère « marquées » demande donc du
+  schéma neuf, contrairement à ce que suppose l'issue.
+- **Aucune table de notes personnelles** n'existe — d'où le report en P1-B.
+
+## Décisions
+
+| Question                | Décision retenue                                                     |
+| ----------------------- | -------------------------------------------------------------------- |
+| Découpage               | Deux specs ; le filtre d'abord (P1-A), les notes ensuite (P1-B)      |
+| Corpus d'historique     | Entraînement **+** examens, verrou anti-triche respecté              |
+| Persistance du marquage | Table de signets durable `question_bookmarks`                        |
+| Définition de « ratée » | **Dernière** tentative fausse (la question sort du lot dès réussite) |
+| Combinaison             | Critères en OU entre eux, en ET avec domaine/objectifs               |
+| Corpus plus court       | Démarrer avec ce qui existe, au lieu de refuser                      |
+| Calcul du corpus        | Agrégation à la volée (pas de table d'état dérivée)                  |
+
+L'agrégation à la volée est imposée autant par la justesse que par la règle
+projet « Comptes via SQL agrégé, pas de tables d'agrégat » (`AGENTS.md`) : une
+table `user_question_states` maintenue à l'écriture dupliquerait un état qui
+dérive dès qu'une écriture rate, exigerait un backfill, et multiplierait les
+définitions de « ratée ». À la volée, il n'existe qu'une définition et qu'un
+seul point d'application de l'anti-triche.
+
+## Design
+
+### 1. Modèle de données
+
+Une seule table neuve :
+
+```
+question_bookmarks
+  id           text PK
+  user_id      text NOT NULL → user(id)      ON DELETE CASCADE
+  question_id  text NOT NULL → questions(id) ON DELETE CASCADE
+  created_at   timestamptz NOT NULL DEFAULT now()
+  UNIQUE (user_id, question_id)
+  INDEX (user_id)
+```
+
+Le `CASCADE` sur `question_id` est délibéré et contre-courant du reste du
+schéma, où les FK vers `questions` sont en `RESTRICT`. `deleteQuestion`
+(`features/questions/actions.ts`) s'appuie sur ce `RESTRICT` : il **tente** le
+hard delete et laisse Postgres arbitrer (`23001` → repli en soft delete). Un
+signet en `RESTRICT` transformerait silencieusement tout hard delete en soft
+delete dès qu'un seul étudiant a marqué la question. Un signet n'est pas du
+contenu : il disparaît avec sa question.
+
+`training_session_items` et `exam_answers` ne changent pas.
+
+### 2. Le corpus de révision
+
+Un builder partagé (`server-only`) construit la **dernière tentative par
+question**, en unissant les deux historiques de l'utilisateur courant :
+
+- `training_session_items` joint à `training_sessions` (filtre `user_id`),
+  `selected_answer IS NOT NULL`, horodatage `answered_at` ;
+- `exam_answers` joint à `exam_participations` (filtre `user_id`),
+  `selected_answer IS NOT NULL`, horodatage `created_at` ;
+
+puis `DISTINCT ON (question_id) … ORDER BY question_id, <horodatage> DESC`.
+
+Les trois critères se lisent sur cette base :
+
+| Critère        | Définition                                                                                                            |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **failed**     | dernière tentative `is_correct = false`                                                                               |
+| **bookmarked** | présente dans `question_bookmarks` (utilisateur courant) **ou** `exam_answers.is_flagged` d'une de ses participations |
+| **unseen**     | absente des deux historiques                                                                                          |
+
+Deux précisions qui lèvent l'ambiguïté du mot « vue » :
+
+- « vue » signifie **répondue**. Une question servie puis laissée sans réponse
+  (session abandonnée, examen non terminé) reste **non vue** et peut donc être
+  retirée — c'est voulu : elle n'a rien appris à l'étudiant.
+- **bookmarked** se lit directement sur `question_bookmarks` et
+  `exam_answers.is_flagged`, **sans** passer par l'agrégat des tentatives : une
+  question marquée mais jamais répondue compte comme marquée.
+
+Les critères cochés s'unissent en **OU**, le résultat est intersecté (**ET**)
+avec domaine + objectifs CMC et `questions.deleted_at IS NULL`, puis
+`ORDER BY random() LIMIT n`.
+
+`exam_answers.created_at` vaut « début de la tentative » et non « instant de la
+réponse » : les lignes sont pré-créées au démarrage de l'examen
+(`features/exams/actions.ts`). Sans conséquence — les réponses d'un même examen
+sont simultanées par nature, et l'ordre entre tentatives distinctes reste juste.
+
+Volume borné : l'historique d'un étudiant vaut ses sessions × 20 items plus ses
+participations × N réponses ; `unseen` balaie la banque (3 000+ lignes) une fois
+à la création de session. Aucune lecture non bornée n'est introduite.
+
+### 3. Anti-triche — deux couches
+
+Le verrou existant `getOpenExamLockedQuestionIds(userId, questionIds)`
+(`features/exams/dal.shared.ts`) marque toute question d'un examen dont
+`end_date` est future **et** où l'étudiant a une participation, quel que soit
+son statut. Il est aujourd'hui appliqué aux trois canaux de **révélation** :
+`getTrainingSessionById`, `getTrainingSessionResults`, et le `reveal` du mode
+tuteur dans `saveTrainingAnswer`.
+
+Ce socle ne suffit pas ici. Un filtre « rejouer mes ratées » est **lui-même un
+oracle** : le simple fait qu'une question apparaisse dans le lot dit « tu t'es
+trompé ». Si la participation de l'étudiant est encore `in_progress`, il apprend
+quelles réponses sont fausses et peut les corriger dans l'examen — triche
+directe, **sans jamais voir la clé**. Après soumission mais avant clôture, cela
+divulgue la correction que le produit diffère volontairement.
+
+D'où la règle centrale de cette spec :
+
+> **Le verrou s'applique à la SÉLECTION, en plus de la RÉVÉLATION.**
+
+- **Sélection** : le corpus retranche `getOpenExamLockedQuestionIds(userId,
+candidats)` pour les **trois** critères, uniformément — y compris `unseen`,
+  pour ne pas laisser de faille par différence — et les **compteurs** affichés
+  dans le formulaire sont calculés sur exactement le même corpus filtré. Sans
+  cela, le compteur redevient l'oracle que le lot n'est plus.
+- **Révélation** : les trois gardes existantes restent en place, inchangées.
+  Elles couvrent la course « je crée ma session filtrée, **puis** je rejoins
+  l'examen » : le verrou est réévalué à chaque lecture.
+
+Autres chemins passés en revue :
+
+- **IDOR** : le filtre ne prend jamais d'identifiant d'utilisateur ni de liste
+  de questions venant du client ; tout se dérive de `session.user.id`.
+- **Bascule d'un signet pendant un examen ouvert** : autorisée, elle ne renvoie
+  que l'état du signet — aucune donnée de correction.
+- **Bypass admin** : inchangé (les gardes existantes sautent déjà le verrou pour
+  le rôle `admin`).
+- **Déverrouillage à `end_date`** : politique existante, non modifiée.
+
+**Trou pré-existant, explicitement hors périmètre** : une question d'un examen
+ouvert que l'étudiant n'a **pas** rejoint peut déjà tomber dans un tirage
+d'entraînement aléatoire — le verrou est volontairement _user-scoped_ (la
+variante anonyme `getOpenExamQuestionIds` est réservée au quiz marketing
+public). P1-A n'aggrave pas ce cas et ne l'élargit pas.
+
+### 4. Server Actions et schémas
+
+`createTrainingSessionSchema` gagne un champ optionnel :
+
+```ts
+revisionFilters: z.array(z.enum(["failed", "unseen", "bookmarked"]))
+  .max(3)
+  .optional()
+```
+
+Quand il est présent et non vide, deux règles de `createTrainingSession`
+changent :
+
+- le nombre demandé est **borné au corpus disponible** au lieu de déclencher le
+  `NOT_ENOUGH` actuel ;
+- `MIN_QUESTIONS` (5) ne s'applique plus : trois questions ratées font une
+  session de révision légitime. `MAX_QUESTIONS` (20), lui, reste la borne haute.
+
+Un `revisionFilters` **vide** équivaut à son absence : tirage aléatoire
+classique, `MIN_QUESTIONS` et `NOT_ENOUGH` inclus. Les modes `tutor` et `test`
+restent tous deux disponibles en révision.
+
+Il ne subsiste qu'une condition de refus, **corpus vide**, avec un message qui
+nomme le critère concerné. Le reste de l'action ne bouge pas : garde d'accès,
+verrou de ligne utilisateur, rate-limit, refus de session active concurrente,
+insertion atomique session + items.
+
+Deux actions neuves :
+
+- `toggleQuestionBookmark(questionId)` — idempotente (insert `ON CONFLICT DO
+NOTHING` / delete), renvoie l'état du signet et rien d'autre.
+- `loadRevisionCounts(domain, objectifs)` — calqué sur
+  `loadAvailableObjectifsCMC`, appelé via `callAction` quand l'étudiant change
+  de domaine ou d'objectifs.
+
+### 5. UI
+
+- **`training-config-form.tsx`** : un groupe « Réviser » de trois puces
+  cochables, chacune avec son compteur live (« Ratées · 42 »). Le curseur de
+  nombre se borne au corpus filtré. Les compteurs se rafraîchissent au
+  changement de domaine/objectifs, sur le mécanisme déjà en place pour les
+  objectifs CMC.
+- **Runner d'entraînement** : le bouton « Marquer » existe déjà côté
+  `QuestionCard` ; `training-session-client.tsx` remplace son `onFlag` no-op par
+  `toggleQuestionBookmark`, avec l'état initial hydraté depuis les signets de
+  la session en cours.
+- Aucun autre écran ne bouge. Le comportement du marquage **en examen** est
+  inchangé.
+
+### 6. Tests
+
+Intégration (base réelle) — l'essentiel de la valeur :
+
+- **exclusion des questions verrouillées du lot ET des compteurs** — test
+  central, c'est lui qui garde l'invariante anti-triche ;
+- définition « dernière tentative » : ratée puis réussie → sort du lot ;
+- union OU des critères, intersection ET avec domaine/objectifs ;
+- corpus plus court que demandé → session démarrée, bornée ;
+- corpus vide → refus explicite ;
+- IDOR : l'historique et les signets d'un autre étudiant n'entrent jamais dans
+  le corpus ;
+- `toggleQuestionBookmark` idempotente sous appels répétés.
+
+Frontend : puces + bornes du curseur dans le formulaire ; persistance du
+marquage dans le runner (fin du no-op).
+
+Nettoyage `afterAll` : `question_bookmarks` avant `questions` (FK), comme les
+autres tables enfants.
+
+## Hors périmètre
+
+- **Notes personnelles** → spec P1-B.
+- **Verrou anonyme sur les examens non rejoints** → trou pré-existant, inchangé.
+- Aucun tableau de bord de statistiques par question.
+- Aucun changement au mode examen ni au quiz marketing.

--- a/drizzle/0012_lowly_paper_doll.sql
+++ b/drizzle/0012_lowly_paper_doll.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "question_bookmarks" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"question_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "question_bookmarks_user_question_unique" UNIQUE("user_id","question_id")
+);
+--> statement-breakpoint
+ALTER TABLE "question_bookmarks" ADD CONSTRAINT "question_bookmarks_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_bookmarks" ADD CONSTRAINT "question_bookmarks_question_id_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "question_bookmarks_user_id_idx" ON "question_bookmarks" USING btree ("user_id");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2687 @@
+{
+  "id": "a021d1d3-6d26-4d02-be51-6884fb920bc7",
+  "prevId": "4bad79ee-0fd3-402e-af38-b2b9fcb19c00",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_key_idx": {
+          "name": "rate_limit_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_exam_results": {
+          "name": "notify_exam_results",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_access_expiry": {
+          "name": "notify_access_expiry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymized_at": {
+          "name": "anonymized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_role_idx": {
+          "name": "user_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_answers": {
+      "name": "exam_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer": {
+          "name": "selected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_flagged": {
+          "name": "is_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_answers_participation_id_idx": {
+          "name": "exam_answers_participation_id_idx",
+          "columns": [
+            {
+              "expression": "participation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_answers_question_id_idx": {
+          "name": "exam_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_answers_participation_id_exam_participations_id_fk": {
+          "name": "exam_answers_participation_id_exam_participations_id_fk",
+          "tableFrom": "exam_answers",
+          "tableTo": "exam_participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_answers_question_id_questions_id_fk": {
+          "name": "exam_answers_question_id_questions_id_fk",
+          "tableFrom": "exam_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exam_answers_participation_question_unique": {
+          "name": "exam_answers_participation_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participation_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_audience": {
+      "name": "exam_audience",
+      "schema": "",
+      "columns": {
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_audience_user_id_idx": {
+          "name": "exam_audience_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_audience_exam_id_exams_id_fk": {
+          "name": "exam_audience_exam_id_exams_id_fk",
+          "tableFrom": "exam_audience",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_audience_user_id_user_id_fk": {
+          "name": "exam_audience_user_id_user_id_fk",
+          "tableFrom": "exam_audience",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exam_audience_exam_id_user_id_pk": {
+          "name": "exam_audience_exam_id_user_id_pk",
+          "columns": [
+            "exam_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_participations": {
+      "name": "exam_participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "exam_participation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results_notified_at": {
+          "name": "results_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_started_at": {
+          "name": "pause_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pause_duration_ms": {
+          "name": "total_pause_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_participations_exam_id_idx": {
+          "name": "exam_participations_exam_id_idx",
+          "columns": [
+            {
+              "expression": "exam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_user_id_idx": {
+          "name": "exam_participations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_status_idx": {
+          "name": "exam_participations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_results_pending_idx": {
+          "name": "exam_participations_results_pending_idx",
+          "columns": [
+            {
+              "expression": "exam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"exam_participations\".\"status\" in ('completed', 'auto_submitted') and \"exam_participations\".\"results_notified_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_participations_exam_id_exams_id_fk": {
+          "name": "exam_participations_exam_id_exams_id_fk",
+          "tableFrom": "exam_participations",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_participations_user_id_user_id_fk": {
+          "name": "exam_participations_user_id_user_id_fk",
+          "tableFrom": "exam_participations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exam_participations_exam_user_unique": {
+          "name": "exam_participations_exam_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "exam_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_questions": {
+      "name": "exam_questions",
+      "schema": "",
+      "columns": {
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "exam_questions_question_id_idx": {
+          "name": "exam_questions_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_questions_exam_id_exams_id_fk": {
+          "name": "exam_questions_exam_id_exams_id_fk",
+          "tableFrom": "exam_questions",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_questions_question_id_questions_id_fk": {
+          "name": "exam_questions_question_id_questions_id_fk",
+          "tableFrom": "exam_questions",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exam_questions_exam_id_question_id_pk": {
+          "name": "exam_questions_exam_id_question_id_pk",
+          "columns": [
+            "exam_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "exam_questions_exam_position_unique": {
+          "name": "exam_questions_exam_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "exam_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exams": {
+      "name": "exams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_time": {
+          "name": "completion_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_pause": {
+          "name": "enable_pause",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pause_duration_minutes": {
+          "name": "pause_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "exam_audience_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribers'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exams_is_active_idx": {
+          "name": "exams_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_start_date_idx": {
+          "name": "exams_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_end_date_idx": {
+          "name": "exams_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_is_active_start_date_idx": {
+          "name": "exams_is_active_start_date_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_created_by_idx": {
+          "name": "exams_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exams_created_by_user_id_fk": {
+          "name": "exams_created_by_user_id_fk",
+          "tableFrom": "exams",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_explanations": {
+      "name": "question_explanations",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_explanations_question_id_questions_id_fk": {
+          "name": "question_explanations_question_id_questions_id_fk",
+          "tableFrom": "question_explanations",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_images": {
+      "name": "question_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_image_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'statement'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_images_question_id_idx": {
+          "name": "question_images_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_images_question_kind_idx": {
+          "name": "question_images_question_kind_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_images_question_id_questions_id_fk": {
+          "name": "question_images_question_id_questions_id_fk",
+          "tableFrom": "question_images",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objectif_cmc": {
+          "name": "objectif_cmc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_domain_idx": {
+          "name": "questions_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_objectif_cmc_idx": {
+          "name": "questions_objectif_cmc_idx",
+          "columns": [
+            {
+              "expression": "objectif_cmc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_bookmarks": {
+      "name": "question_bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_bookmarks_user_id_idx": {
+          "name": "question_bookmarks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_bookmarks_user_id_user_id_fk": {
+          "name": "question_bookmarks_user_id_user_id_fk",
+          "tableFrom": "question_bookmarks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_bookmarks_question_id_questions_id_fk": {
+          "name": "question_bookmarks_question_id_questions_id_fk",
+          "tableFrom": "question_bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_bookmarks_user_question_unique": {
+          "name": "question_bookmarks_user_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_session_items": {
+      "name": "training_session_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer": {
+          "name": "selected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "training_session_items_session_id_idx": {
+          "name": "training_session_items_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_session_items_question_id_idx": {
+          "name": "training_session_items_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_session_items_session_id_training_sessions_id_fk": {
+          "name": "training_session_items_session_id_training_sessions_id_fk",
+          "tableFrom": "training_session_items",
+          "tableTo": "training_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_session_items_question_id_questions_id_fk": {
+          "name": "training_session_items_question_id_questions_id_fk",
+          "tableFrom": "training_session_items",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "training_session_items_session_question_unique": {
+          "name": "training_session_items_session_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "question_id"
+          ]
+        },
+        "training_session_items_session_position_unique": {
+          "name": "training_session_items_session_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_sessions": {
+      "name": "training_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "training_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "training_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'test'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectif_cmc": {
+          "name": "objectif_cmc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_sessions_user_status_idx": {
+          "name": "training_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_user_started_at_idx": {
+          "name": "training_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_status_idx": {
+          "name": "training_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_status_expires_at_idx": {
+          "name": "training_sessions_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_sessions_user_id_user_id_fk": {
+          "name": "training_sessions_user_id_user_id_fk",
+          "tableFrom": "training_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "product_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cad": {
+          "name": "price_cad",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_days": {
+          "name": "duration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_combo": {
+          "name": "is_combo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "products_code_idx": {
+          "name": "products_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stripe_product_id_idx": {
+          "name": "products_stripe_product_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_is_active_idx": {
+          "name": "products_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_days": {
+          "name": "duration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_stripe_event_id_unique": {
+          "name": "transactions_stripe_event_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_id_idx": {
+          "name": "transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_session_id_idx": {
+          "name": "transactions_stripe_session_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_type_idx": {
+          "name": "transactions_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_access_type_idx": {
+          "name": "transactions_user_access_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_created_at_idx": {
+          "name": "transactions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_product_id_products_id_fk": {
+          "name": "transactions_product_id_products_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_recorded_by_user_id_fk": {
+          "name": "transactions_recorded_by_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_access": {
+      "name": "user_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_reminder_sent_at": {
+          "name": "expiry_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transaction_id": {
+          "name": "last_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_access_user_id_idx": {
+          "name": "user_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_access_expires_at_idx": {
+          "name": "user_access_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_access_expiry_reminder_pending_idx": {
+          "name": "user_access_expiry_reminder_pending_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_access\".\"expiry_reminder_sent_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_access_user_id_user_id_fk": {
+          "name": "user_access_user_id_user_id_fk",
+          "tableFrom": "user_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_access_last_transaction_id_transactions_id_fk": {
+          "name": "user_access_last_transaction_id_transactions_id_fk",
+          "tableFrom": "user_access",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "last_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_access_user_access_type_unique": {
+          "name": "user_access_user_access_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "access_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rate_limits": {
+      "name": "quiz_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quiz_rate_limits_key_action_unique": {
+          "name": "quiz_rate_limits_key_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_rate_limits": {
+      "name": "upload_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_type": {
+          "name": "upload_type",
+          "type": "upload_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upload_rate_limits_user_id_idx": {
+          "name": "upload_rate_limits_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_rate_limits_user_id_user_id_fk": {
+          "name": "upload_rate_limits_user_id_user_id_fk",
+          "tableFrom": "upload_rate_limits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "upload_rate_limits_user_type_unique": {
+          "name": "upload_rate_limits_user_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "upload_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_type": {
+      "name": "access_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "training"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "CAD",
+        "XAF"
+      ]
+    },
+    "public.exam_audience_type": {
+      "name": "exam_audience_type",
+      "schema": "public",
+      "values": [
+        "subscribers",
+        "restricted"
+      ]
+    },
+    "public.exam_participation_status": {
+      "name": "exam_participation_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "auto_submitted"
+      ]
+    },
+    "public.exam_pause_phase": {
+      "name": "exam_pause_phase",
+      "schema": "public",
+      "values": [
+        "before_pause",
+        "during_pause",
+        "after_pause"
+      ]
+    },
+    "public.product_code": {
+      "name": "product_code",
+      "schema": "public",
+      "values": [
+        "exam_access",
+        "training_access",
+        "exam_access_promo",
+        "training_access_promo",
+        "premium_access"
+      ]
+    },
+    "public.question_image_kind": {
+      "name": "question_image_kind",
+      "schema": "public",
+      "values": [
+        "statement",
+        "explanation"
+      ]
+    },
+    "public.training_mode": {
+      "name": "training_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "test"
+      ]
+    },
+    "public.training_status": {
+      "name": "training_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "abandoned"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed",
+        "refunded"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "manual"
+      ]
+    },
+    "public.upload_type": {
+      "name": "upload_type",
+      "schema": "public",
+      "values": [
+        "avatar",
+        "question-image"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1783638004589,
       "tag": "0011_demonic_iron_monger",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785644443900,
+      "tag": "0012_lowly_paper_doll",
+      "breakpoints": true
     }
   ]
 }

--- a/features/exams/dal.shared.ts
+++ b/features/exams/dal.shared.ts
@@ -104,6 +104,23 @@ export const getOpenExamLockedQuestionIds = async (
   questionIds: string[],
 ): Promise<Set<string>> => {
   if (questionIds.length === 0) return new Set()
+  const locked = await getUserOpenExamLockedQuestionIds(userId)
+  return new Set(questionIds.filter((id) => locked.has(id)))
+}
+
+/**
+ * TOUTES les questions verrouillées pour `userId`, sans liste de candidats à
+ * restreindre. Source unique de la règle : `getOpenExamLockedQuestionIds` n'en
+ * est qu'une restriction.
+ *
+ * Le corpus de révision s'en sert pour exclure AVANT le tirage — l'appartenance
+ * d'une question au lot « mes ratées » dit déjà « tu t'es trompé », donc triche
+ * pendant qu'un examen est ouvert, sans jamais voir la clé. Borné par les
+ * examens auxquels l'utilisateur participe.
+ */
+export const getUserOpenExamLockedQuestionIds = async (
+  userId: string,
+): Promise<Set<string>> => {
   const rows = await db
     .selectDistinct({ questionId: examQuestions.questionId })
     .from(examQuestions)
@@ -113,11 +130,7 @@ export const getOpenExamLockedQuestionIds = async (
       eq(examParticipations.examId, examQuestions.examId),
     )
     .where(
-      and(
-        eq(examParticipations.userId, userId),
-        gt(exams.endDate, new Date()),
-        inArray(examQuestions.questionId, questionIds),
-      ),
+      and(eq(examParticipations.userId, userId), gt(exams.endDate, new Date())),
     )
   return new Set(rows.map((r) => r.questionId))
 }

--- a/features/exams/dal.shared.ts
+++ b/features/exams/dal.shared.ts
@@ -104,8 +104,7 @@ export const getOpenExamLockedQuestionIds = async (
   questionIds: string[],
 ): Promise<Set<string>> => {
   if (questionIds.length === 0) return new Set()
-  const locked = await getUserOpenExamLockedQuestionIds(userId)
-  return new Set(questionIds.filter((id) => locked.has(id)))
+  return getUserOpenExamLockedQuestionIds(userId, questionIds)
 }
 
 /**
@@ -120,6 +119,13 @@ export const getOpenExamLockedQuestionIds = async (
  */
 export const getUserOpenExamLockedQuestionIds = async (
   userId: string,
+  /**
+   * Restreint la lecture à ces questions quand l'appelant en a la liste (canaux
+   * de révélation). Sans elle, la lecture reste bornée par les examens ouverts
+   * auxquels l'utilisateur participe — le corpus de révision n'a pas de liste de
+   * candidats à fournir, c'est tout l'objet de cette fonction.
+   */
+  questionIds?: string[],
 ): Promise<Set<string>> => {
   const rows = await db
     .selectDistinct({ questionId: examQuestions.questionId })
@@ -130,7 +136,13 @@ export const getUserOpenExamLockedQuestionIds = async (
       eq(examParticipations.examId, examQuestions.examId),
     )
     .where(
-      and(eq(examParticipations.userId, userId), gt(exams.endDate, new Date())),
+      and(
+        eq(examParticipations.userId, userId),
+        gt(exams.endDate, new Date()),
+        questionIds?.length
+          ? inArray(examQuestions.questionId, questionIds)
+          : undefined,
+      ),
     )
   return new Set(rows.map((r) => r.questionId))
 }

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -4,6 +4,7 @@ import { and, eq, gt, inArray, isNull, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { db } from "@/db"
 import {
+  questionBookmarks,
   questionExplanations,
   questions,
   trainingSessionItems,
@@ -11,6 +12,7 @@ import {
   user,
 } from "@/db/schema"
 import { requireSession } from "@/lib/auth-guards"
+import { getPgErrorCode } from "@/lib/db-errors"
 import { createId } from "@/lib/ids"
 import { captureServerError } from "@/lib/observability"
 import { computeScorePercent } from "@/lib/score"
@@ -25,8 +27,10 @@ import {
 import {
   type CreateTrainingSessionInput,
   type SaveTrainingAnswerInput,
+  type SetQuestionBookmarkInput,
   createTrainingSessionSchema,
   saveTrainingAnswerSchema,
+  setQuestionBookmarkSchema,
 } from "./schemas"
 
 const SESSION_EXPIRATION_MS = 24 * 60 * 60 * 1000 // 24 h
@@ -336,6 +340,49 @@ export const saveTrainingAnswer = async (
     captureServerError("[saveTrainingAnswer]", error, {
       userId: session.user.id,
     })
+    return fail("Erreur serveur. Réessayez.")
+  }
+}
+
+/**
+ * [Auth] Pose ou retire le signet de révision d'une question. Idempotente :
+ * l'état voulu est passé en entrée (pas une bascule), donc une reprise réseau de
+ * `callAction` ne l'inverse pas. Aucun `revalidatePath` : l'état vit dans le
+ * runner côté client.
+ */
+export const setQuestionBookmark = async (
+  input: SetQuestionBookmarkInput,
+): Promise<{ success: boolean; error?: string }> => {
+  const session = await requireSession()
+  const parsed = setQuestionBookmarkSchema.safeParse(input)
+  if (!parsed.success) {
+    return fail(parsed.error.issues[0]?.message ?? "Données invalides")
+  }
+  const { questionId, isBookmarked } = parsed.data
+  const userId = session.user.id
+
+  try {
+    if (isBookmarked) {
+      await db
+        .insert(questionBookmarks)
+        .values({ userId, questionId })
+        .onConflictDoNothing()
+    } else {
+      await db
+        .delete(questionBookmarks)
+        .where(
+          and(
+            eq(questionBookmarks.userId, userId),
+            eq(questionBookmarks.questionId, questionId),
+          ),
+        )
+    }
+    return { success: true }
+  } catch (error) {
+    // 23503 : le client a envoyé une question qui n'existe pas. Erreur métier
+    // mappée → pas de capture Sentry.
+    if (getPgErrorCode(error) === "23503") return fail("Question introuvable.")
+    captureServerError("[setQuestionBookmark]", error, { userId })
     return fail("Erreur serveur. Réessayez.")
   }
 }

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -32,9 +32,11 @@ import {
 } from "./revision"
 import {
   type CreateTrainingSessionInput,
+  type RevisionCountsScopeInput,
   type SaveTrainingAnswerInput,
   type SetQuestionBookmarkInput,
   createTrainingSessionSchema,
+  revisionCountsScopeSchema,
   saveTrainingAnswerSchema,
   setQuestionBookmarkSchema,
 } from "./schemas"
@@ -57,13 +59,18 @@ export const loadTrainingHistory = async (args: {
   return getTrainingHistory(args)
 }
 
-/** [Auth] Compteurs de révision de l'utilisateur courant (formulaire). */
-export const loadRevisionCounts = async (args: {
-  domain?: string
-  objectifsCMCs?: string[]
-}): Promise<RevisionCounts> => {
+/**
+ * [Auth] Compteurs de révision de l'utilisateur courant (formulaire). Les
+ * entrées passent par zod comme toute action : `objectifsCMCs` alimente une
+ * clause `in (…)` et doit rester plafonné comme à la création de session.
+ */
+export const loadRevisionCounts = async (
+  args: RevisionCountsScopeInput,
+): Promise<RevisionCounts> => {
   const session = await requireSession()
-  return getRevisionCounts(session.user.id, args)
+  const parsed = revisionCountsScopeSchema.safeParse(args)
+  if (!parsed.success) return { failed: 0, unseen: 0, bookmarked: 0 }
+  return getRevisionCounts(session.user.id, parsed.data)
 }
 
 /** [Auth] Objectifs CMC filtrés par domaine (re-requête du formulaire). */

--- a/features/training/actions.ts
+++ b/features/training/actions.ts
@@ -25,6 +25,12 @@ import {
   getTrainingHistory,
 } from "./dal"
 import {
+  type RevisionCounts,
+  getRevisionCounts,
+  pickRevisionQuestionIds,
+  resolveRevisionLock,
+} from "./revision"
+import {
   type CreateTrainingSessionInput,
   type SaveTrainingAnswerInput,
   type SetQuestionBookmarkInput,
@@ -51,6 +57,15 @@ export const loadTrainingHistory = async (args: {
   return getTrainingHistory(args)
 }
 
+/** [Auth] Compteurs de révision de l'utilisateur courant (formulaire). */
+export const loadRevisionCounts = async (args: {
+  domain?: string
+  objectifsCMCs?: string[]
+}): Promise<RevisionCounts> => {
+  const session = await requireSession()
+  return getRevisionCounts(session.user.id, args)
+}
+
 /** [Auth] Objectifs CMC filtrés par domaine (re-requête du formulaire). */
 export const loadAvailableObjectifsCMC = async (
   domain?: string,
@@ -64,7 +79,8 @@ export const loadAvailableObjectifsCMC = async (
 // ============================================
 
 export type CreateTrainingSessionResult =
-  { success: true; sessionId: string } | { success: false; error: string }
+  | { success: true; sessionId: string; questionCount: number }
+  | { success: false; error: string }
 
 /**
  * [Auth] Crée une session : sélectionne N questions aléatoires (domaine +
@@ -83,7 +99,10 @@ export const createTrainingSession = async (
   if (!parsed.success) {
     return fail(parsed.error.issues[0]?.message ?? "Données invalides")
   }
-  const { questionCount, domain, objectifsCMCs, mode } = parsed.data
+  const { questionCount, domain, objectifsCMCs, mode, revisionFilters } =
+    parsed.data
+  const criteria = revisionFilters ?? []
+  const isRevision = criteria.length > 0
 
   try {
     // Accès payant : hors verrou (ne court pas avec lui-même ; bypass admin).
@@ -108,11 +127,16 @@ export const createTrainingSession = async (
     const expiresAt = new Date(now.getTime() + SESSION_EXPIRATION_MS)
     const sessionId = createId()
 
+    // Résolu HORS transaction : une requête sur le `db` global depuis l'intérieur
+    // réclamerait une 2e connexion au pool (max 5, sans timeout d'acquisition)
+    // → interblocage à cinq créations concurrentes.
+    const lockedIds = isRevision ? await resolveRevisionLock(userId) : []
+
     // Verrou de ligne user : sérialise les créations concurrentes du même
     // utilisateur. Rate-limit + « session déjà en cours » + sélection + insert
     // deviennent atomiques (sinon, deux requêtes simultanées → 2 sessions
     // actives / dépassement de limite — READ COMMITTED ne sérialise pas seul).
-    await db.transaction(async (tx) => {
+    const selectedCount = await db.transaction(async (tx) => {
       await tx
         .select({ id: user.id })
         .from(user)
@@ -158,20 +182,34 @@ export const createTrainingSession = async (
           .where(eq(trainingSessions.id, existing.id))
       }
 
-      const [avail] = await tx
-        .select({ n: sql<number>`count(*)`.mapWith(Number) })
-        .from(questions)
-        .where(where)
-      if ((avail?.n ?? 0) < questionCount) {
-        throw new Error(`NOT_ENOUGH:${avail?.n ?? 0}`)
-      }
+      let picked: { id: string }[]
+      if (isRevision) {
+        const ids = await pickRevisionQuestionIds(tx, {
+          userId,
+          criteria,
+          domain,
+          objectifsCMCs,
+          limit: questionCount,
+          lockedIds,
+        })
+        if (ids.length === 0) throw new Error("EMPTY_REVISION")
+        picked = ids.map((id) => ({ id }))
+      } else {
+        const [avail] = await tx
+          .select({ n: sql<number>`count(*)`.mapWith(Number) })
+          .from(questions)
+          .where(where)
+        if ((avail?.n ?? 0) < questionCount) {
+          throw new Error(`NOT_ENOUGH:${avail?.n ?? 0}`)
+        }
 
-      const picked = await tx
-        .select({ id: questions.id })
-        .from(questions)
-        .where(where)
-        .orderBy(sql`random()`)
-        .limit(questionCount)
+        picked = await tx
+          .select({ id: questions.id })
+          .from(questions)
+          .where(where)
+          .orderBy(sql`random()`)
+          .limit(questionCount)
+      }
 
       await tx.insert(trainingSessions).values({
         id: sessionId,
@@ -180,7 +218,9 @@ export const createTrainingSession = async (
         mode,
         domain: domain && domain !== "all" ? domain : null,
         objectifCmc: null,
-        questionCount,
+        // Le nombre RÉELLEMENT retenu : en révision le corpus peut être plus
+        // court, et le score final se calcule sur ce dénominateur.
+        questionCount: picked.length,
         startedAt: now,
         expiresAt,
       })
@@ -191,10 +231,11 @@ export const createTrainingSession = async (
           position: idx,
         })),
       )
+      return picked.length
     })
 
     revalidatePath("/tableau-de-bord/entrainement")
-    return { success: true, sessionId }
+    return { success: true, sessionId, questionCount: selectedCount }
   } catch (error) {
     if (error instanceof Error) {
       if (error.message === "RATE_LIMIT") {
@@ -205,6 +246,11 @@ export const createTrainingSession = async (
       if (error.message === "ACTIVE_EXISTS") {
         return fail(
           "Vous avez déjà une session en cours. Terminez-la ou attendez son expiration.",
+        )
+      }
+      if (error.message === "EMPTY_REVISION") {
+        return fail(
+          "Aucune question ne correspond à ces critères de révision. Élargissez la sélection.",
         )
       }
       if (error.message.startsWith("NOT_ENOUGH:")) {

--- a/features/training/dal.ts
+++ b/features/training/dal.ts
@@ -14,6 +14,7 @@ import { cache } from "react"
 import "server-only"
 import { db } from "@/db"
 import {
+  questionBookmarks,
   questionExplanations,
   questionImages,
   questions,
@@ -309,6 +310,29 @@ export const getTrainingStats = cache(async (): Promise<TrainingStats> => {
     averageScore: row?.averageScore ?? 0,
   }
 })
+
+/**
+ * Signets de **l'utilisateur courant** parmi `questionIds`. Un signet est un
+ * état personnel : les appelants qui affichent la session d'un autre
+ * utilisateur (admin) ne doivent pas les demander.
+ */
+export const getBookmarkedQuestionIds = async (
+  questionIds: string[],
+): Promise<string[]> => {
+  const session = await getCurrentSession()
+  if (!session?.user || questionIds.length === 0) return []
+
+  const rows = await db
+    .select({ questionId: questionBookmarks.questionId })
+    .from(questionBookmarks)
+    .where(
+      and(
+        eq(questionBookmarks.userId, session.user.id),
+        inArray(questionBookmarks.questionId, questionIds),
+      ),
+    )
+  return rows.map((r) => r.questionId)
+}
 
 // ============================================
 // Historique de score (graphique dashboard)

--- a/features/training/dal.ts
+++ b/features/training/dal.ts
@@ -503,6 +503,8 @@ export type TrainingSessionView = {
   }
   questions: TrainingSessionQuestion[]
   answers: TrainingAnswerRecord
+  /** Signets de l'utilisateur courant parmi les questions de la session. */
+  bookmarkedIds: string[]
   isExpired: boolean
 } | null
 
@@ -565,11 +567,15 @@ export const getTrainingSessionById = async (
   const sessionQuestionIds = items.map((i) => i.questionId)
   // Questions d'un examen OUVERT où l'utilisateur participe : clé de réponse
   // différée jusqu'à la clôture (voir getOpenExamLockedQuestionIds).
-  const [imgMap, lockedIds] = await Promise.all([
+  const isOwner = s.userId === session.user.id
+  const [imgMap, lockedIds, bookmarkedIds] = await Promise.all([
     fetchImages(sessionQuestionIds),
     session.user.role === "admin"
       ? new Set<string>()
       : getOpenExamLockedQuestionIds(session.user.id, sessionQuestionIds),
+    // Un signet est personnel : un admin qui inspecte la session d'un étudiant
+    // verrait les SIENS, donc des drapeaux incohérents avec ce qu'il regarde.
+    isOwner ? getBookmarkedQuestionIds(sessionQuestionIds) : [],
   ])
 
   const questionsView: TrainingSessionQuestion[] = items.map((i) => {
@@ -626,6 +632,7 @@ export const getTrainingSessionById = async (
     },
     questions: questionsView,
     answers,
+    bookmarkedIds,
     isExpired: s.expiresAt.getTime() < Date.now(),
   }
 }

--- a/features/training/revision.ts
+++ b/features/training/revision.ts
@@ -1,0 +1,128 @@
+import { type SQL, sql } from "drizzle-orm"
+import "server-only"
+import { type Db, db } from "@/db"
+import type { RevisionCriterion } from "./schemas"
+
+// `db` ou une transaction : le tirage doit pouvoir vivre dans la transaction qui
+// insère la session.
+type Executor = Pick<Db, "execute">
+
+export type RevisionCounts = Record<RevisionCriterion, number>
+
+export type RevisionScope = {
+  userId: string
+  domain?: string
+  objectifsCMCs?: string[]
+}
+
+// Historique unifié entraînement + examens de l'utilisateur, réduit à sa
+// DERNIÈRE tentative par question. `exam_answers.created_at` vaut « début de la
+// tentative » (lignes pré-créées au démarrage de l'examen, jamais réhorodatées) :
+// un entraînement intercalé pendant un examen long peut donc être classé à tort
+// comme la tentative la plus récente. Limite assumée, documentée dans le spec.
+const historyCte = (userId: string): SQL => sql`
+  attempts as (
+    select i.question_id, i.is_correct, i.answered_at as at
+      from training_session_items i
+      join training_sessions s on s.id = i.session_id
+     where s.user_id = ${userId} and i.selected_answer is not null
+    union all
+    select a.question_id, a.is_correct, a.created_at as at
+      from exam_answers a
+      join exam_participations p on p.id = a.participation_id
+     where p.user_id = ${userId} and a.selected_answer is not null
+  ),
+  last_attempt as (
+    select distinct on (question_id) question_id, is_correct
+      from attempts
+     order by question_id, at desc
+  ),
+  marked as (
+    select question_id from question_bookmarks where user_id = ${userId}
+    union
+    select a.question_id
+      from exam_answers a
+      join exam_participations p on p.id = a.participation_id
+     where p.user_id = ${userId} and a.is_flagged
+  )
+`
+
+// Le marquage se lit hors agrégat : une question marquée mais jamais répondue
+// compte comme marquée.
+const CRITERION_PREDICATE: Record<RevisionCriterion, SQL> = {
+  failed: sql`q.id in (select question_id from last_attempt where is_correct = false)`,
+  bookmarked: sql`q.id in (select question_id from marked)`,
+  unseen: sql`not exists (select 1 from attempts a2 where a2.question_id = q.id)`,
+}
+
+const corpusWhere = ({ domain, objectifsCMCs }: RevisionScope): SQL => {
+  const parts: SQL[] = [sql`q.deleted_at is null`]
+  if (domain && domain !== "all") parts.push(sql`q.domain = ${domain}`)
+
+  const objectifs =
+    objectifsCMCs?.map((o) => o.trim().toLowerCase()).filter(Boolean) ?? []
+  if (objectifs.length > 0) {
+    parts.push(
+      sql`lower(q.objectif_cmc) in (${sql.join(
+        objectifs.map((o) => sql`${o}`),
+        sql`, `,
+      )})`,
+    )
+  }
+  return sql.join(parts, sql` and `)
+}
+
+/** Compteur par critère, sur le corpus filtré (domaine + objectifs). */
+export const getRevisionCounts = async (
+  userId: string,
+  scope: Omit<RevisionScope, "userId"> = {},
+): Promise<RevisionCounts> => {
+  const res = await db.execute(sql`
+    with ${historyCte(userId)}
+    select
+      (count(*) filter (where ${CRITERION_PREDICATE.failed}))::int as failed,
+      (count(*) filter (where ${CRITERION_PREDICATE.unseen}))::int as unseen,
+      (count(*) filter (where ${CRITERION_PREDICATE.bookmarked}))::int as bookmarked
+      from questions q
+     where ${corpusWhere({ userId, ...scope })}
+  `)
+  // Le cast `::int` est indispensable : sans lui, `count(*)` remonte en bigint,
+  // que le driver pg rend en `string`.
+  const row = res.rows[0] as Partial<RevisionCounts> | undefined
+  return {
+    failed: Number(row?.failed ?? 0),
+    unseen: Number(row?.unseen ?? 0),
+    bookmarked: Number(row?.bookmarked ?? 0),
+  }
+}
+
+/**
+ * Tirage aléatoire dans le corpus de révision. Les critères s'unissent en OU, le
+ * tout intersecté avec domaine + objectifs. Renvoie moins que `limit` quand le
+ * corpus est plus court — l'appelant démarre avec ce qu'il obtient.
+ */
+export const pickRevisionQuestionIds = async (
+  exec: Executor,
+  {
+    criteria,
+    limit,
+    ...scope
+  }: RevisionScope & { criteria: RevisionCriterion[]; limit: number },
+): Promise<string[]> => {
+  const unique = [...new Set(criteria)]
+  if (unique.length === 0 || limit <= 0) return []
+
+  const anyCriterion = sql.join(
+    unique.map((c) => CRITERION_PREDICATE[c]),
+    sql` or `,
+  )
+  const res = await exec.execute(sql`
+    with ${historyCte(scope.userId)}
+    select q.id
+      from questions q
+     where ${corpusWhere(scope)} and (${anyCriterion})
+     order by random()
+     limit ${limit}
+  `)
+  return res.rows.map((r) => String(r.id))
+}

--- a/features/training/revision.ts
+++ b/features/training/revision.ts
@@ -17,7 +17,15 @@ export type RevisionScope = {
 }
 
 // Historique unifié entraînement + examens de l'utilisateur, réduit à sa
-// DERNIÈRE tentative par question. `exam_answers.created_at` vaut « début de la
+// DERNIÈRE tentative par question.
+//
+// Les sessions `in_progress` sont EXCLUES : en mode test, `isCorrect` est masqué
+// sur les trois canaux de lecture tant que la session n'est pas terminée. Sans
+// cette exclusion, le compteur « Ratées » en devient le quatrième — sonder entre
+// deux réponses donne un bit de correction par tentative, et `saveTrainingAnswer`
+// autorise la ré-écriture d'un item. Coût assumé : en mode tuteur (où la
+// correction est déjà révélée), les réponses de la session courante ne comptent
+// qu'à sa clôture. `exam_answers.created_at` vaut « début de la
 // tentative » (lignes pré-créées au démarrage de l'examen, jamais réhorodatées) :
 // un entraînement intercalé pendant un examen long peut donc être classé à tort
 // comme la tentative la plus récente. Limite assumée, documentée dans le spec.
@@ -27,6 +35,7 @@ const historyCte = (userId: string): SQL => sql`
       from training_session_items i
       join training_sessions s on s.id = i.session_id
      where s.user_id = ${userId} and i.selected_answer is not null
+       and s.status <> 'in_progress'
     union all
     select a.question_id, a.is_correct, a.created_at as at
       from exam_answers a

--- a/features/training/revision.ts
+++ b/features/training/revision.ts
@@ -1,6 +1,7 @@
 import { type SQL, sql } from "drizzle-orm"
 import "server-only"
 import { type Db, db } from "@/db"
+import { getUserOpenExamLockedQuestionIds } from "../exams/dal.shared"
 import type { RevisionCriterion } from "./schemas"
 
 // `db` ou une transaction : le tirage doit pouvoir vivre dans la transaction qui
@@ -55,7 +56,10 @@ const CRITERION_PREDICATE: Record<RevisionCriterion, SQL> = {
   unseen: sql`not exists (select 1 from attempts a2 where a2.question_id = q.id)`,
 }
 
-const corpusWhere = ({ domain, objectifsCMCs }: RevisionScope): SQL => {
+const corpusWhere = (
+  { domain, objectifsCMCs }: RevisionScope,
+  lockedIds: string[],
+): SQL => {
   const parts: SQL[] = [sql`q.deleted_at is null`]
   if (domain && domain !== "all") parts.push(sql`q.domain = ${domain}`)
 
@@ -69,14 +73,37 @@ const corpusWhere = ({ domain, objectifsCMCs }: RevisionScope): SQL => {
       )})`,
     )
   }
+
+  // Verrou anti-triche appliqué à la SÉLECTION, pas seulement à la révélation :
+  // l'appartenance d'une question au lot est elle-même un oracle sur les
+  // réponses d'un examen encore ouvert.
+  if (lockedIds.length > 0) {
+    parts.push(
+      sql`q.id not in (${sql.join(
+        lockedIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})`,
+    )
+  }
   return sql.join(parts, sql` and `)
 }
+
+/**
+ * Identifiants à exclure du corpus. À résoudre AVANT d'ouvrir une transaction :
+ * le pool pg est à `max: 5` sans timeout d'acquisition, donc réclamer une 2ᵉ
+ * connexion pendant qu'on en détient une fige la requête — et cinq créations
+ * concurrentes figent l'application.
+ */
+export const resolveRevisionLock = async (
+  userId: string,
+): Promise<string[]> => [...(await getUserOpenExamLockedQuestionIds(userId))]
 
 /** Compteur par critère, sur le corpus filtré (domaine + objectifs). */
 export const getRevisionCounts = async (
   userId: string,
   scope: Omit<RevisionScope, "userId"> = {},
 ): Promise<RevisionCounts> => {
+  const lockedIds = await resolveRevisionLock(userId)
   const res = await db.execute(sql`
     with ${historyCte(userId)}
     select
@@ -84,7 +111,7 @@ export const getRevisionCounts = async (
       (count(*) filter (where ${CRITERION_PREDICATE.unseen}))::int as unseen,
       (count(*) filter (where ${CRITERION_PREDICATE.bookmarked}))::int as bookmarked
       from questions q
-     where ${corpusWhere({ userId, ...scope })}
+     where ${corpusWhere({ userId, ...scope }, lockedIds)}
   `)
   // Le cast `::int` est indispensable : sans lui, `count(*)` remonte en bigint,
   // que le driver pg rend en `string`.
@@ -106,8 +133,17 @@ export const pickRevisionQuestionIds = async (
   {
     criteria,
     limit,
+    lockedIds,
     ...scope
-  }: RevisionScope & { criteria: RevisionCriterion[]; limit: number },
+  }: RevisionScope & {
+    criteria: RevisionCriterion[]
+    limit: number
+    /**
+     * Résolus par `resolveRevisionLock` HORS transaction. Paramètre REQUIS : un
+     * oubli casse la compilation au lieu de rouvrir le trou anti-triche.
+     */
+    lockedIds: string[]
+  },
 ): Promise<string[]> => {
   const unique = [...new Set(criteria)]
   if (unique.length === 0 || limit <= 0) return []
@@ -120,7 +156,7 @@ export const pickRevisionQuestionIds = async (
     with ${historyCte(scope.userId)}
     select q.id
       from questions q
-     where ${corpusWhere(scope)} and (${anyCriterion})
+     where ${corpusWhere(scope, lockedIds)} and (${anyCriterion})
      order by random()
      limit ${limit}
   `)

--- a/features/training/schemas.ts
+++ b/features/training/schemas.ts
@@ -14,16 +14,30 @@ export const REVISION_CRITERION_LABELS: Record<RevisionCriterion, string> = {
   bookmarked: "Marquées",
 }
 
-export const createTrainingSessionSchema = z.object({
-  questionCount: z
-    .number()
-    .int()
-    .min(MIN_QUESTIONS, `Au moins ${MIN_QUESTIONS} questions`)
-    .max(MAX_QUESTIONS, `Au plus ${MAX_QUESTIONS} questions`),
-  domain: z.string().trim().min(1).optional(),
-  objectifsCMCs: z.array(z.string().trim().min(1)).max(50).optional(),
-  mode: z.enum(["tutor", "test"]).optional().default("test"),
-})
+export const createTrainingSessionSchema = z
+  .object({
+    questionCount: z
+      .number()
+      .int()
+      .min(1, "Au moins une question")
+      .max(MAX_QUESTIONS, `Au plus ${MAX_QUESTIONS} questions`),
+    domain: z.string().trim().min(1).optional(),
+    objectifsCMCs: z.array(z.string().trim().min(1)).max(50).optional(),
+    mode: z.enum(["tutor", "test"]).optional().default("test"),
+    revisionFilters: z.array(revisionCriterionSchema).max(3).optional(),
+  })
+  // Le plancher de 5 questions n'a de sens que pour un tirage aléatoire : trois
+  // questions ratées font une session de révision légitime.
+  .superRefine((value, ctx) => {
+    const isRevision = (value.revisionFilters?.length ?? 0) > 0
+    if (!isRevision && value.questionCount < MIN_QUESTIONS) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Au moins ${MIN_QUESTIONS} questions`,
+        path: ["questionCount"],
+      })
+    }
+  })
 export type CreateTrainingSessionInput = z.infer<
   typeof createTrainingSessionSchema
 >

--- a/features/training/schemas.ts
+++ b/features/training/schemas.ts
@@ -18,6 +18,12 @@ export type CreateTrainingSessionInput = z.infer<
   typeof createTrainingSessionSchema
 >
 
+export const setQuestionBookmarkSchema = z.object({
+  questionId: z.string().min(1),
+  isBookmarked: z.boolean(),
+})
+export type SetQuestionBookmarkInput = z.infer<typeof setQuestionBookmarkSchema>
+
 export const saveTrainingAnswerSchema = z.object({
   sessionId: z.string().min(1),
   questionId: z.string().min(1),

--- a/features/training/schemas.ts
+++ b/features/training/schemas.ts
@@ -4,6 +4,16 @@ import { z } from "zod"
 export const MIN_QUESTIONS = 5
 export const MAX_QUESTIONS = 20
 
+export const REVISION_CRITERIA = ["failed", "unseen", "bookmarked"] as const
+export type RevisionCriterion = (typeof REVISION_CRITERIA)[number]
+export const revisionCriterionSchema = z.enum(REVISION_CRITERIA)
+
+export const REVISION_CRITERION_LABELS: Record<RevisionCriterion, string> = {
+  failed: "Ratées",
+  unseen: "Non vues",
+  bookmarked: "Marquées",
+}
+
 export const createTrainingSessionSchema = z.object({
   questionCount: z
     .number()

--- a/features/training/schemas.ts
+++ b/features/training/schemas.ts
@@ -42,6 +42,12 @@ export type CreateTrainingSessionInput = z.infer<
   typeof createTrainingSessionSchema
 >
 
+export const revisionCountsScopeSchema = z.object({
+  domain: z.string().trim().min(1).optional(),
+  objectifsCMCs: z.array(z.string().trim().min(1)).max(50).optional(),
+})
+export type RevisionCountsScopeInput = z.infer<typeof revisionCountsScopeSchema>
+
 export const setQuestionBookmarkSchema = z.object({
   questionId: z.string().min(1),
   isBookmarked: z.boolean(),

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -28,12 +28,13 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
-  // Define how likely Replay events are sampled when an error occurs.
+  // Mode buffer pur : aucune session enregistree tant qu'aucune erreur ne
+  // survient. Le plan Developer plafonne a 50 replays/mois ; un taux de session
+  // non nul epuise ce quota en quelques jours de trafic normal, apres quoi
+  // Sentry rejette AUSSI les replays des vraies erreurs — exactement ceux dont
+  // on a besoin. Les taux indexes sur le trafic recommandes par la doc Sentry
+  // (0.25 sous 10 000 sessions/jour) supposent un plan payant.
+  replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
 
   // Enable sending user PII (Personally Identifiable Information)

--- a/scripts/test-integration.ts
+++ b/scripts/test-integration.ts
@@ -16,6 +16,12 @@ config({ path: ".env.local" })
 
 const keep = process.argv.includes("--keep")
 
+// Tout le reste part à vitest : sans ça, `bun run test:integration -- <fichier>`
+// exécutait silencieusement la suite entière.
+const vitestArgs = process.argv
+  .slice(2)
+  .filter((arg) => arg !== "--keep" && arg !== "--")
+
 const removed = await cleanupStaleTestBranches()
 if (removed.length > 0) {
   console.log(
@@ -46,7 +52,11 @@ try {
   }
 
   console.log("[test-integration] tests…")
-  exitCode = run("bunx", ["vitest", "run", "--project", "integration"], env)
+  exitCode = run(
+    "bunx",
+    ["vitest", "run", "--project", "integration", ...vitestArgs],
+    env,
+  )
 } finally {
   if (keep) {
     console.log(

--- a/tests/components/ObjectifsCMCMultiSelect.test.tsx
+++ b/tests/components/ObjectifsCMCMultiSelect.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ObjectifsCMCMultiSelect } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/objectifs-cmc-multi-select"
+
+const objectifs = [
+  { objectif: "Douleur thoracique", count: 12 },
+  { objectif: "Dyspnée", count: 8 },
+  { objectif: "Céphalée", count: 5 },
+]
+
+const onChange = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const openList = async () => {
+  await userEvent.click(screen.getByRole("combobox"))
+}
+
+describe("ObjectifsCMCMultiSelect", () => {
+  it("affiche le libellé vide puis le décompte au pluriel", () => {
+    const { rerender } = render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={[]}
+        onChange={onChange}
+      />,
+    )
+    expect(
+      screen.getByText("Sélectionner des objectifs CMC..."),
+    ).toBeInTheDocument()
+
+    rerender(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={["Dyspnée"]}
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByText("1 objectif sélectionné")).toBeInTheDocument()
+
+    rerender(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={["Dyspnée", "Céphalée"]}
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByText("2 objectifs sélectionnés")).toBeInTheDocument()
+  })
+
+  it("sélectionne un objectif depuis la liste", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={[]}
+        onChange={onChange}
+      />,
+    )
+    await openList()
+    await userEvent.click(screen.getByText("Douleur thoracique"))
+
+    expect(onChange).toHaveBeenCalledWith(["Douleur thoracique"])
+  })
+
+  it("re-cliquer sur un objectif déjà pris le retire", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={["Dyspnée"]}
+        onChange={onChange}
+      />,
+    )
+    await openList()
+    // Le libellé existe aussi dans la puce du haut → scoper sur l'option cmdk.
+    await userEvent.click(screen.getByRole("option", { name: /Dyspnée/ }))
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it("filtre la liste sur la recherche, sans casse", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={[]}
+        onChange={onChange}
+      />,
+    )
+    await openList()
+    await userEvent.type(
+      screen.getByPlaceholderText("Rechercher un objectif CMC..."),
+      "dysp",
+    )
+
+    expect(screen.getByText("Dyspnée")).toBeInTheDocument()
+    expect(screen.queryByText("Céphalée")).not.toBeInTheDocument()
+  })
+
+  it("annonce l'absence de résultat", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={[]}
+        onChange={onChange}
+      />,
+    )
+    await openList()
+    await userEvent.type(
+      screen.getByPlaceholderText("Rechercher un objectif CMC..."),
+      "zzz",
+    )
+
+    expect(screen.getByText("Aucun objectif trouvé.")).toBeInTheDocument()
+  })
+
+  it("refuse d'ajouter au-delà du quota", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={["Dyspnée"]}
+        onChange={onChange}
+        maxSelections={1}
+      />,
+    )
+    await openList()
+    await userEvent.click(screen.getByText("Douleur thoracique"))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("retire un objectif depuis sa puce et vide tout", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={["Dyspnée", "Céphalée"]}
+        onChange={onChange}
+      />,
+    )
+
+    const chipRemove = screen.getAllByRole("button", { name: /Dyspnée/i })
+    await userEvent.click(chipRemove[chipRemove.length - 1])
+    expect(onChange).toHaveBeenCalledWith(["Céphalée"])
+
+    onChange.mockClear()
+    await userEvent.click(screen.getByRole("button", { name: /Tout effacer/i }))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it("désactive le déclencheur pendant le chargement", () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={objectifs}
+        selectedObjectifs={[]}
+        onChange={onChange}
+        isLoading
+      />,
+    )
+    expect(screen.getByRole("combobox")).toBeDisabled()
+  })
+
+  it("tolère une liste absente", async () => {
+    render(
+      <ObjectifsCMCMultiSelect
+        objectifs={undefined as never}
+        selectedObjectifs={[]}
+        onChange={onChange}
+      />,
+    )
+    await openList()
+    expect(screen.getByText("Aucun objectif trouvé.")).toBeInTheDocument()
+  })
+})

--- a/tests/components/TrainingConfigForm.test.tsx
+++ b/tests/components/TrainingConfigForm.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { TrainingConfigForm } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form"
+
+const {
+  push,
+  toastError,
+  toastSuccess,
+  createTrainingSession,
+  loadAvailableObjectifsCMC,
+  loadRevisionCounts,
+} = vi.hoisted(() => ({
+  push: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  createTrainingSession: vi.fn(),
+  loadAvailableObjectifsCMC: vi.fn(),
+  loadRevisionCounts: vi.fn(),
+}))
+
+// Factory async : `vi.mock` est hoisté, donc le helper doit être importé DEDANS.
+vi.mock("motion/react", async () => {
+  const { motionMockFactory } = await import("../helpers/motion-mock")
+  return motionMockFactory
+})
+// Mock COMPLET : `callAction` importe `unstable_isUnrecognizedActionError` de
+// `next/navigation` — un mock partiel casse le chemin d'échec.
+vi.mock("next/navigation", async (orig) => ({
+  ...(await orig<typeof import("next/navigation")>()),
+  useRouter: () => ({ push }),
+}))
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}))
+vi.mock("@/features/training/actions", () => ({
+  createTrainingSession,
+  loadAvailableObjectifsCMC,
+  loadRevisionCounts,
+}))
+
+const props = {
+  domains: [{ domain: "Cardiologie", count: 120 }],
+  totalQuestions: 3000,
+  objectifs: [{ objectif: "Obj A", count: 40 }],
+}
+
+const primeActions = () => {
+  loadAvailableObjectifsCMC.mockResolvedValue({ objectifs: props.objectifs })
+  loadRevisionCounts.mockResolvedValue({
+    failed: 7,
+    unseen: 812,
+    bookmarked: 3,
+  })
+}
+
+describe("TrainingConfigForm — révision", () => {
+  it("affiche les compteurs de révision", async () => {
+    primeActions()
+
+    render(<TrainingConfigForm {...props} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("revision-failed")).toHaveTextContent("7")
+    })
+    expect(screen.getByTestId("revision-bookmarked")).toHaveTextContent("3")
+  })
+
+  it("transmet les critères cochés et annonce le nombre réellement retenu", async () => {
+    primeActions()
+    createTrainingSession.mockResolvedValue({
+      success: true,
+      sessionId: "s1",
+      questionCount: 7,
+    })
+
+    render(<TrainingConfigForm {...props} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    await userEvent.click(screen.getByTestId("revision-failed"))
+    await userEvent.click(
+      screen.getByRole("button", { name: /Commencer l'entraînement/i }),
+    )
+
+    await waitFor(() => {
+      expect(createTrainingSession).toHaveBeenCalledWith(
+        expect.objectContaining({ revisionFilters: ["failed"] }),
+      )
+    })
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Session créée !",
+      expect.objectContaining({ description: expect.stringContaining("7") }),
+    )
+  })
+})

--- a/tests/components/TrainingConfigForm.test.tsx
+++ b/tests/components/TrainingConfigForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TrainingConfigForm } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-config-form"
 
 const {
@@ -54,6 +54,10 @@ const primeActions = () => {
   })
 }
 
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
 describe("TrainingConfigForm — révision", () => {
   it("affiche les compteurs de révision", async () => {
     primeActions()
@@ -91,5 +95,140 @@ describe("TrainingConfigForm — révision", () => {
       "Session créée !",
       expect.objectContaining({ description: expect.stringContaining("7") }),
     )
+    expect(push).toHaveBeenCalledWith("/tableau-de-bord/entrainement/s1")
+  })
+
+  it("décocher un critère le retire de l'envoi", async () => {
+    primeActions()
+    createTrainingSession.mockResolvedValue({
+      success: true,
+      sessionId: "s2",
+      questionCount: 10,
+    })
+
+    render(<TrainingConfigForm {...props} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    const chip = screen.getByTestId("revision-bookmarked")
+    await userEvent.click(chip)
+    expect(chip).toHaveAttribute("aria-pressed", "true")
+    await userEvent.click(chip)
+    expect(chip).toHaveAttribute("aria-pressed", "false")
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Commencer l'entraînement/i }),
+    )
+
+    await waitFor(() => {
+      expect(createTrainingSession).toHaveBeenCalledWith(
+        expect.objectContaining({ revisionFilters: undefined }),
+      )
+    })
+  })
+
+  it("signale un corpus vide renvoyé par le serveur", async () => {
+    primeActions()
+    createTrainingSession.mockResolvedValue({
+      success: false,
+      error: "Aucune question ne correspond à ces critères de révision.",
+    })
+
+    render(<TrainingConfigForm {...props} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    await userEvent.click(screen.getByTestId("revision-failed"))
+    await userEvent.click(
+      screen.getByRole("button", { name: /Commencer l'entraînement/i }),
+    )
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Erreur", {
+        description:
+          "Aucune question ne correspond à ces critères de révision.",
+      })
+    })
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it("prévient quand les compteurs sont injoignables", async () => {
+    loadAvailableObjectifsCMC.mockResolvedValue({ objectifs: props.objectifs })
+    loadRevisionCounts.mockRejectedValue(new Error("Failed to fetch"))
+
+    render(<TrainingConfigForm {...props} />)
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "Impossible de charger vos compteurs de révision. Vérifiez votre réseau.",
+      )
+    })
+  })
+
+  it("prévient quand les objectifs sont injoignables", async () => {
+    loadRevisionCounts.mockResolvedValue({
+      failed: 0,
+      unseen: 0,
+      bookmarked: 0,
+    })
+    loadAvailableObjectifsCMC.mockRejectedValue(new Error("Failed to fetch"))
+
+    render(<TrainingConfigForm {...props} />)
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "Impossible de charger les objectifs du domaine. Vérifiez votre réseau.",
+      )
+    })
+  })
+
+  it("bloque la création quand la banque est plus petite que la demande", async () => {
+    primeActions()
+
+    render(<TrainingConfigForm {...props} totalQuestions={3} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    expect(
+      screen.getByText(/Seulement 3 questions disponibles/i),
+    ).toBeInTheDocument()
+
+    const submit = screen.getByRole("button", {
+      name: /Commencer l'entraînement/i,
+    })
+    expect(submit).toBeDisabled()
+    await userEvent.click(submit)
+    expect(createTrainingSession).not.toHaveBeenCalled()
+  })
+
+  it("accorde le singulier quand une seule question est disponible", async () => {
+    primeActions()
+
+    render(<TrainingConfigForm {...props} totalQuestions={1} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    expect(
+      screen.getByText(/Seulement 1 question disponible/i),
+    ).toBeInTheDocument()
+  })
+
+  it("bascule en mode tuteur et le transmet", async () => {
+    primeActions()
+    createTrainingSession.mockResolvedValue({
+      success: true,
+      sessionId: "s3",
+      questionCount: 10,
+    })
+
+    render(<TrainingConfigForm {...props} />)
+    await waitFor(() => expect(loadRevisionCounts).toHaveBeenCalled())
+
+    await userEvent.click(screen.getByLabelText(/Mode tuteur/i))
+    await userEvent.click(
+      screen.getByRole("button", { name: /Commencer l'entraînement/i }),
+    )
+
+    await waitFor(() => {
+      expect(createTrainingSession).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "tutor" }),
+      )
+    })
   })
 })

--- a/tests/components/quiz/TrainingSessionClient.test.tsx
+++ b/tests/components/quiz/TrainingSessionClient.test.tsx
@@ -1,10 +1,27 @@
-import { render } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TrainingSessionClient } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client"
+// Type seulement : le module `server-only` est effacé à la compilation.
+import type { TrainingSessionView } from "@/features/training/dal"
 
-const { setQuestionBookmark, toastError, runnerProps } = vi.hoisted(() => ({
+type SessionData = NonNullable<TrainingSessionView>
+
+const {
+  setQuestionBookmark,
+  saveTrainingAnswer,
+  completeTrainingSession,
+  toastError,
+  toastSuccess,
+  push,
+  runnerProps,
+} = vi.hoisted(() => ({
   setQuestionBookmark: vi.fn(),
+  saveTrainingAnswer: vi.fn(),
+  completeTrainingSession: vi.fn(),
   toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  push: vi.fn(),
   runnerProps: { current: null as Record<string, unknown> | null },
 }))
 
@@ -13,12 +30,14 @@ const { setQuestionBookmark, toastError, runnerProps } = vi.hoisted(() => ({
 // cryptique (piège documenté dans `.claude/rules/data-layer.md`).
 vi.mock("next/navigation", async (orig) => ({
   ...(await orig<typeof import("next/navigation")>()),
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push }),
 }))
-vi.mock("sonner", () => ({ toast: { error: toastError, success: vi.fn() } }))
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}))
 vi.mock("@/features/training/actions", () => ({
-  saveTrainingAnswer: vi.fn(),
-  completeTrainingSession: vi.fn(),
+  saveTrainingAnswer,
+  completeTrainingSession,
   setQuestionBookmark,
 }))
 // Le runner complet (timers, Radix, motion) est hors sujet : on capture ses props.
@@ -29,12 +48,12 @@ vi.mock("@/components/quiz/runner/quiz-runner", () => ({
   },
 }))
 
-const initialData = {
+const initialData: SessionData = {
   session: {
     id: "s1",
     questionCount: 1,
-    status: "in_progress" as const,
-    mode: "test" as const,
+    status: "in_progress",
+    mode: "test",
     domain: null,
     startedAt: 0,
     completedAt: null,
@@ -59,18 +78,31 @@ const initialData = {
 
 type CapturedProps = {
   initialFlags: Set<string>
+  initialRevealed?: Record<string, unknown>
   callbacks: {
     onFlag: (id: string, flagged: boolean) => Promise<{ ok: boolean }>
+    onAnswer: (
+      id: string,
+      answer: string,
+    ) => Promise<{ ok: boolean; reveal?: unknown }>
+    onFinish: () => Promise<{ ok: boolean; redirectTo?: string }>
   }
 }
+
+const mount = (data: SessionData = initialData) => {
+  render(<TrainingSessionClient sessionId="s1" initialData={data} />)
+  return runnerProps.current as unknown as CapturedProps
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe("TrainingSessionClient — marquage", () => {
   it("hydrate les signets et persiste la bascule", async () => {
     setQuestionBookmark.mockResolvedValue({ success: true })
 
-    render(<TrainingSessionClient sessionId="s1" initialData={initialData} />)
-
-    const props = runnerProps.current as unknown as CapturedProps
+    const props = mount()
     expect(props.initialFlags.has("q1")).toBe(true)
 
     const res = await props.callbacks.onFlag("q1", false)
@@ -84,8 +116,7 @@ describe("TrainingSessionClient — marquage", () => {
   it("signale un échec de marquage au lieu de mentir", async () => {
     setQuestionBookmark.mockRejectedValue(new Error("Failed to fetch"))
 
-    render(<TrainingSessionClient sessionId="s1" initialData={initialData} />)
-    const props = runnerProps.current as unknown as CapturedProps
+    const props = mount()
 
     // `callAction` convertit le rejet réseau en `{ success: false }` — le garde
     // doit le voir passer, pas le laisser filer en rejet non géré.
@@ -94,5 +125,105 @@ describe("TrainingSessionClient — marquage", () => {
     expect(toastError).toHaveBeenCalledWith(
       "Marquage non enregistré, réessayez.",
     )
+  })
+})
+
+describe("TrainingSessionClient — session expirée", () => {
+  it("rend l'écran d'expiration au lieu du runner", () => {
+    render(
+      <TrainingSessionClient
+        sessionId="s1"
+        initialData={{ ...initialData, isExpired: true }}
+      />,
+    )
+    expect(screen.getByText("Session expirée")).toBeInTheDocument()
+    expect(screen.queryByTestId("runner-stub")).not.toBeInTheDocument()
+  })
+
+  it("le bouton de retour ramène à l'entraînement", async () => {
+    render(
+      <TrainingSessionClient
+        sessionId="s1"
+        initialData={{ ...initialData, isExpired: true }}
+      />,
+    )
+    await userEvent.click(
+      screen.getByRole("button", { name: /Retour à l'entraînement/i }),
+    )
+    expect(push).toHaveBeenCalledWith("/tableau-de-bord/entrainement")
+  })
+})
+
+describe("TrainingSessionClient — réponses et fin de session", () => {
+  it("mode tuteur : hydrate les révélations et propage celle du serveur", async () => {
+    saveTrainingAnswer.mockResolvedValue({
+      success: true,
+      isCorrect: true,
+      reveal: { correctAnswer: "A", explanation: "Parce que.", references: [] },
+    })
+
+    const props = mount({
+      ...initialData,
+      session: { ...initialData.session, mode: "tutor" },
+      questions: [
+        {
+          ...initialData.questions[0],
+          correctAnswer: "A",
+          explanation: "Déjà répondue",
+          references: ["Ref"],
+        },
+      ],
+    })
+
+    expect(props.initialRevealed).toHaveProperty("q1")
+
+    const res = await props.callbacks.onAnswer("q1", "A")
+    expect(res.ok).toBe(true)
+    expect(res.reveal).toMatchObject({ correctAnswer: "A" })
+  })
+
+  it("signale une réponse non enregistrée", async () => {
+    saveTrainingAnswer.mockResolvedValue({
+      success: false,
+      error: "Session expirée",
+    })
+
+    const props = mount()
+    const res = await props.callbacks.onAnswer("q1", "A")
+
+    expect(res.ok).toBe(false)
+    expect(toastError).toHaveBeenCalledWith(
+      "Réponse non enregistrée, réessayez.",
+    )
+  })
+
+  it("redirige vers les résultats à la fin", async () => {
+    completeTrainingSession.mockResolvedValue({ success: true, score: 100 })
+
+    const props = mount()
+    const res = await props.callbacks.onFinish()
+
+    expect(res.ok).toBe(true)
+    expect(res.redirectTo).toBe("/tableau-de-bord/entrainement/s1/resultats")
+    expect(push).toHaveBeenCalledWith(
+      "/tableau-de-bord/entrainement/s1/resultats",
+    )
+    expect(toastSuccess).toHaveBeenCalled()
+  })
+
+  it("ne redirige pas si la clôture échoue", async () => {
+    completeTrainingSession.mockResolvedValue({
+      success: false,
+      error: "Session introuvable",
+    })
+
+    const props = mount()
+    const res = await props.callbacks.onFinish()
+
+    expect(res.ok).toBe(false)
+    expect(res.redirectTo).toBeUndefined()
+    expect(toastError).toHaveBeenCalledWith("Erreur", {
+      description: "Session introuvable",
+    })
   })
 })

--- a/tests/components/quiz/TrainingSessionClient.test.tsx
+++ b/tests/components/quiz/TrainingSessionClient.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { TrainingSessionClient } from "@/app/(dashboard)/tableau-de-bord/entrainement/_components/training-session-client"
+
+const { setQuestionBookmark, toastError, runnerProps } = vi.hoisted(() => ({
+  setQuestionBookmark: vi.fn(),
+  toastError: vi.fn(),
+  runnerProps: { current: null as Record<string, unknown> | null },
+}))
+
+// Mock COMPLET : `callAction` importe `unstable_isUnrecognizedActionError` de
+// `next/navigation` — un mock partiel casse le chemin d'échec avec une erreur
+// cryptique (piège documenté dans `.claude/rules/data-layer.md`).
+vi.mock("next/navigation", async (orig) => ({
+  ...(await orig<typeof import("next/navigation")>()),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock("sonner", () => ({ toast: { error: toastError, success: vi.fn() } }))
+vi.mock("@/features/training/actions", () => ({
+  saveTrainingAnswer: vi.fn(),
+  completeTrainingSession: vi.fn(),
+  setQuestionBookmark,
+}))
+// Le runner complet (timers, Radix, motion) est hors sujet : on capture ses props.
+vi.mock("@/components/quiz/runner/quiz-runner", () => ({
+  QuizRunner: (props: Record<string, unknown>) => {
+    runnerProps.current = props
+    return <div data-testid="runner-stub" />
+  },
+}))
+
+const initialData = {
+  session: {
+    id: "s1",
+    questionCount: 1,
+    status: "in_progress" as const,
+    mode: "test" as const,
+    domain: null,
+    startedAt: 0,
+    completedAt: null,
+    expiresAt: Date.now() + 3_600_000,
+    score: null,
+  },
+  questions: [
+    {
+      _id: "q1",
+      _creationTime: 0,
+      question: "Q1 ?",
+      options: ["A", "B"],
+      objectifCMC: "Obj",
+      domain: "Cardiologie",
+      images: [],
+    },
+  ],
+  answers: {},
+  bookmarkedIds: ["q1"],
+  isExpired: false,
+}
+
+type CapturedProps = {
+  initialFlags: Set<string>
+  callbacks: {
+    onFlag: (id: string, flagged: boolean) => Promise<{ ok: boolean }>
+  }
+}
+
+describe("TrainingSessionClient — marquage", () => {
+  it("hydrate les signets et persiste la bascule", async () => {
+    setQuestionBookmark.mockResolvedValue({ success: true })
+
+    render(<TrainingSessionClient sessionId="s1" initialData={initialData} />)
+
+    const props = runnerProps.current as unknown as CapturedProps
+    expect(props.initialFlags.has("q1")).toBe(true)
+
+    const res = await props.callbacks.onFlag("q1", false)
+    expect(res.ok).toBe(true)
+    expect(setQuestionBookmark).toHaveBeenCalledWith({
+      questionId: "q1",
+      isBookmarked: false,
+    })
+  })
+
+  it("signale un échec de marquage au lieu de mentir", async () => {
+    setQuestionBookmark.mockRejectedValue(new Error("Failed to fetch"))
+
+    render(<TrainingSessionClient sessionId="s1" initialData={initialData} />)
+    const props = runnerProps.current as unknown as CapturedProps
+
+    // `callAction` convertit le rejet réseau en `{ success: false }` — le garde
+    // doit le voir passer, pas le laisser filer en rejet non géré.
+    const res = await props.callbacks.onFlag("q1", true)
+    expect(res.ok).toBe(false)
+    expect(toastError).toHaveBeenCalledWith(
+      "Marquage non enregistré, réessayez.",
+    )
+  })
+})

--- a/tests/integration/exam-lock-source.test.ts
+++ b/tests/integration/exam-lock-source.test.ts
@@ -1,0 +1,120 @@
+import { eq, inArray } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import {
+  examParticipations,
+  examQuestions,
+  exams,
+  questions,
+  user,
+} from "@/db/schema"
+import {
+  getOpenExamLockedQuestionIds,
+  getUserOpenExamLockedQuestionIds,
+} from "@/features/exams/dal.shared"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const OPEN_EXAM_ID = createId()
+const CLOSED_EXAM_ID = createId()
+// 0-1 = examen ouvert · 2 = examen clos · 3 = hors examen
+const qIds = Array.from({ length: 4 }, () => createId())
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: "IT verrou",
+    email: `lock-${suffix}@test.invalid`,
+  })
+  await db.insert(questions).values(
+    qIds.map((id, i) => ({
+      id,
+      question: `LOCK Q${i} ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj LOCK ${suffix}`,
+      domain: `LOCK-${suffix}`,
+    })),
+  )
+  await db.insert(exams).values([
+    {
+      id: OPEN_EXAM_ID,
+      title: `LOCK ouvert ${suffix}`,
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2099-01-01T00:00:00Z"),
+      completionTime: 3600,
+      createdBy: USER_ID,
+    },
+    {
+      id: CLOSED_EXAM_ID,
+      title: `LOCK clos ${suffix}`,
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-02T00:00:00Z"),
+      completionTime: 3600,
+      createdBy: USER_ID,
+    },
+  ])
+  await db.insert(examQuestions).values([
+    { examId: OPEN_EXAM_ID, questionId: qIds[0], position: 0 },
+    { examId: OPEN_EXAM_ID, questionId: qIds[1], position: 1 },
+    { examId: CLOSED_EXAM_ID, questionId: qIds[2], position: 0 },
+  ])
+  await db.insert(examParticipations).values([
+    {
+      id: createId(),
+      examId: OPEN_EXAM_ID,
+      userId: USER_ID,
+      status: "in_progress",
+      startedAt: new Date("2026-01-01T01:00:00Z"),
+    },
+    {
+      id: createId(),
+      examId: CLOSED_EXAM_ID,
+      userId: USER_ID,
+      status: "completed",
+      startedAt: new Date("2026-01-01T01:00:00Z"),
+    },
+  ])
+})
+
+afterAll(async () => {
+  await db
+    .delete(examParticipations)
+    .where(inArray(examParticipations.examId, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db
+    .delete(examQuestions)
+    .where(inArray(examQuestions.examId, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db
+    .delete(exams)
+    .where(inArray(exams.id, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("verrou anti-triche — source unique", () => {
+  it("le jeu complet ne dépend d'aucune liste de candidats", async () => {
+    const all = await getUserOpenExamLockedQuestionIds(USER_ID)
+
+    expect(all.has(qIds[0])).toBe(true)
+    expect(all.has(qIds[1])).toBe(true)
+    expect(all.has(qIds[2])).toBe(false) // examen clos
+    expect(all.has(qIds[3])).toBe(false) // hors examen
+  })
+
+  it("la version restreinte est un sous-ensemble du jeu complet", async () => {
+    const all = await getUserOpenExamLockedQuestionIds(USER_ID)
+    const narrowed = await getOpenExamLockedQuestionIds(USER_ID, [
+      qIds[0],
+      qIds[3],
+    ])
+
+    expect([...narrowed]).toEqual([qIds[0]])
+    for (const id of narrowed) expect(all.has(id)).toBe(true)
+  })
+})

--- a/tests/integration/question-bookmarks.test.ts
+++ b/tests/integration/question-bookmarks.test.ts
@@ -1,0 +1,80 @@
+import { eq, inArray } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import { questionBookmarks, questions, user } from "@/db/schema"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const DOMAIN = `QB-${suffix}`
+const qIds = Array.from({ length: 3 }, () => createId())
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: "IT bookmarks",
+    email: `qb-${suffix}@test.invalid`,
+  })
+  await db.insert(questions).values(
+    qIds.map((id, i) => ({
+      id,
+      question: `QB Q${i} ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj QB ${suffix}`,
+      domain: DOMAIN,
+    })),
+  )
+})
+
+afterAll(async () => {
+  await db
+    .delete(questionBookmarks)
+    .where(eq(questionBookmarks.userId, USER_ID))
+  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("table question_bookmarks", () => {
+  it("refuse un doublon (utilisateur, question)", async () => {
+    await db
+      .insert(questionBookmarks)
+      .values({ userId: USER_ID, questionId: qIds[0] })
+
+    await expect(
+      db.insert(questionBookmarks).values({
+        userId: USER_ID,
+        questionId: qIds[0],
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("la suppression d'une question emporte ses signets (cascade)", async () => {
+    const doomedQuestionId = createId()
+    await db.insert(questions).values({
+      id: doomedQuestionId,
+      question: `QB doomed ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: `Obj QB ${suffix}`,
+      domain: DOMAIN,
+    })
+    await db
+      .insert(questionBookmarks)
+      .values({ userId: USER_ID, questionId: doomedQuestionId })
+
+    await db.delete(questions).where(eq(questions.id, doomedQuestionId))
+
+    const rows = await db
+      .select({ id: questionBookmarks.id })
+      .from(questionBookmarks)
+      .where(eq(questionBookmarks.questionId, doomedQuestionId))
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/tests/integration/question-bookmarks.test.ts
+++ b/tests/integration/question-bookmarks.test.ts
@@ -2,6 +2,9 @@ import { eq, inArray } from "drizzle-orm"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { db } from "@/db"
 import { questionBookmarks, questions, user } from "@/db/schema"
+import { setQuestionBookmark } from "@/features/training/actions"
+import { getBookmarkedQuestionIds } from "@/features/training/dal"
+import { getCurrentSession } from "@/lib/dal"
 import { createId } from "@/lib/ids"
 
 vi.mock("react", async (orig) => {
@@ -9,6 +12,12 @@ vi.mock("react", async (orig) => {
   return { ...actual, cache: (fn: unknown) => fn }
 })
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
+
+const asOwner = () =>
+  vi.mocked(getCurrentSession).mockResolvedValue({
+    user: { id: USER_ID, role: "admin" },
+  } as never)
 
 const suffix = createId().slice(0, 8)
 const USER_ID = createId()
@@ -31,6 +40,7 @@ beforeAll(async () => {
       domain: DOMAIN,
     })),
   )
+  asOwner()
 })
 
 afterAll(async () => {
@@ -76,5 +86,57 @@ describe("table question_bookmarks", () => {
       .from(questionBookmarks)
       .where(eq(questionBookmarks.questionId, doomedQuestionId))
     expect(rows).toHaveLength(0)
+  })
+})
+
+describe("setQuestionBookmark", () => {
+  it("pose le signet, puis le retire", async () => {
+    asOwner()
+    const posed = await setQuestionBookmark({
+      questionId: qIds[1],
+      isBookmarked: true,
+    })
+    expect(posed.success).toBe(true)
+    expect(await getBookmarkedQuestionIds([qIds[1]])).toEqual([qIds[1]])
+
+    const removed = await setQuestionBookmark({
+      questionId: qIds[1],
+      isBookmarked: false,
+    })
+    expect(removed.success).toBe(true)
+    expect(await getBookmarkedQuestionIds([qIds[1]])).toEqual([])
+  })
+
+  it("est idempotente : deux poses successives ne cassent rien", async () => {
+    asOwner()
+    await setQuestionBookmark({ questionId: qIds[2], isBookmarked: true })
+    const again = await setQuestionBookmark({
+      questionId: qIds[2],
+      isBookmarked: true,
+    })
+    expect(again.success).toBe(true)
+    expect(await getBookmarkedQuestionIds([qIds[2]])).toEqual([qIds[2]])
+  })
+
+  it("ne lit jamais les signets d'un autre étudiant", async () => {
+    asOwner()
+    await setQuestionBookmark({ questionId: qIds[0], isBookmarked: true })
+
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      user: { id: createId(), role: "user" },
+    } as never)
+    expect(await getBookmarkedQuestionIds([qIds[0]])).toEqual([])
+
+    asOwner()
+  })
+
+  it("refuse proprement une question inexistante", async () => {
+    asOwner()
+    const res = await setQuestionBookmark({
+      questionId: "question-qui-n-existe-pas",
+      isBookmarked: true,
+    })
+    expect(res.success).toBe(false)
+    expect(res.error).toBe("Question introuvable.")
   })
 })

--- a/tests/integration/revision-corpus.test.ts
+++ b/tests/integration/revision-corpus.test.ts
@@ -1,0 +1,231 @@
+import { eq, inArray } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { db } from "@/db"
+import {
+  questionBookmarks,
+  questions,
+  trainingSessionItems,
+  trainingSessions,
+  user,
+} from "@/db/schema"
+import {
+  getRevisionCounts,
+  pickRevisionQuestionIds,
+} from "@/features/training/revision"
+import { createId } from "@/lib/ids"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+const suffix = createId().slice(0, 8)
+const USER_ID = createId()
+const OTHER_USER_ID = createId()
+const DOMAIN = `RC-${suffix}`
+const OBJ = `Obj RC ${suffix}`
+// Deuxième objectif, porté par la seule question d'index 4 : exerce la branche
+// « filtre objectifs » du SQL brut, qu'aucun autre test ne traverse.
+const OBJ_ALT = `Obj RC alt ${suffix}`
+
+// 0 = ratée · 1 = ratée puis réussie · 2 = réussie · 3 = marquée (jamais vue)
+// 4 = jamais vue (objectif alternatif) · 5 = ratée par l'AUTRE utilisateur
+const qIds = Array.from({ length: 6 }, () => createId())
+const SESSION_ID = createId()
+const OTHER_SESSION_ID = createId()
+
+const seedSession = async (
+  sessionId: string,
+  userId: string,
+  items: { questionId: string; isCorrect: boolean; answeredAt: Date }[],
+) => {
+  await db.insert(trainingSessions).values({
+    id: sessionId,
+    userId,
+    status: "completed",
+    mode: "test",
+    questionCount: items.length,
+    startedAt: new Date("2026-01-01T00:00:00Z"),
+    expiresAt: new Date("2026-01-02T00:00:00Z"),
+  })
+  await db.insert(trainingSessionItems).values(
+    items.map((it, position) => ({
+      sessionId,
+      questionId: it.questionId,
+      position,
+      selectedAnswer: it.isCorrect ? "A" : "B",
+      isCorrect: it.isCorrect,
+      answeredAt: it.answeredAt,
+    })),
+  )
+}
+
+beforeAll(async () => {
+  await db.insert(user).values([
+    { id: USER_ID, name: "IT revision", email: `rc-${suffix}@test.invalid` },
+    {
+      id: OTHER_USER_ID,
+      name: "IT revision autre",
+      email: `rc-other-${suffix}@test.invalid`,
+    },
+  ])
+  await db.insert(questions).values(
+    qIds.map((id, i) => ({
+      id,
+      question: `RC Q${i} ${suffix}?`,
+      correctAnswer: "A",
+      options: ["A", "B", "C", "D"],
+      objectifCmc: i === 4 ? OBJ_ALT : OBJ,
+      domain: DOMAIN,
+    })),
+  )
+
+  await seedSession(SESSION_ID, USER_ID, [
+    {
+      questionId: qIds[0],
+      isCorrect: false,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+    {
+      questionId: qIds[1],
+      isCorrect: false,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+    {
+      questionId: qIds[2],
+      isCorrect: true,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+  ])
+  // Reprise plus tardive de q1 : réussie → elle doit SORTIR des ratées.
+  await seedSession(createId(), USER_ID, [
+    {
+      questionId: qIds[1],
+      isCorrect: true,
+      answeredAt: new Date("2026-01-05T10:00:00Z"),
+    },
+  ])
+  await seedSession(OTHER_SESSION_ID, OTHER_USER_ID, [
+    {
+      questionId: qIds[5],
+      isCorrect: false,
+      answeredAt: new Date("2026-01-01T10:00:00Z"),
+    },
+  ])
+
+  await db
+    .insert(questionBookmarks)
+    .values({ userId: USER_ID, questionId: qIds[3] })
+})
+
+afterAll(async () => {
+  await db
+    .delete(questionBookmarks)
+    .where(eq(questionBookmarks.userId, USER_ID))
+  await db
+    .delete(trainingSessions)
+    .where(inArray(trainingSessions.userId, [USER_ID, OTHER_USER_ID]))
+  await db.delete(questions).where(inArray(questions.id, qIds))
+  await db.delete(user).where(inArray(user.id, [USER_ID, OTHER_USER_ID]))
+})
+
+describe("corpus de révision", () => {
+  it("« ratée » = dernière tentative fausse (une réussite ultérieure la retire)", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).toEqual([qIds[0]])
+  })
+
+  it("« non vue » = jamais répondue", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect([...ids].sort()).toEqual([qIds[3], qIds[4], qIds[5]].sort())
+  })
+
+  it("les critères s'unissent en OU", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed", "bookmarked"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect([...ids].sort()).toEqual([qIds[0], qIds[3]].sort())
+  })
+
+  it("borne le tirage à la limite demandée", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      limit: 2,
+    })
+    expect(ids).toHaveLength(2)
+  })
+
+  it("n'emprunte jamais l'historique d'un autre étudiant", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["failed"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).not.toContain(qIds[5])
+  })
+
+  it("une question servie mais jamais répondue reste « non vue »", async () => {
+    // Session abandonnée : l'item existe, `selected_answer` est nul.
+    const orphanSessionId = createId()
+    await db.insert(trainingSessions).values({
+      id: orphanSessionId,
+      userId: USER_ID,
+      status: "abandoned",
+      mode: "test",
+      questionCount: 1,
+      startedAt: new Date("2026-01-03T00:00:00Z"),
+      expiresAt: new Date("2026-01-04T00:00:00Z"),
+    })
+    await db.insert(trainingSessionItems).values({
+      sessionId: orphanSessionId,
+      questionId: qIds[4],
+      position: 0,
+    })
+
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).toContain(qIds[4])
+  })
+
+  it("intersecte avec le filtre d'objectifs CMC", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      criteria: ["unseen"],
+      domain: DOMAIN,
+      objectifsCMCs: [OBJ_ALT],
+      limit: 20,
+    })
+    expect(ids).toEqual([qIds[4]])
+
+    const counts = await getRevisionCounts(USER_ID, {
+      domain: DOMAIN,
+      objectifsCMCs: [OBJ_ALT],
+    })
+    expect(counts.unseen).toBe(1)
+  })
+
+  it("les compteurs décrivent le même corpus que le tirage", async () => {
+    const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+    expect(counts).toEqual({ failed: 1, unseen: 3, bookmarked: 1 })
+  })
+})

--- a/tests/integration/revision-corpus.test.ts
+++ b/tests/integration/revision-corpus.test.ts
@@ -355,6 +355,51 @@ describe("corpus de révision — verrou examen ouvert", () => {
   })
 })
 
+describe("corpus de révision — session d'entraînement en cours", () => {
+  it("n'expose pas la correction d'une session mode test encore ouverte", async () => {
+    // Mode test in_progress : `isCorrect` est délibérément masqué sur les trois
+    // canaux de lecture. Le compteur ne doit pas devenir le quatrième — sonder
+    // « Ratées » entre deux réponses donnerait un bit de correction par tentative,
+    // et saveTrainingAnswer autorise la ré-écriture d'un item.
+    const openSessionId = createId()
+    await db.insert(trainingSessions).values({
+      id: openSessionId,
+      userId: USER_ID,
+      status: "in_progress",
+      mode: "test",
+      questionCount: 1,
+      startedAt: new Date("2026-01-06T00:00:00Z"),
+      expiresAt: new Date("2099-01-01T00:00:00Z"),
+    })
+    await db.insert(trainingSessionItems).values({
+      sessionId: openSessionId,
+      questionId: qIds[2], // réussie en session complétée → ne doit pas basculer
+      position: 0,
+      selectedAnswer: "B",
+      isCorrect: false,
+      answeredAt: new Date("2026-01-06T10:00:00Z"),
+    })
+
+    try {
+      const ids = await pickRevisionQuestionIds(db, {
+        userId: USER_ID,
+        lockedIds: await resolveRevisionLock(USER_ID),
+        criteria: ["failed"],
+        domain: DOMAIN,
+        limit: 20,
+      })
+      expect(ids).not.toContain(qIds[2])
+
+      const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+      expect(counts.failed).toBe(0)
+    } finally {
+      await db
+        .delete(trainingSessions)
+        .where(eq(trainingSessions.id, openSessionId))
+    }
+  })
+})
+
 describe("createTrainingSession en révision", () => {
   it("démarre avec un corpus plus court que demandé, sous MIN_QUESTIONS", async () => {
     asUser(USER_ID)

--- a/tests/integration/revision-corpus.test.ts
+++ b/tests/integration/revision-corpus.test.ts
@@ -13,16 +13,29 @@ import {
   user,
 } from "@/db/schema"
 import {
+  abandonTrainingSession,
+  createTrainingSession,
+  loadRevisionCounts,
+} from "@/features/training/actions"
+import {
   getRevisionCounts,
   pickRevisionQuestionIds,
   resolveRevisionLock,
 } from "@/features/training/revision"
+import { getCurrentSession } from "@/lib/dal"
 import { createId } from "@/lib/ids"
 
 vi.mock("react", async (orig) => {
   const actual = await orig<typeof import("react")>()
   return { ...actual, cache: (fn: unknown) => fn }
 })
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("@/lib/dal", () => ({ getCurrentSession: vi.fn() }))
+
+const asUser = (id: string) =>
+  vi
+    .mocked(getCurrentSession)
+    .mockResolvedValue({ user: { id, role: "admin" } } as never)
 
 const suffix = createId().slice(0, 8)
 const USER_ID = createId()
@@ -339,5 +352,51 @@ describe("corpus de révision — verrou examen ouvert", () => {
       limit: 20,
     })
     expect(ids).toEqual([qIds[5]])
+  })
+})
+
+describe("createTrainingSession en révision", () => {
+  it("démarre avec un corpus plus court que demandé, sous MIN_QUESTIONS", async () => {
+    asUser(USER_ID)
+    const res = await createTrainingSession({
+      questionCount: 20,
+      domain: DOMAIN,
+      mode: "test",
+      revisionFilters: ["unseen"],
+    })
+    expect(res.success).toBe(true)
+    if (!res.success) return
+
+    try {
+      expect(res.questionCount).toBe(2)
+      const items = await db
+        .select({ id: trainingSessionItems.id })
+        .from(trainingSessionItems)
+        .where(eq(trainingSessionItems.sessionId, res.sessionId))
+      expect(items).toHaveLength(2)
+    } finally {
+      await abandonTrainingSession({ sessionId: res.sessionId })
+    }
+  })
+
+  it("refuse explicitement un corpus vide", async () => {
+    asUser(USER_ID)
+    const res = await createTrainingSession({
+      questionCount: 10,
+      domain: DOMAIN,
+      mode: "test",
+      revisionFilters: ["failed"],
+    })
+    expect(res.success).toBe(false)
+    if (res.success) return
+    expect(res.error).toContain("Aucune question")
+  })
+})
+
+describe("loadRevisionCounts", () => {
+  it("compte pour l'utilisateur de la session, pas celui passé en argument", async () => {
+    asUser(OTHER_USER_ID)
+    const counts = await loadRevisionCounts({ domain: DOMAIN })
+    expect(counts.failed).toBe(1) // la ratée de l'AUTRE utilisateur (qIds[5])
   })
 })

--- a/tests/integration/revision-corpus.test.ts
+++ b/tests/integration/revision-corpus.test.ts
@@ -2,6 +2,10 @@ import { eq, inArray } from "drizzle-orm"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { db } from "@/db"
 import {
+  examAnswers,
+  examParticipations,
+  examQuestions,
+  exams,
   questionBookmarks,
   questions,
   trainingSessionItems,
@@ -11,6 +15,7 @@ import {
 import {
   getRevisionCounts,
   pickRevisionQuestionIds,
+  resolveRevisionLock,
 } from "@/features/training/revision"
 import { createId } from "@/lib/ids"
 
@@ -33,6 +38,9 @@ const OBJ_ALT = `Obj RC alt ${suffix}`
 const qIds = Array.from({ length: 6 }, () => createId())
 const SESSION_ID = createId()
 const OTHER_SESSION_ID = createId()
+const OPEN_EXAM_ID = createId()
+const CLOSED_EXAM_ID = createId()
+const CLOSED_PARTICIPATION_ID = createId()
 
 const seedSession = async (
   sessionId: string,
@@ -116,9 +124,71 @@ beforeAll(async () => {
   await db
     .insert(questionBookmarks)
     .values({ userId: USER_ID, questionId: qIds[3] })
+
+  // Examen OUVERT portant la ratée (q0) et la marquée (q3) : elles doivent
+  // disparaître du corpus tant qu'il n'est pas clos.
+  await db.insert(exams).values([
+    {
+      id: OPEN_EXAM_ID,
+      title: `RC examen ouvert ${suffix}`,
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2099-01-01T00:00:00Z"),
+      completionTime: 3600,
+      createdBy: USER_ID,
+    },
+    {
+      id: CLOSED_EXAM_ID,
+      title: `RC examen clos ${suffix}`,
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-02T00:00:00Z"),
+      completionTime: 3600,
+      createdBy: USER_ID,
+    },
+  ])
+  await db.insert(examQuestions).values([
+    { examId: OPEN_EXAM_ID, questionId: qIds[0], position: 0 },
+    { examId: OPEN_EXAM_ID, questionId: qIds[3], position: 1 },
+    { examId: CLOSED_EXAM_ID, questionId: qIds[5], position: 0 },
+  ])
+  await db.insert(examParticipations).values([
+    {
+      id: createId(),
+      examId: OPEN_EXAM_ID,
+      userId: USER_ID,
+      status: "in_progress",
+      startedAt: new Date("2026-01-01T01:00:00Z"),
+    },
+    {
+      id: CLOSED_PARTICIPATION_ID,
+      examId: CLOSED_EXAM_ID,
+      userId: USER_ID,
+      status: "completed",
+      startedAt: new Date("2026-01-01T01:00:00Z"),
+    },
+  ])
+  // Marquée pendant un examen CLOS et jamais répondue : couvre la branche
+  // `is_flagged` et prouve que l'exclusion ne vise que les examens ouverts.
+  await db.insert(examAnswers).values({
+    participationId: CLOSED_PARTICIPATION_ID,
+    questionId: qIds[5],
+    selectedAnswer: null,
+    isCorrect: null,
+    isFlagged: true,
+  })
 })
 
 afterAll(async () => {
+  // Les réponses partent en cascade avec leur participation ; les participations
+  // doivent tomber avant les questions (`exam_answers.question_id` en restrict).
+  await db
+    .delete(examParticipations)
+    .where(inArray(examParticipations.examId, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db
+    .delete(examQuestions)
+    .where(inArray(examQuestions.examId, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
+  await db
+    .delete(exams)
+    .where(inArray(exams.id, [OPEN_EXAM_ID, CLOSED_EXAM_ID]))
   await db
     .delete(questionBookmarks)
     .where(eq(questionBookmarks.userId, USER_ID))
@@ -133,36 +203,42 @@ describe("corpus de révision", () => {
   it("« ratée » = dernière tentative fausse (une réussite ultérieure la retire)", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["failed"],
       domain: DOMAIN,
       limit: 20,
     })
-    expect(ids).toEqual([qIds[0]])
+    // q0 est dans un examen OUVERT → retirée du corpus (voir le describe verrou).
+    expect(ids).toEqual([])
   })
 
   it("« non vue » = jamais répondue", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["unseen"],
       domain: DOMAIN,
       limit: 20,
     })
-    expect([...ids].sort()).toEqual([qIds[3], qIds[4], qIds[5]].sort())
+    expect([...ids].sort()).toEqual([qIds[4], qIds[5]].sort())
   })
 
   it("les critères s'unissent en OU", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["failed", "bookmarked"],
       domain: DOMAIN,
       limit: 20,
     })
-    expect([...ids].sort()).toEqual([qIds[0], qIds[3]].sort())
+    // q0 et q3 verrouillées ; reste q5, marquée via un examen CLOS.
+    expect(ids).toEqual([qIds[5]])
   })
 
   it("borne le tirage à la limite demandée", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["unseen"],
       domain: DOMAIN,
       limit: 2,
@@ -173,6 +249,7 @@ describe("corpus de révision", () => {
   it("n'emprunte jamais l'historique d'un autre étudiant", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["failed"],
       domain: DOMAIN,
       limit: 20,
@@ -200,6 +277,7 @@ describe("corpus de révision", () => {
 
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["unseen"],
       domain: DOMAIN,
       limit: 20,
@@ -210,6 +288,7 @@ describe("corpus de révision", () => {
   it("intersecte avec le filtre d'objectifs CMC", async () => {
     const ids = await pickRevisionQuestionIds(db, {
       userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
       criteria: ["unseen"],
       domain: DOMAIN,
       objectifsCMCs: [OBJ_ALT],
@@ -226,6 +305,39 @@ describe("corpus de révision", () => {
 
   it("les compteurs décrivent le même corpus que le tirage", async () => {
     const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
-    expect(counts).toEqual({ failed: 1, unseen: 3, bookmarked: 1 })
+    expect(counts).toEqual({ failed: 0, unseen: 2, bookmarked: 1 })
+  })
+})
+
+describe("corpus de révision — verrou examen ouvert", () => {
+  it("exclut du TIRAGE les questions d'un examen ouvert où l'étudiant participe", async () => {
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
+      criteria: ["failed", "bookmarked", "unseen"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).not.toContain(qIds[0])
+    expect(ids).not.toContain(qIds[3])
+  })
+
+  it("exclut aussi des COMPTEURS (sinon le compteur redevient l'oracle)", async () => {
+    const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+    expect(counts.failed).toBe(0) // la seule ratée est dans l'examen ouvert
+  })
+
+  it("un examen CLOS ne verrouille rien : sa question marquée reste révisable", async () => {
+    const counts = await getRevisionCounts(USER_ID, { domain: DOMAIN })
+    expect(counts.bookmarked).toBe(1) // qIds[5], marquée via l'examen clos
+
+    const ids = await pickRevisionQuestionIds(db, {
+      userId: USER_ID,
+      lockedIds: await resolveRevisionLock(USER_ID),
+      criteria: ["bookmarked"],
+      domain: DOMAIN,
+      limit: 20,
+    })
+    expect(ids).toEqual([qIds[5]])
   })
 })

--- a/tests/integration/training.test.ts
+++ b/tests/integration/training.test.ts
@@ -14,6 +14,7 @@ import {
   examQuestions,
   exams,
   products,
+  questionBookmarks,
   questionExplanations,
   questionImages,
   questions,
@@ -29,6 +30,7 @@ import {
   createTrainingSession,
   deleteTrainingSession,
   saveTrainingAnswer,
+  setQuestionBookmark,
 } from "@/features/training/actions"
 import {
   getActiveTrainingSession,
@@ -99,6 +101,9 @@ beforeEach(() => {
 })
 
 afterAll(async () => {
+  await db
+    .delete(questionBookmarks)
+    .where(eq(questionBookmarks.userId, USER_ID))
   await db.delete(trainingSessions).where(eq(trainingSessions.userId, USER_ID))
   await db
     .delete(questionImages)
@@ -108,6 +113,35 @@ afterAll(async () => {
     .where(inArray(questionExplanations.questionId, qIds))
   await db.delete(questions).where(inArray(questions.id, qIds))
   await db.delete(user).where(eq(user.id, USER_ID))
+})
+
+describe("signets sur la vue de session", () => {
+  it("la vue expose les signets de l'utilisateur", async () => {
+    asAdmin()
+    const created = await createTrainingSession({
+      questionCount: 5,
+      domain: DOMAIN,
+      mode: "test",
+    })
+    expect(created.success).toBe(true)
+    if (!created.success) return
+
+    try {
+      const before = await getTrainingSessionById(created.sessionId)
+      expect(before?.bookmarkedIds).toEqual([])
+      const questionId = before!.questions[0]._id
+
+      await setQuestionBookmark({ questionId, isBookmarked: true })
+
+      const after = await getTrainingSessionById(created.sessionId)
+      expect(after?.bookmarkedIds).toContain(questionId)
+    } finally {
+      await abandonTrainingSession({ sessionId: created.sessionId })
+      await db
+        .delete(questionBookmarks)
+        .where(eq(questionBookmarks.userId, USER_ID))
+    }
+  })
 })
 
 describe("parcours complet (création → réponses → fin → résultats)", () => {


### PR DESCRIPTION
Implémente la première moitié de l'issue #115 : un étudiant compose sa session d'entraînement à partir de son propre historique. La seconde moitié (notes personnelles) part en P1-B.

Spec et plan sont sur la branche : `docs/superpowers/specs/2026-08-01-revision-ciblee-entrainement-design.md` et `docs/superpowers/plans/2026-08-01-revision-ciblee-entrainement.md`.

## Ce que ça change pour l'étudiant

Trois puces cochables dans le formulaire d'entraînement — **Ratées**, **Non vues**, **Marquées** — cumulables entre elles (OU) et avec domaine/objectifs CMC (ET), chacune avec son compteur. Quand le corpus est plus court que demandé, la session démarre avec ce qu'il y a et le toast annonce le nombre réellement retenu au lieu de refuser.

Le bouton « Marquer » de l'entraînement **écrit enfin** : il était branché sur un no-op (`onFlag: async () => ({ ok: true })`), le marquage n'était jamais persisté.

## L'invariante anti-triche

Le verrou des examens ouverts ne s'appliquait qu'à la **révélation** (trois canaux). Or un filtre « mes ratées » est **lui-même un oracle** : l'appartenance d'une question au lot dit « tu t'es trompé », donc triche pendant qu'un examen est ouvert, sans jamais voir la clé.

Le verrou passe donc à la **sélection** du corpus **et aux compteurs** — sinon le compteur redevient l'oracle que le lot n'est plus. `getOpenExamLockedQuestionIds` devient une restriction d'un jeu complet : une seule définition de la règle.

Deux pièges du même genre, trouvés en revue et corrigés :

- **Le compteur était un quatrième canal de lecture.** Le corpus dérivait `isCorrect` d'une session d'entraînement mode test **encore ouverte**, alors que trois gardes le masquent précisément dans ce cas. Sonder « Ratées » entre deux réponses donnait un bit de correction par tentative, et `saveTrainingAnswer` autorise la ré-écriture d'un item — trois sondages suffisaient. Le formulaire n'était masqué que par un rendu conditionnel, pas par une garde serveur.
- **Interblocage de pool évité.** Résoudre le verrou depuis l'intérieur de la transaction réclamait une 2ᵉ connexion (`max: 5`, sans `connectionTimeoutMillis`) : cinq créations concurrentes figeaient l'application entière. Les identifiants verrouillés sont un paramètre **requis**, résolu avant l'ouverture de la transaction.

## Modèle de données

Une seule table neuve, `question_bookmarks` (migration `0012`). Le `CASCADE` sur `question_id` est délibéré et contre-courant : `deleteQuestion` tente le hard delete et laisse Postgres arbitrer, donc un `RESTRICT` transformerait tout hard delete en soft delete dès le premier signet.

Le corpus se calcule **à la volée** (union des historiques entraînement + examens, `DISTINCT ON` sur la dernière tentative) plutôt que via une table d'agrégat — conforme à la règle projet, et une seule définition de « ratée ».

## Vérifications

- `bun run check` exit 0 · **1028 tests frontend**, couverture 83,69 / 80,26 / 81,88 / 84,57 · **310 tests d'intégration**
- **Revue adversariale de design** (12 constats : 11 corrigés, 1 rétrogradé avec preuve) puis **revue adversariale d'implémentation** (8 constats : 4 corrigés, 4 assumés)
- **E2E navigateur** : cycle complet du verrou prouvé sur un vrai compte étudiant — `Ratées` 5 → 2 à l'ouverture d'un examen contenant 3 des ratées, puis 5 après sa clôture ; `Marquées` 1 → 0 → 1 en parallèle

## Points d'attention pour la relecture

- Le SQL de `features/training/revision.ts` est le **premier SQL brut du repo** : l'union suivie d'un `DISTINCT ON` n'est pas exprimable au query builder, et une sous-requête `.as()` y déqualifie ses colonnes en silence. Tout reste paramétré via le template `sql`.
- La marge de couverture est mince (80,26 % pour un seuil de 80 %) : la prochaine branche non couverte fera rougir la CI.
- `scripts/test-integration.ts` transmet enfin ses arguments à vitest — les commandes ciblées lançaient la suite entière (134 s au lieu de 2 s).
- Le commit `7d78e51` (notes de doc) est sans rapport avec la feature : il reporte des notes restées non commitées d'une campagne précédente.
