### PR TITLE
Hydratation : retirer la session cliente du chemin de décision du rendu (NOMAQBANQ-5 / -1E)

### DIFF
--- a/.claude/rules/loading-ui.md
+++ b/.claude/rules/loading-ui.md
@@ -37,6 +37,35 @@ justifie dans le code.
   zone côté serveur et font descendre l'utilisateur en props via `toSessionUser`
   (`lib/session-user.ts`) : ne jamais réintroduire d'`authClient.useSession()`
   dans le shell.
+  **Cause racine, établie sur le replay de NOMAQBANQ-1E (2026-08-12).** L'atome
+  de session Better Auth n'est JAMAIS pré-rempli : il naît à
+  `{ data: null, isPending: true }` et n'est peuplé que par `onMount` →
+  `setTimeout(…, 0)` → aller-retour réseau. La session n'arrive donc pas AVANT
+  l'hydratation — elle arrive **PENDANT**, quand l'hydratation dure assez
+  longtemps (appareil d'entrée de gamme, gros bundle). Le store change entre
+  deux frames et le sous-arbre que React s'apprête à hydrater ne rend plus le
+  DOM servi.
+  **Aucun composant rendu côté serveur ne doit brancher son balisage sur
+  `authClient.useSession()`** — pas seulement le shell dashboard. Deux remèdes,
+  selon que la page peut lire les cookies :
+  - page déjà dynamique → descendre l'information en **prop depuis le Server
+    Component** (`app/(marketing)/tarifs/page.tsx` passe `isAuthenticated`) ;
+  - page ISR, où lire les cookies casserait la génération statique
+    (`/`, `/domaines`, `/a-propos`, `/evaluation` sont en `revalidate = 3600`)
+    → garder la session cliente mais la neutraliser pendant l'hydratation avec
+    `useMounted()` (`hooks/use-mounted.ts`), comme `components/marketing-header`
+    et `components/shared/theme-toggle.tsx`.
+
+  Deux corollaires qui coûtent cher à réapprendre :
+  - **le levier de reproduction est la DURÉE d'hydratation, pas l'état.** Une
+    machine de développement ne reproduira jamais : il faut throttler le CPU/le
+    réseau, ou un vrai appareil lent. Trois PR (#127, #130, #133) ont visé cette
+    issue en corrigeant du formatage avant que le replay ne donne la réponse ;
+  - **un test qui fige la session à une valeur constante ne teste rien** — il
+    passe que la garde existe ou non. Il faut faire CHANGER la valeur entre
+    `renderToString` et `hydrateRoot`, et observer `onRecoverableError`
+    (`tests/components/MarketingHeader.test.tsx`).
+
   Corollaire général : **tout état dérivé du client seul (session, `window`,
   `Date.now()`) rendu conditionnellement pendant le SSR produit un mismatch.**
   L'autre cause de la même issue était le salut du hero calculé sur l'heure du

--- a/app/(marketing)/tarifs/_components/pricing-grid.tsx
+++ b/app/(marketing)/tarifs/_components/pricing-grid.tsx
@@ -14,7 +14,6 @@ import { PricingCard } from "@/components/shared/payments/pricing-card"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { createStripeCheckout } from "@/features/payments/actions"
 import type { AccessStatus, ProductView } from "@/features/payments/dal"
-import { useCurrentUser } from "@/hooks/useCurrentUser"
 import { cn } from "@/lib/utils"
 
 type AccessFilter = "all" | "exam" | "training"
@@ -22,19 +21,19 @@ type AccessFilter = "all" | "exam" | "training"
 interface PricingGridProps {
   products: ProductView[]
   accessStatus: AccessStatus | null
+  isAuthenticated: boolean
 }
 
-export const PricingGrid = ({ products, accessStatus }: PricingGridProps) => {
+export const PricingGrid = ({
+  products,
+  accessStatus,
+  isAuthenticated,
+}: PricingGridProps) => {
   const [filter, setFilter] = useState<AccessFilter>("all")
   const [loadingProduct, setLoadingProduct] = useState<string | null>(null)
   const router = useRouter()
 
-  const { isAuthenticated, isLoading: isAuthLoading } = useCurrentUser()
-
   const handlePurchase = async (productCode: string) => {
-    // Attendre que l'état d'authentification soit déterminé.
-    if (isAuthLoading) return
-
     if (!isAuthenticated) {
       router.push("/inscription")
       return

--- a/app/(marketing)/tarifs/_components/tarifs-page-client.tsx
+++ b/app/(marketing)/tarifs/_components/tarifs-page-client.tsx
@@ -36,10 +36,12 @@ export default function TarifsPageClient({
   products,
   accessStatus,
   stats,
+  isAuthenticated,
 }: {
   products: ProductView[]
   accessStatus: AccessStatus | null
   stats: MarketingStats
+  isAuthenticated: boolean
 }) {
   return (
     <>
@@ -47,7 +49,11 @@ export default function TarifsPageClient({
       <PricingHeader stats={stats} />
 
       {/* Pricing cards */}
-      <PricingGrid products={products} accessStatus={accessStatus} />
+      <PricingGrid
+        products={products}
+        accessStatus={accessStatus}
+        isAuthenticated={isAuthenticated}
+      />
 
       {/* Guarantees section */}
       <section className="bg-linear-to-br from-gray-50 to-white py-20 dark:from-gray-900 dark:to-gray-800">

--- a/app/(marketing)/tarifs/page.tsx
+++ b/app/(marketing)/tarifs/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next"
 import { getMarketingStats } from "@/features/marketing/dal"
 import { getAccessStatus, getAvailableProducts } from "@/features/payments/dal"
+import { getCurrentSession } from "@/lib/dal"
 import TarifsPageClient from "./_components/tarifs-page-client"
 
 export const metadata: Metadata = {
@@ -20,16 +21,21 @@ export const metadata: Metadata = {
 export default async function TarifsPage() {
   // Produits publics + accès courant (null si visiteur non connecté) + stats.
   // Page dynamique (session via getAccessStatus) : pas d'ISR ici.
-  const [products, accessStatus, stats] = await Promise.all([
+  // `isAuthenticated` descend en prop plutôt que d'être lu côté client : la
+  // session n'est pas résolue au SSR, un rendu qui en dépend produit deux
+  // arbres DOM différents à l'hydratation.
+  const [products, accessStatus, stats, session] = await Promise.all([
     getAvailableProducts(),
     getAccessStatus(),
     getMarketingStats(),
+    getCurrentSession(),
   ])
   return (
     <TarifsPageClient
       products={products}
       accessStatus={accessStatus}
       stats={stats}
+      isAuthenticated={!!session?.user}
     />
   )
 }

--- a/components/marketing-header/index.tsx
+++ b/components/marketing-header/index.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { useMounted } from "@/hooks/use-mounted"
 import { useCurrentUser } from "@/hooks/useCurrentUser"
 import { authClient } from "@/lib/auth-client"
 import { MobileMenu } from "./mobile-menu"
@@ -35,6 +36,9 @@ export const MarketingHeader = () => {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
   const { isVisible, isScrolled } = useHeaderScroll()
   const { currentUser, isAuthenticated } = useCurrentUser()
+  // La session n'est pas résolue au SSR : la laisser choisir le balisage
+  // pendant l'hydratation produit deux arbres DOM différents.
+  const showUser = useMounted() && isAuthenticated
   const pathname = usePathname()
   const router = useRouter()
 
@@ -144,7 +148,7 @@ export const MarketingHeader = () => {
             <div className="hidden items-center gap-3 lg:flex">
               <ThemeToggle />
 
-              {isAuthenticated && currentUser ? (
+              {showUser && currentUser ? (
                 <DropdownMenu
                   modal={false}
                   open={isUserMenuOpen}
@@ -245,7 +249,7 @@ export const MarketingHeader = () => {
         onOpenChange={setIsMobileMenuOpen}
         navigation={navigation}
         currentUser={currentUser}
-        isAuthenticated={isAuthenticated}
+        isAuthenticated={showUser}
       />
 
       {/* Spacer pour le contenu */}

--- a/components/shared/theme-toggle.tsx
+++ b/components/shared/theme-toggle.tsx
@@ -2,7 +2,7 @@
 
 import { Monitor, Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
-import { useEffect, useState, useSyncExternalStore } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -10,18 +10,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-
-// useSyncExternalStore pour détecter le montage côté client sans setState dans useEffect
-const emptySubscribe = () => () => {}
+import { useMounted } from "@/hooks/use-mounted"
 
 export default function ThemeToggle() {
   const { setTheme } = useTheme()
   const [open, setOpen] = useState(false)
-  const mounted = useSyncExternalStore(
-    emptySubscribe,
-    () => true, // Côté client : toujours monté
-    () => false, // Côté serveur : jamais monté
-  )
+  const mounted = useMounted()
 
   useEffect(() => {
     if (!open) return

--- a/docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md
+++ b/docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md
@@ -1,0 +1,769 @@
+# Hydratation : supprimer le branchement de rendu sur la session cliente — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Supprimer les deux endroits où le rendu dépend de `authClient.useSession()` alors que le composant est rendu côté serveur en premier — cause de `NOMAQBANQ-5` / `NOMAQBANQ-1E` sur `/tarifs`.
+
+**Architecture:** Sur `/tarifs` (page dynamique), l'authentification descend du Server Component en prop explicite. Sur le header marketing (présent sur des pages ISR, où lire les cookies casserait la génération statique), la session reste cliente mais ne peut plus décider pendant le rendu d'hydratation : une garde `mounted` bâtie sur `useSyncExternalStore` avec un `getServerSnapshot` constant.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, Better Auth, Vitest + happy-dom + Testing Library.
+
+**Spec :** `docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md`
+
+**Branche :** `fix/hydratation-session-tarifs-header` (déjà créée, contient le commit de la spec).
+
+---
+
+## Pourquoi c'est un vrai bug (à garder en tête pendant l'exécution)
+
+`node_modules/better-auth/dist/client/react/react-store.mjs:41` :
+
+```js
+return useSyncExternalStore(subscribe, get, get)
+```
+
+Le 3ᵉ argument est `getServerSnapshot` — celui que React utilise pour le **rendu d'hydratation**. Better Auth y passe `get`, la même fonction que le snapshot client : elle renvoie l'état courant du store, pas une valeur neutre. Si la session est déjà résolue côté client à l'hydratation, le rendu d'hydratation voit un utilisateur là où le HTML serveur n'en avait aucun → deux arbres DOM différents → `throwOnHydrationMismatch`.
+
+**Corollaire pour les tests :** un `render()` de Testing Library est un rendu **client**, il passe par `getSnapshot`. Il ne peut donc PAS constater le comportement d'hydratation. Le seul test honnête pour la garde du header est un `renderToString` de `react-dom/server`, qui emprunte `getServerSnapshot`.
+
+## Structure des fichiers
+
+| Fichier | Rôle | Action |
+| --- | --- | --- |
+| `app/(marketing)/tarifs/page.tsx` | Server Component : résout la session et la descend | Modifier |
+| `app/(marketing)/tarifs/_components/tarifs-page-client.tsx` | Relais de props | Modifier |
+| `app/(marketing)/tarifs/_components/pricing-grid.tsx` | Consommateur fautif n°1 | Modifier |
+| `hooks/use-mounted.ts` | Garde d'hydratation partagée | Créer |
+| `components/shared/theme-toggle.tsx` | Adopte le hook partagé (dédup) | Modifier |
+| `components/marketing-header/index.tsx` | Consommateur fautif n°2 | Modifier |
+| `tests/helpers/motion-mock.tsx` | Ajouter `motion.header` | Modifier |
+| `tests/components/payments/PricingGrid.test.tsx` | Tests tâche 1 | Créer |
+| `tests/hooks/useMounted.test.tsx` | Tests tâche 2 | Créer |
+| `tests/components/MarketingHeader.test.tsx` | Tests tâche 4 | Créer |
+| `.claude/rules/loading-ui.md` | Généraliser la règle | Modifier |
+
+`components/marketing-header/mobile-menu.tsx` **ne change pas** : il reçoit déjà `currentUser` et `isAuthenticated` en props depuis le header, la garde posée dans le header le couvre.
+
+---
+
+## Task 1 : `PricingGrid` — descendre `isAuthenticated` depuis le serveur
+
+**Files:**
+- Modify: `app/(marketing)/tarifs/page.tsx`
+- Modify: `app/(marketing)/tarifs/_components/tarifs-page-client.tsx`
+- Modify: `app/(marketing)/tarifs/_components/pricing-grid.tsx:27-64,120`
+- Test: `tests/components/payments/PricingGrid.test.tsx` (créer)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `tests/components/payments/PricingGrid.test.tsx`.
+
+Point clé : ce fichier **ne mocke PAS `@/hooks/useCurrentUser`**. C'est délibéré — c'est ce qui rend le test discriminant. Tant que le composant lit la session cliente, aucune session n'est résolue dans happy-dom et le bandeau ne se rend pas.
+
+```tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { PricingGrid } from "@/app/(marketing)/tarifs/_components/pricing-grid"
+
+vi.mock("motion/react", async () => {
+  const { motionMockFactory } = await import("../../helpers/motion-mock")
+  return motionMockFactory
+})
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh: vi.fn() }),
+}))
+
+const createStripeCheckout = vi.fn()
+vi.mock("@/features/payments/actions", () => ({
+  createStripeCheckout: (...args: unknown[]) => createStripeCheckout(...args),
+}))
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock("@/lib/format", () => ({
+  formatCurrency: (amount: number) => `${(amount / 100).toFixed(0)} $`,
+  formatExpiration: (ts: number) => `exp-${ts}`,
+}))
+
+const products = [
+  {
+    id: "prod_1",
+    code: "exam_access" as const,
+    name: "Accès Examens 30 jours",
+    description: "Accès complet aux examens simulés",
+    priceCAD: 5000,
+    durationDays: 30,
+    accessType: "exam" as const,
+    isCombo: false,
+    stripeProductId: "prod_test",
+    stripePriceId: "price_test",
+  },
+]
+
+const accessStatus = {
+  examAccess: { expiresAt: 1_800_000_000_000, daysRemaining: 12 },
+  trainingAccess: null,
+}
+
+describe("PricingGrid", () => {
+  beforeEach(() => {
+    createStripeCheckout.mockResolvedValue({ checkoutUrl: "https://stripe.test/x" })
+  })
+
+  it("rend le bandeau d'accès à partir de la prop serveur, sans session cliente", () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={accessStatus}
+        isAuthenticated
+      />,
+    )
+
+    expect(screen.getByText("Vos accès actuels")).toBeInTheDocument()
+  })
+
+  it("n'affiche pas le bandeau pour un visiteur non authentifié", () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={null}
+        isAuthenticated={false}
+      />,
+    )
+
+    expect(screen.queryByText("Vos accès actuels")).not.toBeInTheDocument()
+  })
+
+  it("redirige vers l'inscription quand le visiteur n'est pas authentifié", async () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={null}
+        isAuthenticated={false}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/inscription"))
+    expect(createStripeCheckout).not.toHaveBeenCalled()
+  })
+
+  it("ouvre le checkout Stripe dès le premier clic d'un visiteur authentifié", async () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={{ examAccess: null, trainingAccess: null }}
+        isAuthenticated
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+
+    await waitFor(() =>
+      expect(createStripeCheckout).toHaveBeenCalledWith({
+        productCode: "exam_access",
+        successPath: "/tableau-de-bord/paiement/succes",
+        cancelPath: "/tarifs",
+      }),
+    )
+    expect(push).not.toHaveBeenCalled()
+  })
+})
+```
+
+> Le libellé « Acheter maintenant » vient de `components/shared/payments/pricing-card.tsx:285`. Il bascule en « Prolonger l'accès » quand la carte a un `currentAccess` — les deux tests de clic passent un accès nul pour ce type, le libellé reste donc « Acheter maintenant ».
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+```bash
+bun run test -- tests/components/payments/PricingGrid.test.tsx
+```
+
+Attendu : ÉCHEC. `PricingGrid` n'accepte pas encore la prop `isAuthenticated` (erreur TypeScript / prop ignorée), le bandeau ne se rend pas et le clic ne déclenche rien (le `if (isAuthLoading) return` sort tôt, `isPending` valant `true` sans session résolue).
+
+- [ ] **Step 3 : Modifier `pricing-grid.tsx`**
+
+Retirer l'import du hook :
+
+```diff
+-import { useCurrentUser } from "@/hooks/useCurrentUser"
+```
+
+Étendre les props :
+
+```diff
+ interface PricingGridProps {
+   products: ProductView[]
+   accessStatus: AccessStatus | null
++  isAuthenticated: boolean
+ }
+
+-export const PricingGrid = ({ products, accessStatus }: PricingGridProps) => {
++export const PricingGrid = ({
++  products,
++  accessStatus,
++  isAuthenticated,
++}: PricingGridProps) => {
+   const [filter, setFilter] = useState<AccessFilter>("all")
+   const [loadingProduct, setLoadingProduct] = useState<string | null>(null)
+   const router = useRouter()
+-
+-  const { isAuthenticated, isLoading: isAuthLoading } = useCurrentUser()
+```
+
+Simplifier `handlePurchase` :
+
+```diff
+   const handlePurchase = async (productCode: string) => {
+-    // Attendre que l'état d'authentification soit déterminé.
+-    if (isAuthLoading) return
+-
+     if (!isAuthenticated) {
+       router.push("/inscription")
+       return
+     }
+```
+
+Le reste du composant (bandeau ligne 120, grille, onglets) est inchangé : `isAuthenticated` est désormais une prop.
+
+- [ ] **Step 4 : Câbler la prop depuis le Server Component**
+
+`app/(marketing)/tarifs/page.tsx` :
+
+```diff
+ import { Metadata } from "next"
+ import { getMarketingStats } from "@/features/marketing/dal"
+ import { getAccessStatus, getAvailableProducts } from "@/features/payments/dal"
++import { getCurrentSession } from "@/lib/dal"
+ import TarifsPageClient from "./_components/tarifs-page-client"
+```
+
+```diff
+ export default async function TarifsPage() {
+-  // Produits publics + accès courant (null si visiteur non connecté) + stats.
+-  // Page dynamique (session via getAccessStatus) : pas d'ISR ici.
+-  const [products, accessStatus, stats] = await Promise.all([
++  // Produits publics + accès courant (null si visiteur non connecté) + stats.
++  // Page dynamique (session via getAccessStatus) : pas d'ISR ici.
++  // `isAuthenticated` descend en prop plutôt que d'être lu côté client : la
++  // session n'est pas résolue au SSR, un rendu qui en dépend produit deux
++  // arbres DOM différents à l'hydratation.
++  const [products, accessStatus, stats, session] = await Promise.all([
+     getAvailableProducts(),
+     getAccessStatus(),
+     getMarketingStats(),
++    getCurrentSession(),
+   ])
+   return (
+     <TarifsPageClient
+       products={products}
+       accessStatus={accessStatus}
+       stats={stats}
++      isAuthenticated={!!session?.user}
+     />
+   )
+ }
+```
+
+`getCurrentSession` (`lib/dal.ts:7`) est enveloppé dans React `cache()` et `getAccessStatus` l'appelle déjà en interne : aucune requête supplémentaire n'est émise.
+
+`app/(marketing)/tarifs/_components/tarifs-page-client.tsx` :
+
+```diff
+ export default function TarifsPageClient({
+   products,
+   accessStatus,
+   stats,
++  isAuthenticated,
+ }: {
+   products: ProductView[]
+   accessStatus: AccessStatus | null
+   stats: MarketingStats
++  isAuthenticated: boolean
+ }) {
+   return (
+     <>
+       <PricingHeader stats={stats} />
+
+-      <PricingGrid products={products} accessStatus={accessStatus} />
++      <PricingGrid
++        products={products}
++        accessStatus={accessStatus}
++        isAuthenticated={isAuthenticated}
++      />
+```
+
+- [ ] **Step 5 : Relancer le test — il doit passer**
+
+```bash
+bun run test -- tests/components/payments/PricingGrid.test.tsx
+```
+
+Attendu : 4 tests PASS.
+
+- [ ] **Step 6 : Vérifier la discriminance**
+
+Remettre temporairement le défaut dans `pricing-grid.tsx` : réintroduire `const { isAuthenticated } = useCurrentUser()` (en ignorant la prop) et relancer.
+
+Attendu : les tests « rend le bandeau » et « ouvre le checkout » ÉCHOUENT. Si tout passe encore, le test ne teste rien — corriger le test avant de continuer. Puis annuler cette modification temporaire.
+
+- [ ] **Step 7 : Gate + commit**
+
+```bash
+bun run check
+git add app/\(marketing\)/tarifs tests/components/payments/PricingGrid.test.tsx
+git commit -m "fix(tarifs): descendre l'authentification du serveur au lieu de la lire côté client"
+```
+
+---
+
+## Task 2 : Hook partagé `useMounted`
+
+**Files:**
+- Create: `hooks/use-mounted.ts`
+- Test: `tests/hooks/useMounted.test.tsx` (créer)
+
+`hooks/**/*.ts` est inclus dans la couverture (`vitest.config.ts`) : ce hook doit être testé.
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `tests/hooks/useMounted.test.tsx` :
+
+```tsx
+import { renderHook } from "@testing-library/react"
+import { renderToString } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { useMounted } from "@/hooks/use-mounted"
+
+const Probe = () => <span>{useMounted() ? "monté" : "non monté"}</span>
+
+describe("useMounted", () => {
+  it("vaut false au snapshot serveur (donc au rendu d'hydratation)", () => {
+    expect(renderToString(<Probe />)).toContain("non monté")
+  })
+
+  it("vaut true côté client", () => {
+    const { result } = renderHook(() => useMounted())
+    expect(result.current).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+```bash
+bun run test -- tests/hooks/useMounted.test.tsx
+```
+
+Attendu : ÉCHEC — `Cannot find module '@/hooks/use-mounted'`.
+
+- [ ] **Step 3 : Écrire le hook**
+
+Créer `hooks/use-mounted.ts` :
+
+```ts
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+const emptySubscribe = () => () => {}
+const getSnapshot = () => true
+const getServerSnapshot = () => false
+
+/**
+ * `false` pendant le rendu serveur ET pendant le rendu d'hydratation, `true`
+ * ensuite. `getServerSnapshot` renvoie une constante : React l'emprunte à
+ * l'hydratation, le rendu client reproduit donc exactement le HTML serveur.
+ *
+ * Sert à empêcher un état exclusivement client (session Better Auth, thème)
+ * de décider du balisage pendant l'hydratation. `authClient.useSession()` en a
+ * besoin parce que Better Auth passe son snapshot CLIENT comme
+ * `getServerSnapshot` (`better-auth/dist/client/react/react-store.mjs`) : sans
+ * cette garde, une session déjà en cache rend un arbre différent du HTML servi.
+ */
+export const useMounted = () =>
+  useSyncExternalStore(emptySubscribe, getSnapshot, getServerSnapshot)
+```
+
+- [ ] **Step 4 : Relancer le test — il doit passer**
+
+```bash
+bun run test -- tests/hooks/useMounted.test.tsx
+```
+
+Attendu : 2 tests PASS.
+
+- [ ] **Step 5 : Faire adopter le hook par `ThemeToggle`**
+
+`components/shared/theme-toggle.tsx` — remplacer la duplication locale :
+
+```diff
+ import { useTheme } from "next-themes"
+-import { useEffect, useState, useSyncExternalStore } from "react"
++import { useEffect, useState } from "react"
+ import { Button } from "@/components/ui/button"
+ import {
+   DropdownMenu,
+   DropdownMenuContent,
+   DropdownMenuItem,
+   DropdownMenuTrigger,
+ } from "@/components/ui/dropdown-menu"
+-
+-// useSyncExternalStore pour détecter le montage côté client sans setState dans useEffect
+-const emptySubscribe = () => () => {}
++import { useMounted } from "@/hooks/use-mounted"
+
+ export default function ThemeToggle() {
+   const { setTheme } = useTheme()
+   const [open, setOpen] = useState(false)
+-  const mounted = useSyncExternalStore(
+-    emptySubscribe,
+-    () => true, // Côté client : toujours monté
+-    () => false, // Côté serveur : jamais monté
+-  )
++  const mounted = useMounted()
+```
+
+Le reste du fichier (placeholder `if (!mounted)`, dropdown) est inchangé.
+
+- [ ] **Step 6 : Gate + commit**
+
+```bash
+bun run check
+bun run test -- tests/hooks/useMounted.test.tsx
+git add hooks/use-mounted.ts tests/hooks/useMounted.test.tsx components/shared/theme-toggle.tsx
+git commit -m "refactor: extraire la garde d'hydratation useMounted"
+```
+
+---
+
+## Task 3 : Ajouter `motion.header` au mock de tests
+
+**Files:**
+- Modify: `tests/helpers/motion-mock.tsx:96` (après l'entrée `circle`)
+
+`MarketingHeader` rend un `<motion.header>`, absent du mock actuel — sans cette entrée le test de la tâche 4 lève `motion.header is not a function`.
+
+- [ ] **Step 1 : Ajouter l'entrée**
+
+```diff
+     // SVG : utilisé par ProgressRing (dashboard étudiant).
+     circle: ({
+       children,
+       ...props
+     }: ComponentPropsWithoutRef<"circle"> & Record<string, unknown>) => {
+       const filtered = filterMotionProps(props)
+       return <circle {...filtered}>{children}</circle>
+     },
++    header: ({
++      children,
++      ...props
++    }: ComponentPropsWithoutRef<"header"> & Record<string, unknown>) => {
++      const filtered = filterMotionProps(props)
++      return <header {...filtered}>{children}</header>
++    },
+   },
+```
+
+- [ ] **Step 2 : Vérifier que la suite existante ne régresse pas**
+
+```bash
+bun run test
+```
+
+Attendu : tous les tests existants PASS (ajout purement additif).
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add tests/helpers/motion-mock.tsx
+git commit -m "test: ajouter motion.header au mock motion"
+```
+
+---
+
+## Task 4 : `MarketingHeader` — garde d'hydratation
+
+**Files:**
+- Modify: `components/marketing-header/index.tsx:20,37,147,247-248`
+- Test: `tests/components/MarketingHeader.test.tsx` (créer)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `tests/components/MarketingHeader.test.tsx`. Le test mocke `useCurrentUser` pour renvoyer un **utilisateur connecté**, puis constate que le rendu serveur/hydratation affiche quand même la branche déconnectée — c'est exactement l'invariant qu'on veut verrouiller.
+
+```tsx
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { renderToString } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { MarketingHeader } from "@/components/marketing-header"
+import { useCurrentUser } from "@/hooks/useCurrentUser"
+
+vi.mock("motion/react", async () => {
+  const { motionMockFactory } = await import("../helpers/motion-mock")
+  return motionMockFactory
+})
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/tarifs",
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light", setTheme: vi.fn() }),
+}))
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { signOut: vi.fn() },
+}))
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: vi.fn(),
+}))
+
+const connecte = {
+  currentUser: {
+    name: "Awa Diallo",
+    email: "awa@example.test",
+    image: null,
+  },
+  isLoading: false,
+  isAuthenticated: true,
+  refetch: vi.fn(),
+}
+
+describe("MarketingHeader", () => {
+  it("rend la branche déconnectée à l'hydratation, même avec une session résolue", () => {
+    vi.mocked(useCurrentUser).mockReturnValue(
+      connecte as ReturnType<typeof useCurrentUser>,
+    )
+
+    const html = renderToString(<MarketingHeader />)
+
+    expect(html).toContain("Connexion")
+    expect(html).toContain("Inscription")
+    expect(html).not.toContain("Awa Diallo")
+  })
+
+  it("affiche l'utilisateur une fois monté côté client", () => {
+    vi.mocked(useCurrentUser).mockReturnValue(
+      connecte as ReturnType<typeof useCurrentUser>,
+    )
+
+    render(<MarketingHeader />)
+
+    expect(screen.queryByRole("link", { name: "Connexion" })).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+```bash
+bun run test -- tests/components/MarketingHeader.test.tsx
+```
+
+Attendu : ÉCHEC sur le premier test — sans la garde, `renderToString` rend déjà la branche connectée (le mock renvoie un utilisateur), donc `Connexion` est absent et `Awa Diallo` présent.
+
+- [ ] **Step 3 : Poser la garde**
+
+`components/marketing-header/index.tsx` :
+
+```diff
+ import { useCurrentUser } from "@/hooks/useCurrentUser"
++import { useMounted } from "@/hooks/use-mounted"
+ import { authClient } from "@/lib/auth-client"
+```
+
+```diff
+   const { isVisible, isScrolled } = useHeaderScroll()
+   const { currentUser, isAuthenticated } = useCurrentUser()
++  // La session n'est pas résolue au SSR : la laisser choisir le balisage
++  // pendant l'hydratation produit deux arbres DOM différents.
++  const showUser = useMounted() && isAuthenticated
+   const pathname = usePathname()
+```
+
+Branche desktop (ligne 147) :
+
+```diff
+-              {isAuthenticated && currentUser ? (
++              {showUser && currentUser ? (
+```
+
+Passage au menu mobile (lignes 247-248) :
+
+```diff
+         currentUser={currentUser}
+-        isAuthenticated={isAuthenticated}
++        isAuthenticated={showUser}
+```
+
+`mobile-menu.tsx` n'est pas modifié : il consomme la prop.
+
+- [ ] **Step 4 : Relancer le test — il doit passer**
+
+```bash
+bun run test -- tests/components/MarketingHeader.test.tsx
+```
+
+Attendu : 2 tests PASS.
+
+- [ ] **Step 5 : Vérifier la discriminance**
+
+Remplacer temporairement `showUser` par `isAuthenticated` à la ligne 147 et relancer.
+
+Attendu : le premier test ÉCHOUE. Si les deux passent encore, le test ne teste pas la garde. Puis annuler cette modification temporaire.
+
+- [ ] **Step 6 : Gate + commit**
+
+```bash
+bun run check
+git add components/marketing-header/index.tsx tests/components/MarketingHeader.test.tsx
+git commit -m "fix(marketing): empêcher la session cliente de décider du rendu d'hydratation du header"
+```
+
+> **Message de commit — à ne pas embellir.** Ce correctif est un durcissement structurel : aucun événement Sentry ne désigne le header (les 3 événements résiduels sont tous sur `/tarifs`). Le corps du commit doit le dire, sinon le prochain lecteur croira que le header était prouvé fautif.
+
+---
+
+## Task 5 : Généraliser la règle dans `.claude/rules/loading-ui.md`
+
+**Files:**
+- Modify: `.claude/rules/loading-ui.md` (section « Pas d'état de chargement pour la session »)
+
+La règle actuelle interdit `authClient.useSession()` **dans le shell dashboard**. Le défaut est en réalité général, et sa cause est maintenant prouvée dans la source de la bibliothèque.
+
+- [ ] **Step 1 : Remplacer le corollaire final de la section**
+
+Remplacer le paragraphe qui commence par « Corollaire général : » par :
+
+```markdown
+  **Cause racine, prouvée dans la bibliothèque** :
+  `better-auth/dist/client/react/react-store.mjs` appelle
+  `useSyncExternalStore(subscribe, get, get)` — le 3ᵉ argument est
+  `getServerSnapshot`, celui que React emprunte pour le **rendu d'hydratation**,
+  et Better Auth y passe le snapshot CLIENT. Une session déjà en cache est donc
+  visible pendant l'hydratation alors que le HTML serveur a été produit sans
+  elle. **Aucun composant rendu côté serveur ne doit brancher son balisage sur
+  `authClient.useSession()`** — pas seulement le shell dashboard.
+  Deux remèdes, selon que la page peut lire les cookies :
+  - page déjà dynamique → descendre l'information en **prop depuis le Server
+    Component** (`app/(marketing)/tarifs/page.tsx` passe `isAuthenticated`) ;
+  - page ISR, où lire les cookies casserait la génération statique
+    (`/`, `/domaines`, `/a-propos`, `/evaluation` sont en `revalidate = 3600`)
+    → garder la session cliente mais la neutraliser pendant l'hydratation avec
+    `useMounted()` (`hooks/use-mounted.ts`), comme `components/marketing-header`
+    et `components/shared/theme-toggle.tsx`.
+
+  Corollaire général : **tout état dérivé du client seul (session, `window`,
+  `Date.now()`) rendu conditionnellement pendant le SSR produit un mismatch.**
+  L'autre cause de la même issue était le salut du hero calculé sur l'heure du
+  runtime (corrigé par #130, `getAppZoneHour`).
+```
+
+- [ ] **Step 2 : Vérifier le formatage**
+
+```bash
+bun run format:check
+```
+
+Attendu : PASS. Sinon `bun run format`.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add .claude/rules/loading-ui.md
+git commit -m "docs(rules): généraliser l'interdiction de brancher le rendu sur la session cliente"
+```
+
+---
+
+## Task 6 : Validation complète
+
+- [ ] **Step 1 : Suite complète + gates**
+
+```bash
+bun run check
+bun run test
+```
+
+Attendu : `check` PASS (prettier + tsc + eslint `--max-warnings 0`) ; suite frontend entièrement verte.
+
+- [ ] **Step 2 : Couverture**
+
+```bash
+bun run test:coverage
+```
+
+Attendu : les 4 seuils restent ≥ 80 %. `components/marketing-header/**` et `components/shared/theme-toggle.tsx` sont exclus de la couverture (`vitest.config.ts`) ; `hooks/use-mounted.ts` y entre et est couvert par la tâche 2.
+
+- [ ] **Step 3 : Tests d'intégration**
+
+```bash
+bun run test:integration
+```
+
+Attendu : PASS. Aucun DAL n'est modifié, c'est un contrôle de non-régression sur `getAccessStatus` / `getCurrentSession`.
+
+- [ ] **Step 4 : Vérification navigateur (à faire par l'utilisateur)**
+
+Le serveur de dev n'est **jamais** lancé par l'agent. Demander à l'utilisateur de lancer `bun dev` et de donner le port, puis vérifier, **connecté** :
+
+1. `/tarifs` — le bandeau « Vos accès actuels » s'affiche si un accès est actif ; aucune erreur d'hydratation en console.
+2. `/tarifs` — un clic sur « Acheter » ouvre le checkout **dès le premier clic**, sans clic mort.
+3. `/` puis `/domaines` (pages ISR) — l'avatar apparaît dans le header, aucune erreur d'hydratation en console.
+4. Déconnecté sur `/tarifs` — le clic « Acheter » redirige vers `/inscription`.
+
+- [ ] **Step 5 : Marquer les issues Sentry**
+
+Après déploiement seulement :
+
+```bash
+sentry issue resolve NOMAQBANQ-5
+sentry issue resolve NOMAQBANQ-1E
+```
+
+Sentry rouvre automatiquement une issue résolue si l'erreur réapparaît sur une release postérieure. **C'est le seul verdict qui compte** — les trois tentatives précédentes (#127, #130, #133) passaient leurs tests aussi. Surveiller deux semaines.
+
+Si `-5` se rouvre sur une page marketing **autre** que `/tarifs`, c'est le header qui était en cause et la garde a été contournée : le noter dans l'issue plutôt que de deviner.
+
+`NOMAQBANQ-1D` reste ouverte — hors périmètre, voir la section _Hors périmètre_ de la spec.
+
+---
+
+## Ce que ce plan ne fait pas
+
+- **`NOMAQBANQ-1D`** (`Unknown unit of work tag (9227)`) : une occurrence, `handled: yes`, pas de duplication React côté build. Lead conservé dans la spec.
+- **Les cinq autres consommateurs de `useCurrentUser`** (`nav-secondary`, `onboarding-guard`, `onboarding-form`, `profile-personal-info`, `avatar-uploader`) : tous en zone `(dashboard)`, dont le layout garde déjà la session côté serveur. Écarté explicitement de cette itération.
+- **Un test d'architecture interdisant `useCurrentUser` dans un composant rendu côté serveur** : écarté avec le balayage complet. À reconsidérer si `-5` se rouvre.
+- **`Sentry.setUser`** : absent du dépôt, `user.id` toujours nul. Angle mort d'observabilité noté, non traité.

--- a/docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md
+++ b/docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md
@@ -16,15 +16,28 @@
 
 ## Pourquoi c'est un vrai bug (à garder en tête pendant l'exécution)
 
-`node_modules/better-auth/dist/client/react/react-store.mjs:41` :
+La session Better Auth n'est **jamais** pré-remplie au premier rendu client :
+`session-atom.mjs:29-35` naît à `{ data: null, isPending: true }` et seul
+`onMount` → `setTimeout(…, 0)` → aller-retour réseau la peuple. Elle n'arrive
+donc pas AVANT l'hydratation — elle arrive **PENDANT**, quand l'hydratation dure
+assez longtemps. Sur l'appareil de l'incident (Android 10 d'entrée de gamme,
+~25 scripts dont un de 560 Ko), le replay montre le DOM servi en branche
+déconnectée à −826 ms, l'erreur à 0, et la régénération à +246 ms avec les
+initiales d'avatar et le bandeau d'accès. Le store a changé entre deux frames
+d'hydratation.
 
-```js
-return useSyncExternalStore(subscribe, get, get)
-```
+C'est pour ça que le défaut ne se reproduit sur aucune machine de développement :
+le levier n'est pas l'état de la session, c'est la **durée de l'hydratation**.
 
-Le 3ᵉ argument est `getServerSnapshot` — celui que React utilise pour le **rendu d'hydratation**. Better Auth y passe `get`, la même fonction que le snapshot client : elle renvoie l'état courant du store, pas une valeur neutre. Si la session est déjà résolue côté client à l'hydratation, le rendu d'hydratation voit un utilisateur là où le HTML serveur n'en avait aucun → deux arbres DOM différents → `throwOnHydrationMismatch`.
+**Deux corollaires pour les tests.**
 
-**Corollaire pour les tests :** un `render()` de Testing Library est un rendu **client**, il passe par `getSnapshot`. Il ne peut donc PAS constater le comportement d'hydratation. Le seul test honnête pour la garde du header est un `renderToString` de `react-dom/server`, qui emprunte `getServerSnapshot`.
+1. Un `render()` de Testing Library est un rendu client déjà monté : il ne
+   traverse jamais la fenêtre d'hydratation. Il ne peut rien prouver ici.
+2. Un test qui rend avec un mock figé ne prouve rien non plus — c'est le défaut
+   de la première version de ce plan, relevé en revue. Le seul test qui exerce
+   l'invariant fait **changer la session entre la génération du HTML serveur et
+   l'hydratation**, puis vérifie que React n'a rien à récupérer. C'est ce que
+   fait la tâche 4.
 
 ## Structure des fichiers
 
@@ -192,7 +205,7 @@ describe("PricingGrid", () => {
 - [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
 
 ```bash
-bun run test -- tests/components/payments/PricingGrid.test.tsx
+bunx vitest run --project frontend tests/components/payments/PricingGrid.test.tsx
 ```
 
 Attendu : ÉCHEC. `PricingGrid` n'accepte pas encore la prop `isAuthenticated` (erreur TypeScript / prop ignorée), le bandeau ne se rend pas et le clic ne déclenche rien (le `if (isAuthLoading) return` sort tôt, `isPending` valant `true` sans session résolue).
@@ -241,6 +254,8 @@ Simplifier `handlePurchase` :
 ```
 
 Le reste du composant (bandeau ligne 120, grille, onglets) est inchangé : `isAuthenticated` est désormais une prop.
+
+> **Conséquence assumée, relevée en revue.** La prop est figée au rendu serveur, alors que le header continue de suivre la session en direct (Better Auth rafraîchit au focus de l'onglet et entre onglets). Un utilisateur dont la session expire pendant qu'il lit la page verra donc un header repassé en « Connexion » tandis que la grille le croit toujours authentifié. Un clic « Acheter » dans cet état atteint `createStripeCheckout`, dont le garde `requireSession()` (`lib/auth-guards.ts:6-10`) redirige vers `/connexion` — comportement correct, et strictement meilleur que l'actuel, où le même clic ne produit **rien**. On ne rajoute pas de synchronisation client pour ça : ce serait réintroduire la dépendance qu'on est en train de retirer.
 
 - [ ] **Step 4 : Câbler la prop depuis le Server Component**
 
@@ -312,7 +327,7 @@ Le reste du composant (bandeau ligne 120, grille, onglets) est inchangé : `isAu
 - [ ] **Step 5 : Relancer le test — il doit passer**
 
 ```bash
-bun run test -- tests/components/payments/PricingGrid.test.tsx
+bunx vitest run --project frontend tests/components/payments/PricingGrid.test.tsx
 ```
 
 Attendu : 4 tests PASS.
@@ -368,7 +383,7 @@ describe("useMounted", () => {
 - [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
 
 ```bash
-bun run test -- tests/hooks/useMounted.test.tsx
+bunx vitest run --project frontend tests/hooks/useMounted.test.tsx
 ```
 
 Attendu : ÉCHEC — `Cannot find module '@/hooks/use-mounted'`.
@@ -404,7 +419,7 @@ export const useMounted = () =>
 - [ ] **Step 4 : Relancer le test — il doit passer**
 
 ```bash
-bun run test -- tests/hooks/useMounted.test.tsx
+bunx vitest run --project frontend tests/hooks/useMounted.test.tsx
 ```
 
 Attendu : 2 tests PASS.
@@ -446,7 +461,7 @@ Le reste du fichier (placeholder `if (!mounted)`, dropdown) est inchangé.
 
 ```bash
 bun run check
-bun run test -- tests/hooks/useMounted.test.tsx
+bunx vitest run --project frontend tests/hooks/useMounted.test.tsx
 git add hooks/use-mounted.ts tests/hooks/useMounted.test.tsx components/shared/theme-toggle.tsx
 git commit -m "refactor: extraire la garde d'hydratation useMounted"
 ```
@@ -506,11 +521,14 @@ git commit -m "test: ajouter motion.header au mock motion"
 
 - [ ] **Step 1 : Écrire le test qui échoue**
 
-Créer `tests/components/MarketingHeader.test.tsx`. Le test mocke `useCurrentUser` pour renvoyer un **utilisateur connecté**, puis constate que le rendu serveur/hydratation affiche quand même la branche déconnectée — c'est exactement l'invariant qu'on veut verrouiller.
+Créer `tests/components/MarketingHeader.test.tsx`.
+
+**Ce test rejoue le scénario de l'incident**, il ne se contente pas d'un mock figé : le HTML serveur est produit **déconnecté**, puis la session bascule sur **connectée**, et seulement ensuite React hydrate. C'est exactement la fenêtre où le store se résout dans le replay. Sans la garde, `hydrateRoot` signale une récupération via `onRecoverableError` ; avec elle, l'hydratation est propre.
 
 ```tsx
-import { render, screen } from "@testing-library/react"
+import { act } from "@testing-library/react"
 import type { ReactNode } from "react"
+import { hydrateRoot } from "react-dom/client"
 import { renderToString } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
 import { MarketingHeader } from "@/components/marketing-header"
@@ -550,6 +568,15 @@ vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: vi.fn(),
 }))
 
+type Session = ReturnType<typeof useCurrentUser>
+
+const deconnecte = {
+  currentUser: null,
+  isLoading: true,
+  isAuthenticated: false,
+  refetch: vi.fn(),
+} as unknown as Session
+
 const connecte = {
   currentUser: {
     name: "Awa Diallo",
@@ -559,50 +586,73 @@ const connecte = {
   isLoading: false,
   isAuthenticated: true,
   refetch: vi.fn(),
-}
+} as unknown as Session
 
 describe("MarketingHeader", () => {
-  it("rend la branche déconnectée à l'hydratation, même avec une session résolue", () => {
-    vi.mocked(useCurrentUser).mockReturnValue(
-      connecte as ReturnType<typeof useCurrentUser>,
-    )
-
+  it("hydrate proprement quand la session se résout entre le HTML serveur et l'hydratation", async () => {
+    // 1. HTML serveur : aucune session résolue côté serveur.
+    vi.mocked(useCurrentUser).mockReturnValue(deconnecte)
     const html = renderToString(<MarketingHeader />)
-
     expect(html).toContain("Connexion")
-    expect(html).toContain("Inscription")
-    expect(html).not.toContain("Awa Diallo")
+
+    // 2. La session arrive AVANT qu'on hydrate — la fenêtre de l'incident.
+    vi.mocked(useCurrentUser).mockReturnValue(connecte)
+
+    const container = document.createElement("div")
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const recoverable: unknown[] = []
+    await act(async () => {
+      hydrateRoot(container, <MarketingHeader />, {
+        onRecoverableError: (err) => recoverable.push(err),
+      })
+    })
+
+    // 3. Sans la garde, React signale ici un mismatch d'hydratation.
+    expect(recoverable).toEqual([])
   })
 
-  it("affiche l'utilisateur une fois monté côté client", () => {
-    vi.mocked(useCurrentUser).mockReturnValue(
-      connecte as ReturnType<typeof useCurrentUser>,
-    )
+  it("affiche l'utilisateur une fois l'hydratation terminée", async () => {
+    vi.mocked(useCurrentUser).mockReturnValue(deconnecte)
+    const html = renderToString(<MarketingHeader />)
 
-    render(<MarketingHeader />)
+    vi.mocked(useCurrentUser).mockReturnValue(connecte)
+    const container = document.createElement("div")
+    container.innerHTML = html
+    document.body.appendChild(container)
 
-    expect(screen.queryByRole("link", { name: "Connexion" })).not.toBeInTheDocument()
+    await act(async () => {
+      hydrateRoot(container, <MarketingHeader />)
+    })
+
+    expect(container.textContent).toContain("Awa Diallo")
+    expect(container.textContent).not.toContain("Connexion")
   })
 })
 ```
 
+> **Pourquoi ce test et pas un `renderToString` avec un mock figé.** La revue adversariale a montré que la première version passait au vert que la garde existe ou non : elle mockait la session à une valeur constante, donc serveur et client rendaient forcément la même chose. Ici la valeur **change** entre les deux rendus — c'est le seul montage qui distingue un composant gardé d'un composant nu.
+
 - [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
 
 ```bash
-bun run test -- tests/components/MarketingHeader.test.tsx
+bunx vitest run --project frontend tests/components/MarketingHeader.test.tsx
 ```
 
-Attendu : ÉCHEC sur le premier test — sans la garde, `renderToString` rend déjà la branche connectée (le mock renvoie un utilisateur), donc `Connexion` est absent et `Awa Diallo` présent.
+Attendu : ÉCHEC du premier test — sans la garde, l'hydratation trouve « Connexion » dans le DOM alors que le composant rend l'avatar, React récupère et `onRecoverableError` reçoit une erreur d'hydratation. `recoverable` n'est donc pas vide.
 
 - [ ] **Step 3 : Poser la garde**
 
 `components/marketing-header/index.tsx` :
 
 ```diff
- import { useCurrentUser } from "@/hooks/useCurrentUser"
 +import { useMounted } from "@/hooks/use-mounted"
+ import { useCurrentUser } from "@/hooks/useCurrentUser"
  import { authClient } from "@/lib/auth-client"
 ```
+
+L'ordre compte : `prettier` trie le groupe `@/` et `use-mounted` précède `useCurrentUser` (`-` avant `C`). L'inverse fait échouer `bun run check`.
 
 ```diff
    const { isVisible, isScrolled } = useHeaderScroll()
@@ -633,7 +683,7 @@ Passage au menu mobile (lignes 247-248) :
 - [ ] **Step 4 : Relancer le test — il doit passer**
 
 ```bash
-bun run test -- tests/components/MarketingHeader.test.tsx
+bunx vitest run --project frontend tests/components/MarketingHeader.test.tsx
 ```
 
 Attendu : 2 tests PASS.
@@ -642,7 +692,7 @@ Attendu : 2 tests PASS.
 
 Remplacer temporairement `showUser` par `isAuthenticated` à la ligne 147 et relancer.
 
-Attendu : le premier test ÉCHOUE. Si les deux passent encore, le test ne teste pas la garde. Puis annuler cette modification temporaire.
+Attendu : le premier test ÉCHOUE — `recoverable` contient une erreur d'hydratation. Si les deux passent encore, le test ne teste pas la garde ; ne pas continuer avant de l'avoir corrigé. Puis annuler cette modification temporaire.
 
 - [ ] **Step 6 : Gate + commit**
 
@@ -725,7 +775,17 @@ Attendu : `check` PASS (prettier + tsc + eslint `--max-warnings 0`) ; suite fron
 bun run test:coverage
 ```
 
-Attendu : les 4 seuils restent ≥ 80 %. `components/marketing-header/**` et `components/shared/theme-toggle.tsx` sont exclus de la couverture (`vitest.config.ts`) ; `hooks/use-mounted.ts` y entre et est couvert par la tâche 2.
+Attendu : les 4 seuils restent ≥ 80 %.
+
+**La couverture ne mesure rien de ce correctif, et il faut le savoir.** `coverage.include` (`vitest.config.ts`) ne liste que `lib/**`, `hooks/**`, `components/**`, `schemas/**`, `email/**` — et `components/marketing-header/**` comme `components/shared/theme-toggle.tsx` sont explicitement exclus. Sur les trois fichiers corrigés :
+
+| Fichier | Mesuré ? |
+| --- | --- |
+| `app/(marketing)/tarifs/_components/pricing-grid.tsx` | non — `app/**` n'est pas dans `include` |
+| `components/marketing-header/index.tsx` | non — exclu |
+| `hooks/use-mounted.ts` | oui |
+
+Un seuil qui reste vert ne dit donc **rien** sur ce travail. Ce sont les tests des tâches 1, 2 et 4 et leurs contrôles de discriminance qui valent, pas le pourcentage. Ne pas élargir `coverage.include` dans cette itération : ça ferait bouger la barre pour des raisons sans rapport avec le correctif.
 
 - [ ] **Step 3 : Tests d'intégration**
 

--- a/docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md
+++ b/docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md
@@ -777,15 +777,21 @@ bun run test:coverage
 
 Attendu : les 4 seuils restent ≥ 80 %.
 
-**La couverture ne mesure rien de ce correctif, et il faut le savoir.** `coverage.include` (`vitest.config.ts`) ne liste que `lib/**`, `hooks/**`, `components/**`, `schemas/**`, `email/**` — et `components/marketing-header/**` comme `components/shared/theme-toggle.tsx` sont explicitement exclus. Sur les trois fichiers corrigés :
+**Attention au piège de couverture, mesuré pendant l'exécution.** `coverage.include` ne sert PAS à filtrer les fichiers mesurés : il ajoute au rapport les fichiers **jamais exécutés**. Un fichier exécuté par un test entre dans le rapport dès lors qu'aucune règle d'`exclude` ne le vise — même s'il ne correspond à aucune entrée d'`include`.
+
+Conséquence concrète : écrire `tests/components/payments/PricingGrid.test.tsx` fait **entrer** `app/(marketing)/tarifs/_components/pricing-grid.tsx` dans la couverture, alors qu'`app/**` n'est dans aucun glob d'`include`. Mesuré : le fichier arrive à 59,45 % de branches et fait passer l'agrégat de **80,36 % → 79,92 %**, sous le seuil, alors que la base était verte. Le correctif casse donc la CI si on s'arrête aux 4 tests initiaux.
+
+Sur les trois fichiers touchés :
 
 | Fichier | Mesuré ? |
 | --- | --- |
-| `app/(marketing)/tarifs/_components/pricing-grid.tsx` | non — `app/**` n'est pas dans `include` |
-| `components/marketing-header/index.tsx` | non — exclu |
+| `app/(marketing)/tarifs/_components/pricing-grid.tsx` | **oui, dès qu'un test le charge** |
+| `components/marketing-header/index.tsx` | non — `components/marketing-header/**` est dans `exclude` |
 | `hooks/use-mounted.ts` | oui |
 
-Un seuil qui reste vert ne dit donc **rien** sur ce travail. Ce sont les tests des tâches 1, 2 et 4 et leurs contrôles de discriminance qui valent, pas le pourcentage. Ne pas élargir `coverage.include` dans cette itération : ça ferait bouger la barre pour des raisons sans rapport avec le correctif.
+La tâche 1 doit donc couvrir aussi les branches d'erreur du parcours d'achat (erreur métier renvoyée par l'action, `navigator.onLine` faux vs vrai), l'état vide, la mise en avant du combo et le filtre par type d'accès — sans quoi le seuil tombe. Après ces tests : `pricing-grid.tsx` à 89,18 % de branches, agrégat à **80,54 %**, au-dessus de la base.
+
+Ne pas « régler » ça en ajoutant `app/**` à `coverage.exclude` : ce serait masquer un fichier réellement exécuté par les tests, exactement le travers que la campagne vitest a corrigé.
 
 - [ ] **Step 3 : Tests d'intégration**
 

--- a/docs/superpowers/reviews/2026-08-12-revue-design-hydratation-session.md
+++ b/docs/superpowers/reviews/2026-08-12-revue-design-hydratation-session.md
@@ -1,0 +1,552 @@
+# Revue adversariale de conception — Hydratation : session cliente sur `/tarifs` et header
+
+## 1. En-tête
+
+- **Date** : 2026-08-12
+- **Branche** : `fix/hydratation-session-tarifs-header` (2 commits de docs, `git status` propre, aucun code modifié)
+- **Périmètre relu**
+  - Spec : `docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md`
+  - Plan : `docs/superpowers/plans/2026-08-12-hydratation-session-tarifs-header.md`
+  - Code réel confronté : `app/(marketing)/tarifs/page.tsx`, `.../_components/{tarifs-page-client,pricing-grid,pricing-header}.tsx`,
+    `components/marketing-header/{index,mobile-menu,use-header-scroll}.tsx`, `components/shared/theme-toggle.tsx`,
+    `components/shared/user-avatar.tsx`, `components/shared/payments/{pricing-card,access-badge}.tsx`,
+    `components/shared/{marketing-shell,footer}.tsx`, `app/(marketing)/layout.tsx`, `app/layout.tsx`,
+    `features/payments/{dal,actions}.ts`, `lib/{dal,auth-guards,auth-client,format}.ts`, `hooks/useCurrentUser.ts`,
+    `tests/helpers/motion-mock.tsx`, `vitest.config.ts`, `prettier.config.mjs`, `package.json`
+  - Bibliothèques lues dans `node_modules` : `better-auth@1.6.25` (`client/react/{index,react-store}.mjs`,
+    `client/{config,session-atom,session-refresh}.mjs`, `client/plugins/index.mjs`),
+    `react-dom@19.2.8` (`cjs/react-dom-client.development.js`, `server.browser.js`)
+  - Règles projet : `AGENTS.md`, `.claude/rules/{loading-ui,data-layer,payments,seo}.md`
+- **Méthode** : lecture seule, hostile. Chaque constat est prouvé contre l'arbre courant avec `fichier:ligne` et la
+  commande rejouable. Chaque défaut suspecté a subi une tentative de réfutation ; les morts sont consignés en §4.
+- **Gate** : `bun run check` → **exit code 0** (prettier + `tsc --noEmit` + `eslint --max-warnings 0`). La base est verte
+  avant implémentation.
+
+---
+
+## 2. Tableau des constats
+
+| #   | Sév | fichier:ligne                                                          | problème                                                                                                                        | régression ? |
+| --- | --- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| 1   | 🔴  | `node_modules/better-auth/dist/client/session-atom.mjs:26-31,127-133`   | La cause racine décrite est **irréalisable** : l'atome session vaut toujours `{data:null,isPending:true}` au rendu d'hydratation. Le mismatch visé ne peut pas se produire ; la garde `mounted` du header est un no-op prouvé. | NON          |
+| 2   | 🔴  | spec §« Cause », plan §« Pourquoi c'est un vrai bug »                   | La preuve décisive (diff serveur/client attaché à l'exception React de `NOMAQBANQ-1E`) existe encore et n'a pas été consultée. Le plan conclut par élimination. | N/A          |
+| 3   | 🟠  | `lib/format.ts:31-53` · `components/shared/payments/pricing-card.tsx:207` | Candidat alternatif jamais inventorié : `Intl.NumberFormat("fr-CA", {style:"currency"})` rendu au SSR sur chaque carte. Écart d'espace insécable entre l'ICU de Node et celui du navigateur = mismatch invisible, propre à `/tarifs`. | NON (préexistant) |
+| 4   | 🟠  | `node_modules/better-auth/dist/client/session-refresh.mjs:12,50-61`     | Geler `isAuthenticated` au SSR supprime le rafraîchissement au focus et la synchro inter-onglets : header (avatar) et grille (« non connecté ») divergent sur la même page. | **OUI**      |
+| 5   | 🟠  | `vitest.config.ts:39-45`                                                | `app/**` n'est pas dans `coverage.include` : le correctif principal (`pricing-grid.tsx`) n'est pas mesuré non plus. L'affirmation de Task 6 Step 2 est incomplète. | NON          |
+| 6   | 🟡  | plan Task 4 Step 3                                                      | Ordre d'import faux : `@/hooks/use-mounted` doit précéder `@/hooks/useCurrentUser` → `bun run check` échoue au Step 6.            | NON          |
+| 7   | 🟡  | plan Task 1 S2/S5, Task 2 S2/S4, Task 4 S2/S4                           | `bun run test -- <fichier>` ne filtre pas (1287 tests au lieu de 19). Les étapes « Attendu : 2 tests PASS » sont invérifiables.  | NON          |
+| 8   | 🟡  | `app/(marketing)/tarifs/_components/pricing-grid.tsx:45`                | `await` d'une Server Action sans `callAction` : le plan réécrit `handlePurchase` sans corriger le trou deploy-skew imposé par `.claude/rules/data-layer.md`. | NON (préexistant) |
+| 9   | ℹ️  | plan Task 4 Step 1, test `MarketingHeader`                              | `expect(html).not.toContain("Awa Diallo")` est vrai par construction, garde ou pas : le nom n'est jamais rendu au SSR.            | NON          |
+
+---
+
+## 3. Détail par constat
+
+### 🔴 #1 — Le store Better Auth est *toujours* en attente au rendu d'hydratation : le mismatch décrit ne peut pas se produire
+
+**Code**
+
+- `node_modules/better-auth/dist/client/session-atom.mjs:26-31` — l'atome est créé à
+  `{ data: null, error: null, isPending: true, isRefetching: false, refetch }`.
+- `session-atom.mjs:127-133` — `onMount(session, () => { … if (!isServer()) timeoutId = setTimeout(() => { fetchSession() }, 0) … })`.
+  Le seul chemin qui peuple l'atome est un `setTimeout(…, 0)` **suivi d'un aller-retour réseau** vers `/get-session`.
+- `client/react/react-store.mjs:28` — `const snapshotRef = useRef(store.get())` : évalué **pendant le rendu**, donc
+  pendant le rendu d'hydratation.
+- `react-store.mjs:30-39` — `subscribe` (donc le `listen()` qui déclenche `onMount`) est passé à `useSyncExternalStore`,
+  que React exécute dans un **effet passif, après le commit d'hydratation**
+  (`react-dom/cjs/react-dom-client.development.js:8143-8146` : `mountEffect(subscribeToStore.bind(…))`).
+- `client/config.mjs:54-90` — l'atome `session` n'est jamais souscrit à l'initialisation ; `$store.listen` (l.86-87) est
+  un utilitaire offert aux plugins, et `client/plugins/index.mjs` ne contient ni `$store`, ni `listen(`, ni `getActions`.
+
+**Pourquoi c'est un vrai défaut**
+
+La spec pose comme prémisse : « si la session est **déjà résolue** côté client au moment où React hydrate (cache cookie
+Better Auth) ». Cette prémisse est fausse pour la version installée. Il n'existe **aucune** lecture synchrone de cookie
+ou de `localStorage` qui amorcerait le store : au premier rendu client, l'atome est neuf et la requête n'a même pas été
+lancée. Donc au rendu d'hydratation de `/tarifs` :
+
+- `useCurrentUser()` → `isAuthenticated = false`, `isLoading = true` — **identique au SSR** ;
+- `pricing-grid.tsx:120` (`isAuthenticated && accessStatus && …`) → bandeau absent des deux côtés ;
+- `marketing-header/index.tsx:147` (`isAuthenticated && currentUser`) → branche déconnectée des deux côtés.
+
+Le mécanisme `getServerSnapshot === get` (`react-store.mjs:41`) est réellement présent et correctement décrit — mais il
+est **inatteignable** ici, parce que la valeur qu'il renvoie est justement la valeur neutre.
+
+Corollaire dur sur la tâche 4 : `showUser = useMounted() && isAuthenticated` est **algébriquement équivalent à
+`isAuthenticated`**. `useMounted()` ne vaut `false` que pendant un rendu d'hydratation, et pendant un rendu
+d'hydratation `isAuthenticated` vaut déjà nécessairement `false`. La garde ne peut donc jamais changer le balisage
+produit. Le test de discriminance du plan (Task 4 Step 5) ne passera au vert que parce que le test **mocke**
+`useCurrentUser` pour renvoyer un utilisateur — situation qui ne se produit pas en production.
+
+**Échappatoire examinée et écartée** : une hydratation différée (une frontière `<Suspense>` hydratée après qu'une autre
+a déjà déclenché le fetch) ferait lire un store peuplé. Mais `/tarifs` n'a **ni `loading.tsx` ni `<Suspense>`** —
+`find "app/(marketing)" -name loading.tsx` ne renvoie que `evaluation/` et `evaluation/quiz/`, et
+`grep -rn "Suspense" "app/(marketing)" components/shared/marketing-shell.tsx components/marketing-header` ne renvoie
+rien. `MarketingHeader` (layout) et `PricingGrid` (page) hydratent et committent dans la même passe.
+
+**Régression ?** NON — le correctif n'abîme rien de ce côté. Mais il **ne corrige pas** `NOMAQBANQ-5` / `-1E`.
+
+**Comment je l'ai prouvé**
+
+```bash
+cat node_modules/better-auth/dist/client/session-atom.mjs        # atom() initial + onMount/setTimeout
+sed -n '50,110p' node_modules/better-auth/dist/client/config.mjs # aucune souscription à `session`
+grep -rn 'localStorage|document.cookie' node_modules/better-auth/dist/client/*.mjs
+#   → seul node_modules/better-auth/dist/client/broadcast-channel.mjs:19 (émission BroadcastChannel, pas une graine)
+grep -rn '\$store|listen\(|getActions' node_modules/better-auth/dist/client/plugins/index.mjs   # → aucun résultat
+find "app/(marketing)" -name loading.tsx                          # → evaluation/ uniquement
+```
+
+**Correctif suggéré**
+
+1. Ne pas présenter ce plan comme le correctif de `NOMAQBANQ-5`. Reprendre le diagnostic (voir #2 et #3).
+2. Garder la tâche 1 (prop serveur) : elle reste un vrai gain (voir plus bas), mais sous un autre motif — supprimer le
+   clic mort et le saut visuel du bandeau après hydratation, pas « corriger un mismatch ».
+3. Trancher la tâche 4 : soit l'assumer comme durcissement défensif contre une future version de Better Auth qui
+   amorcerait le store — et l'écrire ainsi dans le commit ET dans le test — soit la retirer. Telle qu'écrite, elle
+   affirme corriger quelque chose qu'elle ne corrige pas.
+
+---
+
+### 🔴 #2 — La preuve décisive existe et n'a pas été lue
+
+**Code / données**
+
+- Spec l.14-22 : `NOMAQBANQ-1E` est « la première fois que l'exception React elle-même est remontée, avec sa pile
+  (`throwOnHydrationMismatch`) », et le replay `fae19f5b…` était encore en rétention le 2026-08-12.
+- Spec l.115-119 : l'auteur reconnaît lui-même que le second point n'est « pas prouvé en production ».
+- Spec l.91-95 puis §« Vérification en production » : la conclusion vient d'un balayage de l'arbre `/tarifs`, pas de
+  l'événement.
+
+**Pourquoi c'est un vrai défaut**
+
+React 19 attache à l'erreur d'hydratation un diff (texte serveur attendu / texte client obtenu) et une pile de
+composants. `.claude/rules/loading-ui.md` atteste que l'équipe sait déjà exploiter cette « capture serveur/client de
+Sentry » — c'est exactement comme ça que la cause du 2026-07-29 a été établie. Ici on dispose d'un événement diagnostique
+unique et encore consultable, et le plan choisit de raisonner par élimination. Trois tentatives (#127, #130, #133) ont
+déjà échoué sur cette issue ; la quatrième ne devrait pas repartir d'une déduction.
+
+**Régression ?** N/A (défaut de méthode).
+
+**Comment je l'ai prouvé** : lecture de la spec l.14-22 / l.115-119 et de `.claude/rules/loading-ui.md`
+(section « Pas d'état de chargement pour la session »), qui documente la capture serveur/client comme outil de
+diagnostic déjà employé.
+
+**Correctif suggéré** : avant toute ligne de code, ouvrir `NOMAQBANQ-1E` et relever le diff serveur/client + la pile de
+composants. Le nœud fautif y est nommé. Si c'est bien `PricingGrid`, #1 est réfuté et le plan repart tel quel ; sinon on
+évite une quatrième tentative à l'aveugle. Lecture seule côté Sentry — je n'ai muté aucune issue.
+
+---
+
+### 🟠 #3 — Candidat alternatif jamais inventorié : `Intl.NumberFormat` au SSR
+
+**Code**
+
+- `lib/format.ts:31-53` — `formatCurrency` termine par
+  `new Intl.NumberFormat("fr-CA", { style: "currency", currency, minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(amount)`.
+- `components/shared/payments/pricing-card.tsx:207` — `{formatCurrency(product.priceCAD)}`, rendu côté serveur sur
+  **chaque** carte de `/tarifs`.
+- `components/shared/payments/premium-pricing-card.tsx:168,172,188` — trois occurrences de plus sur la même page.
+
+**Pourquoi c'est un vrai défaut**
+
+Node 24.13 / ICU 77.1 produit `300 $` — codepoints `U+0033 U+0030 U+0030 U+00A0 U+0024`. Le séparateur est une
+espace insécable **U+00A0**. Depuis CLDR 42 / ICU 72, plusieurs locales francophones ont basculé ce séparateur vers
+**U+202F** (espace insécable étroite). Un navigateur dont l'ICU diffère de celui de Node rend donc un caractère
+différent — invisible à l'œil, mais un mismatch de nœud texte pour React.
+
+Ce candidat explique tout ce que le diagnostic « session » explique, et davantage :
+
+- il est **spécifique à `/tarifs`** parmi les pages marketing : `grep -rn "formatCurrency" app components --include=*.tsx`
+  ne le trouve nulle part dans `/`, `/domaines`, `/a-propos`, `/evaluation` ni dans le header ou le footer ;
+- il est **spécifique au terminal**, ce qui colle aux données Sentry (3 événements résiduels, tous Chrome Mobile 150 /
+  Android 10, deux IP) — alors qu'un défaut de session frapperait tout le monde ;
+- il **survit** à #127, #130 et #133, qui n'ont touché que le fuseau horaire et les états de chargement ;
+- la règle projet ne protège pas : `.claude/rules/data-layer.md` exige « toujours passer une locale fixe », ce qui
+  neutralise l'écart de locale par défaut mais **pas** l'écart de version ICU entre Node et le navigateur.
+
+Je ne peux pas confirmer le rendu de Chrome Mobile 150 depuis cette session : je le donne comme hypothèse concurrente
+sérieuse et testable, pas comme fait établi.
+
+**Régression ?** NON — préexistant. Mais c'est probablement la vraie cause, et le plan ne la mentionne nulle part.
+
+**Comment je l'ai prouvé**
+
+```bash
+node -e "const s=new Intl.NumberFormat('fr-CA',{style:'currency',currency:'CAD',minimumFractionDigits:0,maximumFractionDigits:2}).format(300);
+console.log(process.versions.icu, JSON.stringify(s), [...s].map(c=>'U+'+c.codePointAt(0).toString(16).toUpperCase().padStart(4,'0')).join(' '))"
+#   77.1 "300 $" U+0033 U+0030 U+0030 U+00A0 U+0024
+grep -rn "formatCurrency" app components --include=*.tsx
+```
+
+**Correctif suggéré**
+
+- Vérification décisive et gratuite : le diff de `NOMAQBANQ-1E` (#2) montrera un écart sur un nœud de prix si c'est ça.
+- Si confirmé : formater les prix **au serveur** (le DAL renvoie déjà `priceCAD`, il peut renvoyer la chaîne) ou
+  remplacer `Intl` par un formatage déterministe maison — c'est la seule façon de rendre le rendu insensible à l'ICU du
+  client. Étendre alors la règle `data-layer.md` : « locale explicite » ne suffit pas, `Intl.*` dans un composant rendu
+  côté serveur est un mismatch en puissance.
+
+---
+
+### 🟠 #4 — Geler `isAuthenticated` au SSR casse le rafraîchissement au focus et la synchro inter-onglets
+
+**Code**
+
+- `node_modules/better-auth/dist/client/session-refresh.mjs:12` — `refetchOnWindowFocus = options.sessionOptions?.refetchOnWindowFocus ?? true` :
+  **activé par défaut**, et `lib/auth-client.ts` ne passe aucune `sessionOptions`.
+- `session-refresh.mjs:50-61` — `setupBroadcast()` (BroadcastChannel inter-onglets) et `setupFocusRefetch()`
+  (`visibilitychange`) déclenchent `fetchSession()`.
+- `session-atom.mjs:135-137` — le manager est initialisé au montage de l'atome, donc dès qu'un composant appelle
+  `useSession()`.
+- Plan Task 1 Step 3 : `pricing-grid.tsx` perd `useCurrentUser()` et lit une prop figée au rendu serveur.
+- Plan Task 4 Step 3 : `marketing-header/index.tsx` **conserve** `useCurrentUser()`.
+
+**Pourquoi c'est un vrai défaut**
+
+Scénario concret et banal : un visiteur ouvre `/tarifs` déconnecté, se connecte dans un second onglet, revient sur le
+premier. Aujourd'hui, le BroadcastChannel + le refetch au focus repeuplent le store : le header affiche l'avatar **et**
+le bouton « Acheter » ouvre le checkout. Après le plan, le header affiche toujours l'avatar (il garde le hook) mais la
+grille lit une prop figée à `false` → le clic « Acheter » déclenche `router.push("/inscription")`
+(`pricing-grid.tsx:38-41`). Deux composants de la même page affirment deux choses contradictoires, et le parcours
+d'achat est le perdant.
+
+Le cas symétrique évoqué par l'auteur (session **morte** entre le SSR et le clic) est en revanche couvert : voir §5 Q4.
+
+**Régression ?** **OUI** — perte d'une mise à jour que le code actuel produit.
+
+**Comment je l'ai prouvé**
+
+```bash
+cat node_modules/better-auth/dist/client/session-refresh.mjs   # refetchOnWindowFocus ?? true, setupBroadcast, setupFocusRefetch
+cat lib/auth-client.ts                                          # aucune sessionOptions → défauts actifs
+```
+
+**Correctif suggéré** : garder la prop serveur comme **valeur initiale déterministe** et laisser la session cliente la
+relever une fois montée, par exemple `const authed = isAuthenticated || (mounted && clientAuthenticated)`. On conserve
+le premier rendu déterministe (objectif du plan) sans perdre la fraîcheur. À défaut, accepter la régression
+explicitement et l'écrire dans la spec — mais alors le header devrait recevoir le même traitement, sinon l'incohérence
+inter-composants reste.
+
+---
+
+### 🟠 #5 — La couverture ne mesure pas le correctif principal, et le plan ne le dit qu'à moitié
+
+**Code**
+
+- `vitest.config.ts:39-45` — `coverage.include = ["lib/**/*.ts", "hooks/**/*.ts", "components/**/*.tsx", "schemas/**/*.ts", "email/**/*.{ts,tsx}"]`.
+  **`app/**` est absent de la liste d'inclusion.**
+- `vitest.config.ts:81,83` — `components/shared/theme-toggle.tsx` et `components/marketing-header/**` sont en plus
+  explicitement exclus.
+- Plan Task 6 Step 2 : « `components/marketing-header/**` et `components/shared/theme-toggle.tsx` sont exclus de la
+  couverture ; `hooks/use-mounted.ts` y entre et est couvert par la tâche 2. »
+
+**Pourquoi c'est un vrai défaut**
+
+L'affirmation est vraie mais incomplète, et l'omission porte sur le morceau qui compte : `PricingGrid` vit dans
+`app/(marketing)/tarifs/_components/`, donc **il n'est pas mesuré non plus**. Sur les trois fichiers de production
+touchés, le seul qui entre dans la métrique est `hooks/use-mounted.ts` — trois lignes triviales. Le pourcentage de
+couverture montera (ou restera) sans que rien du code corrigé ne soit mesuré. Ce n'est pas une tricherie du plan, mais
+c'est exactement le motif « couverture qui monte sans mesurer le correctif » que la campagne vitest-audit a voulu
+éliminer. La valeur des tests `PricingGrid` reste réelle — elle est juste invisible à la métrique, et le plan devrait le
+dire pour que personne ne lise le seuil vert comme une garantie.
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé** : lecture de `vitest.config.ts:37-121` ; `app/**` n'apparaît que dans `coverage.exclude`
+(l.51-54), jamais dans `include`.
+
+**Correctif suggéré** : corriger la phrase de Task 6 Step 2 (« aucun des deux fichiers de composant modifiés n'est
+mesuré ; seul `hooks/use-mounted.ts` entre dans la métrique »). Décision d'ajouter `app/**/_components/**` à
+`coverage.include` : hors périmètre de cette itération, à proposer séparément.
+
+---
+
+### 🟡 #6 — Ordre d'import : `bun run check` échouera au Step 6 de la tâche 4
+
+**Code**
+
+Plan Task 4 Step 3 :
+
+```diff
+ import { useCurrentUser } from "@/hooks/useCurrentUser"
++import { useMounted } from "@/hooks/use-mounted"
+```
+
+`prettier.config.mjs` charge `@trivago/prettier-plugin-sort-imports` avec
+`importOrder: ["^(node:(.*)$)|^([a-zA-Z0-9].*)$", "^@/(.*)$", "^[./]"]`.
+
+**Pourquoi c'est un vrai défaut**
+
+Dans le groupe `^@/(.*)$`, le tri compare les chaînes : `use-` (`U+002D`) précède `useC` (`U+0043`). L'ordre prescrit
+par le plan est donc inversé, et `prettier --check` — premier maillon de `bun run check` — échoue. Le plan s'arrête
+alors juste avant son commit. Détail, mais qui bloque une étape nommée dans le plan.
+
+Note : les deux autres insertions d'import du plan sont correctes — `@/hooks/use-mounted` après
+`@/components/ui/dropdown-menu` dans `theme-toggle.tsx` (Task 2 Step 5) et `@/lib/dal` après `@/features/payments/dal`
+dans `page.tsx` (Task 1 Step 4).
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé**
+
+```bash
+printf 'import { useCurrentUser } from "@/hooks/useCurrentUser"\nimport { useMounted } from "@/hooks/use-mounted"\n' \
+  | bunx prettier --stdin-filepath x.tsx
+# → use-mounted ressort en premier
+```
+
+**Correctif suggéré** : intervertir les deux lignes dans le diff du plan.
+
+---
+
+### 🟡 #7 — `bun run test -- <fichier>` ne filtre rien : les étapes TDD du plan sont invérifiables
+
+**Code**
+
+- `package.json` → `"test": "vitest run --project frontend"`.
+- Plan Task 1 Steps 2 & 5, Task 2 Steps 2 & 4, Task 4 Steps 2 & 4 : `bun run test -- tests/…`.
+
+**Pourquoi c'est un vrai défaut**
+
+Le `--` est consommé comme fin d'options ; le chemin n'atteint pas les filtres positionnels de Vitest et la suite
+entière tourne. Les attendus du plan (« ÉCHEC », « 2 tests PASS », « 4 tests PASS ») deviennent illisibles au milieu de
+1287 tests, et la vérification de discriminance — le point que la spec désigne elle-même comme le point dur — perd son
+signal.
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé**
+
+```bash
+bunx vitest list --project frontend -- tests/components/payments/PricingCard.test.tsx | wc -l   # → 1287
+bunx vitest list --project frontend    tests/components/payments/PricingCard.test.tsx | wc -l   # →   19
+```
+
+**Correctif suggéré** : retirer le `--` partout — `bun run test tests/components/payments/PricingGrid.test.tsx`.
+
+---
+
+### 🟡 #8 — `handlePurchase` reste un `await` d'action serveur hors `callAction`
+
+**Code**
+
+- `app/(marketing)/tarifs/_components/pricing-grid.tsx:44-63` — `const res = await createStripeCheckout({…})` dans un
+  `try/catch` maison.
+- `.claude/rules/data-layer.md`, § « Appels client de Server Actions » : « Mutations : `callAction(() => action(x))`
+  (`lib/safe-action.ts`) », avec détection `UnrecognizedActionError` et toast « Recharger » central.
+
+**Pourquoi c'est un vrai défaut**
+
+Le `try/catch` couvre bien le rejet réseau (le code affiche déjà un message hors-ligne), mais pas le **deploy skew** :
+après un déploiement, un onglet resté ouvert appelle une référence d'action périmée et l'utilisateur reçoit
+« Une erreur est survenue. Veuillez réessayer. » — message qui masque le seul remède (recharger), sur un bouton de
+paiement. C'est précisément le cas que `callAction` a été écrit pour couvrir. Le plan réécrit cette fonction (Task 1
+Step 3) et laisse le trou.
+
+**Régression ?** NON — préexistant, mais l'occasion de le fermer est dans le périmètre édité.
+
+**Comment je l'ai prouvé** : lecture de `pricing-grid.tsx:44-63` et de `.claude/rules/data-layer.md`.
+
+**Correctif suggéré** : passer par `callAction(() => createStripeCheckout({…}))` et lire le retour discriminé, en même
+temps que la suppression de la branche `isAuthLoading`. Une ligne, dans une fonction déjà ouverte par le plan.
+
+---
+
+### ℹ️ #9 — Une assertion du test `MarketingHeader` est vraie par construction
+
+**Code**
+
+- Plan Task 4 Step 1 : `expect(html).not.toContain("Awa Diallo")`.
+- `components/marketing-header/index.tsx:167-178` — le nom n'est rendu que dans `DropdownMenuContent`, sous
+  `open={isUserMenuOpen}` qui vaut `false` au premier rendu : Radix ne rend rien.
+- `components/shared/user-avatar.tsx:30` — `alt={name}` est porté par `AvatarImage`, que Radix n'émet qu'une fois
+  l'image chargée — jamais au rendu serveur.
+
+**Pourquoi c'est un vrai défaut** : l'assertion passe avec ou sans la garde. Elle donne l'impression de vérifier
+« aucune donnée utilisateur ne fuit dans le HTML serveur » alors qu'elle ne vérifie rien. Seul
+`expect(html).toContain("Connexion")` discrimine réellement (sans garde, la branche connectée est rendue et
+« Connexion » disparaît, y compris de `MobileMenu` qui est fermé).
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé** : lecture de `index.tsx:147-222`, `mobile-menu.tsx:59-64,204-224` (le `SheetContent` n'est
+monté que si `isOpen`), `user-avatar.tsx:29-34`.
+
+**Correctif suggéré** : supprimer l'assertion, ou la remplacer par une qui porte — par exemple l'absence des initiales
+du fallback (`"AD"`), effectivement rendues par `AvatarFallback` dans la branche connectée.
+
+---
+
+## 4. Faux positifs écartés
+
+| Soupçon                                                                                                  | Preuve qui l'a tué                                                                                                                                                          |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Les ancres de ligne du plan ont bougé                                                                    | Toutes vérifiées exactes : `pricing-grid.tsx:32,36-41,120` · `marketing-header/index.tsx:20,37,147,247-248` · `theme-toggle.tsx:20` · `pricing-card.tsx:285` (« Acheter maintenant ») · `motion-mock.tsx:96` (fin de l'entrée `circle`) · `lib/dal.ts:7` · `features/payments/dal.ts:43-46` · `page.tsx:23-27`. Les chaînes à remplacer existent littéralement. |
+| `mobile-menu.tsx` doit être modifié (fuite de `currentUser` non gardé)                                   | `mobile-menu.tsx:145` : `{isAuthenticated && currentUser ? (…)}`. La branche connectée est intégralement sous la garde. Passer `isAuthenticated={showUser}` suffit — le plan a raison. |
+| `renderToString` est absent du build `browser` de `react-dom`, le test de la tâche 2 ne compilera pas    | `node_modules/react-dom/server.browser.js` : `exports.renderToString = l.renderToString` (build legacy). Disponible par la condition `browser` **comme** par `node`.          |
+| `getCurrentSession()` ajouté au `Promise.all` = deuxième lecture de session en base                       | `lib/dal.ts:7` : `cache(async () => auth.api.getSession(…))`. `getAccessStatus` (`features/payments/dal.ts:43`) appelle la même fonction mémoïsée dans le même scope de requête ; les deux appels concurrents partagent la promesse. Une seule lecture. |
+| Passer `isAuthenticated` en prop bascule des pages ISR en dynamique                                      | Les 4 pages ISR sont `app/(marketing)/{page,domaines/page,a-propos/page,evaluation/page}.tsx` (`revalidate = 3600`). `/tarifs` n'en fait pas partie et est déjà dynamique (`getAccessStatus` → `headers()`). Aucune édition ne touche `app/(marketing)/layout.tsx` ni `marketing-shell.tsx`. |
+| Le libellé du bouton serait « Prolonger l'accès » dans les deux tests de clic                            | `pricing-card.tsx:285` bascule sur `hasAccess = !!currentAccess`. Les tests passent `accessStatus: null` et `{examAccess:null,trainingAccess:null}` → `getCurrentAccess` renvoie `null` → « Acheter maintenant ». La note du plan est juste. |
+| Le `new Date().getFullYear()` du footer est la vraie cause du mismatch                                    | `components/shared/footer.tsx:17` : `const CURRENT_YEAR = getAppZoneYear(Date.now())` au scope module, ancré sur le fuseau applicatif. Pas de recalcul au rendu.              |
+| Le test `PricingGrid` ne mocke pas `@/lib/auth-client` → rejet réseau non géré en happy-dom               | `session-atom.mjs:110-121` : le `fetchSession` est enveloppé d'un `catch (fetchError)` qui range l'erreur dans l'atome. Aucun rejet non géré ne remonte.                       |
+| La garde `mounted` est illusoire sous rendu concurrent / `<Suspense>`                                     | `react-dom/cjs/react-dom-client.development.js:8112-8117` : `mountSyncExternalStore` teste `isHydrating` et emprunte `getServerSnapshot()` pour **tout** fiber hydraté. Voir §5 Q1. |
+| Les décomptes de la spec (« 3 événements », « les cinq autres consommateurs ») sont approximatifs        | `grep -rln useCurrentUser app components hooks` → 7 fichiers + le hook : `pricing-grid` et `marketing-header` (périmètre) + exactement `nav-secondary`, `onboarding-guard`, `onboarding-form`, `profile-personal-info`, `avatar-uploader`. Le compte est exact. Les 4 pages ISR annoncées sont exactement les 4 trouvées. |
+
+---
+
+## 5. Réponses aux questions ouvertes
+
+### Q1 — La garde `mounted` tient-elle vraiment ?
+
+**Oui, techniquement.** `react-dom/cjs/react-dom-client.development.js:8109-8123` :
+
+```js
+function mountSyncExternalStore(subscribe, getSnapshot, getServerSnapshot) {
+  …
+  if (isHydrating) {
+    if (void 0 === getServerSnapshot) throw Error("Missing getServerSnapshot…")
+    var nextSnapshot = getServerSnapshot()
+  } else { nextSnapshot = getSnapshot() … }
+```
+
+`isHydrating` est un drapeau du rendu en cours, pas une propriété de la racine : il est positionné pour **tout** fiber
+que React est en train d'hydrater, y compris à l'intérieur d'une frontière `<Suspense>` hydratée tardivement et sous
+rendu concurrent. Les deux cas où React appelle `getSnapshot()` au premier montage sont (a) un rendu client normal —
+pas d'hydratation, donc pas de HTML serveur à contredire — et (b) un sous-arbre dont React **abandonne** l'hydratation
+pour le rendre côté client : le HTML serveur correspondant est alors jeté, il n'y a rien à faire diverger. Un composant
+qui suspend puis reprend passe par `updateSyncExternalStore` (l.8162-8223), qui compare au snapshot mémorisé — même
+conclusion.
+
+**Mais la garde est sans effet ici**, pour la raison du constat #1 : elle ne peut valoir `false` que pendant un rendu
+d'hydratation, moment où `isAuthenticated` vaut déjà `false` par construction. `useMounted() && isAuthenticated` ≡
+`isAuthenticated`.
+
+### Q2 — Le diagnostic est-il seulement le bon ?
+
+**Non, pas tel qu'il est écrit — et c'est le constat le plus important de cette revue.**
+
+1. Le mécanisme invoqué est **inatteignable** : le store Better Auth est neuf et vide au rendu d'hydratation (constat
+   #1, prouvé dans `session-atom.mjs`, `config.mjs` et `plugins/index.mjs`). Il n'existe aucun « cache cookie » côté
+   client — le `cookieCache` de Better Auth est une optimisation **serveur**, elle n'amorce rien dans le navigateur.
+2. Votre intuition sur le replay est fondée mais ne mène pas là où vous le craigniez. Un `navigation.push` vers
+   `/tarifs` alors qu'on y est déjà s'explique trivialement : `marketing-header/index.tsx:25-31` déclare `/tarifs` dans
+   la nav, et `mobile-menu.tsx:94-111` la rend aussi — l'utilisateur a tapé « Tarifs » en étant sur `/tarifs`. Ce n'est
+   donc pas une preuve de bfcache ni de double montage. En revanche, votre conclusion tient pour une autre raison : une
+   navigation cliente **n'hydrate pas**, donc cette séquence ne peut pas être le déclencheur, et le plan ne l'a jamais
+   expliqué.
+3. **Cause alternative concrète** : `formatCurrency` (constat #3). `Intl.NumberFormat("fr-CA", {style:"currency"})` rend
+   au SSR sur les 4+ cartes de `/tarifs` et nulle part ailleurs dans le marketing ; Node/ICU 77 émet `U+00A0`, un
+   navigateur au CLDR plus récent émet `U+202F`. Invisible, spécifique au terminal, spécifique à `/tarifs`, insensible
+   aux trois correctifs précédents — toutes les signatures observées.
+4. Deuxième piste à ne pas écarter : la mutation DOM tierce déjà connue du dépôt. `instrumentation-client.ts:44-46`
+   filtre les crashs `$RS` attribués à un tiers (traduction, extension, proxy). Un volume de 3 événements en 90 jours,
+   depuis 2 IP, tous sur Chrome Mobile 150 / Android 10, est aussi la signature d'un ou deux utilisateurs dont le
+   navigateur réécrit le DOM (traduction automatique mobile).
+
+**Recommandation** : ouvrir le diff serveur/client de `NOMAQBANQ-1E` avant d'écrire du code. Il nomme le nœud fautif et
+départage en cinq minutes les hypothèses 1, 3 et 4.
+
+### Q3 — `getCurrentSession()` ajouté au `Promise.all` est-il gratuit ?
+
+**Oui, le plan a raison.** `lib/dal.ts:7` enveloppe `getCurrentSession` dans React `cache()`. `getAccessStatus`
+(`features/payments/dal.ts:39-46`) appelle exactement cette fonction mémoïsée quand `userId` est absent — ce qui est le
+cas ici, la page l'appelle sans argument. Les deux appels partent concurremment dans le même `Promise.all`, donc dans le
+même scope de requête React : le second reçoit la promesse déjà mémoïsée. **Une seule** exécution de
+`auth.api.getSession`, donc une seule lecture de session en base par rendu de `/tarifs`. Aucune requête ajoutée.
+
+### Q4 — Session morte entre le SSR et le clic
+
+**Le garde serveur couvre le cas, et on ne perd rien de ce côté.** `createStripeCheckout`
+(`features/payments/actions.ts:331`) commence par `await requireSession()`, qui appelle `redirect("/connexion")`
+(`lib/auth-guards.ts:6-10`) si la session a disparu. L'utilisateur est donc renvoyé vers la connexion — aucun accès
+n'est octroyé à tort, aucune session Stripe n'est créée.
+
+Deux réserves :
+
+- Le message affiché est médiocre. Le `redirect()` d'une Server Action ne renvoie pas de résultat exploitable ; le
+  `if ("error" in res)` de `pricing-grid.tsx:50` reçoit alors un `res` non conforme, l'exception part dans le `catch`
+  et l'utilisateur voit « Une erreur est survenue. Veuillez réessayer. » en même temps qu'il est navigué vers
+  `/connexion`. Désagréable, pas dangereux — et **inchangé** par le plan.
+- L'ancien code ne protégeait pas mieux : `authClient.useSession()` ne détecte pas une session invalidée côté serveur
+  avant son prochain refetch. Il n'y a donc **pas** de régression sur ce scénario-ci.
+
+**En revanche le scénario inverse régresse**, et il est plus fréquent : la session qui *apparaît* pendant que la page est
+ouverte (connexion dans un autre onglet, refetch au focus). Voir constat #4.
+
+### Q5 — `MobileMenu` reçoit `currentUser` non gardé
+
+**Le plan a raison, prouvé.** `components/marketing-header/mobile-menu.tsx:145` :
+`{isAuthenticated && currentUser ? (…) : (…)}`. C'est le **seul** endroit du fichier qui lit `currentUser` : les trois
+usages (`currentUser.name` l.152/161, `currentUser.image` l.153, `currentUser.email` l.164) sont tous à l'intérieur de
+cette branche. Aucun chemin n'affiche de donnée utilisateur avec `isAuthenticated === false`. Passer
+`isAuthenticated={showUser}` en laissant `currentUser` descendre est sûr, et `mobile-menu.tsx` n'a effectivement pas
+besoin d'être modifié.
+
+### Q6 — Le test de couverture est-il honnête ?
+
+**Deux réponses distinctes.**
+
+- **La ligne `getServerSnapshot` est bien atteinte.** `renderToString` (React 19) exige le 3ᵉ argument de
+  `useSyncExternalStore` et l'**appelle** ; la flèche `getServerSnapshot = () => false` de `hooks/use-mounted.ts` est
+  donc réellement exécutée, et v8 la comptera couverte. Le test de la tâche 2 est honnête. Résolution non bloquante :
+  `react-dom/server` expose `renderToString` par la condition `node` comme par `browser`
+  (`node_modules/react-dom/server.browser.js`), le projet happy-dom résoudra dans les deux cas.
+- **Mais la couverture ne mesure pas le correctif.** Voir constat #5 : `app/**` est absent de `coverage.include`
+  (`vitest.config.ts:39-45`), donc `pricing-grid.tsx` n'est pas plus mesuré que
+  `components/marketing-header/**`. Sur trois fichiers de production touchés, **zéro** n'est mesuré ; seul le hook de
+  trois lignes entre dans la métrique. Le seuil restera vert sans rien prouver du correctif. Les tests
+  `PricingGrid` gardent leur valeur — elle est simplement invisible au tableau de bord, et le plan devrait l'écrire au
+  lieu de laisser croire que « ces fichiers sont déjà couverts ».
+
+---
+
+## 6. Verdict
+
+> **Ce plan est-il sûr et complet à implémenter tel quel ? → NON.**
+
+Il est **sûr** (aucune édition ne casse un consommateur, ne touche une frontière d'accès ni ne bascule une page ISR en
+dynamique) et remarquablement précis dans ses ancres — je n'ai trouvé **aucune** édition qui ne s'appliquerait pas. Mais
+il n'est pas **correct sur le fond** : la cause qu'il prétend corriger ne peut pas se produire avec la version de
+Better Auth installée, et sa tâche centrale (la garde du header) est un no-op démontrable. L'implémenter en l'état
+livrerait une quatrième tentative infructueuse sur `NOMAQBANQ-5`, avec la conviction fausse d'avoir prouvé la cause dans
+la source de la bibliothèque.
+
+**Points bloquants** : constat #1 (diagnostic irréalisable) et constat #2 (preuve décisive non consultée). Ils se
+règlent tous les deux en ouvrant le diff serveur/client de `NOMAQBANQ-1E` avant de coder.
+
+### Correctifs priorisés
+
+| Quand                             | Constat | Action                                                                                                                            |
+| --------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Avant de coder (bloquant)**     | #2      | Lire le diff serveur/client et la pile de composants de `NOMAQBANQ-1E`. C'est ce qui décide de tout le reste.                       |
+| **Avant de coder (bloquant)**     | #1      | Rectifier la spec : le store est vide à l'hydratation, le mécanisme décrit est inatteignable. Retirer ou requalifier la tâche 4.     |
+| **Avant de coder**                | #3      | Instruire l'hypothèse `Intl.NumberFormat` — la plus compatible avec les signatures Sentry observées.                                |
+| **Avant de coder**                | #4      | Décider : prop serveur comme valeur initiale relevée par le client, ou régression assumée et écrite. Ne pas la laisser implicite.   |
+| **Pendant l'implémentation**      | #6      | Intervertir les deux imports de la tâche 4 (`use-mounted` avant `useCurrentUser`).                                                  |
+| **Pendant l'implémentation**      | #7      | Retirer le `--` des six commandes `bun run test -- …`.                                                                             |
+| **Pendant l'implémentation**      | #5      | Corriger la phrase de Task 6 Step 2 : aucun composant modifié n'est mesuré.                                                        |
+| **Opportuniste (même fonction)**  | #8      | Passer `createStripeCheckout` par `callAction`.                                                                                    |
+| **Cosmétique**                    | #9      | Retirer ou remplacer `not.toContain("Awa Diallo")`.                                                                                |
+
+**Ce que je garderais du plan, quoi qu'il arrive** : la tâche 1. Descendre `isAuthenticated` du Server Component
+supprime un vrai clic mort (`pricing-grid.tsx:36`) et le saut visuel du bandeau après hydratation, et l'argument de la
+spec contre la dérivation `accessStatus !== null` est juste. Elle mérite simplement un autre motif de commit que
+« corrige l'erreur d'hydratation ».
+
+---
+
+## 7. Confirmations de sécurité opérationnelle
+
+- **Lecture seule** : le seul fichier écrit est ce rapport. Aucun fichier source, spec, plan ou règle modifié —
+  `git status` reste propre hors ce rapport non suivi.
+- **Aucun commit, aucun push, aucune branche créée ou supprimée.**
+- **Base de données** : aucune commande Neon, aucun outil MCP Neon appelé, aucune branche créée ou détruite. Les tests
+  d'intégration (qui provisionnent une branche Neon) n'ont **pas** été lancés.
+- **Secrets** : aucun `.env*` lu ni affiché. Aucun secret dans ce rapport.
+- **Serveurs** : aucun serveur de dev lancé, ni au premier plan ni en arrière-plan. `bun dev` n'a jamais été invoqué.
+- **Sentry** : aucune mutation (`resolve` / `archive` / commentaire). Les issues sont citées d'après la spec ; je n'ai
+  pas non plus lu l'API Sentry dans cette session.
+- **Commandes exécutées** : `bun run check` (gate demandé, exit 0), `git log`/`git status` (lecture),
+  `bunx prettier --stdin-filepath` (aucune écriture), `bunx vitest list` (énumération, aucun test exécuté),
+  `node -e` pour inspecter `Intl` et les métadonnées de paquets, plus des lectures/greps de fichiers.

--- a/docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md
+++ b/docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md
@@ -1,0 +1,238 @@
+# Spec — Hydratation : supprimer le branchement de rendu sur la session cliente
+
+- **Date** : 2026-08-12
+- **Statut** : DESIGN VALIDÉ (en attente de revue adversariale)
+- **Origine** : triage des issues Sentry ouvertes du 2026-08-12. Trois issues
+  ouvertes ; deux nouvelles apparues les 2026-08-10 et 2026-08-11.
+
+## Ce que disent les données Sentry
+
+### Les trois issues ouvertes
+
+| Issue           | Titre                                       | Page                                          | Volume                       | Dernier vu                       |
+| --------------- | ------------------------------------------- | --------------------------------------------- | ---------------------------- | -------------------------------- |
+| `NOMAQBANQ-5`   | `Hydration Error` (type `replay_hydration_error`) | `/tarifs`                                | 115 evts / 21 users depuis 2025-11-26 | 2026-08-11 01:08:49**.746** |
+| `NOMAQBANQ-1E`  | `Hydration failed because the server rendered HTML didn't match the client` | `/tarifs` | 1 evt / 1 user | 2026-08-11 01:08:49**.739** |
+| `NOMAQBANQ-1D`  | `Unknown unit of work tag (9227)`           | `/tableau-de-bord/examen-blanc/:examId/resultats` | 1 evt / 1 user          | 2026-08-10 19:03:57              |
+
+**`-1E` et `-5` sont le même incident**, pas deux : même `replayId`
+(`fae19f5bd6594aa6af37e243808e861a`), même milliseconde. Deux détecteurs
+distincts (le Session Replay et le `onerror` global du SDK) ont vu la même
+erreur. `-1E` est simplement la première fois que l'exception React elle-même
+est remontée, avec sa pile (`throwOnHydrationMismatch`).
+
+**`-1D` n'est pas une erreur d'hydratation** — c'est une invariante interne de
+React (`beginWork` lit un `tag` de fiber aberrant), `handled: yes`. Hors
+périmètre de cette spec (voir _Hors périmètre_).
+
+### Les correctifs précédents ont fonctionné
+
+Trois PR ont visé `NOMAQBANQ-5` : #127 et #130 (ancrage du formatage et des
+branchements horaires sur le fuseau du Québec), #133 (refonte des états de
+chargement). Sur les 33 événements des 90 derniers jours :
+
+- **avant le 2026-07-28** : `/tableau-de-bord` en majorité, plus
+  `/tableau-de-bord/examen-blanc` et `/admin`, sur desktop et mobile, toutes
+  familles de navigateurs ;
+- **après** : **3 événements**, tous sur `/tarifs`, depuis deux IP distinctes
+  (Oakville ×2, Ottawa ×1), toutes Chrome Mobile 150 / Android 10.
+
+Le dashboard est guéri. Le résidu est `/tarifs`.
+
+### Le visiteur touché était connecté
+
+Le replay `fae19f5b…` (encore dans la rétention au 2026-08-12) contient, après
+`/tarifs`, des vues de `/tableau-de-bord` et
+`/tableau-de-bord/examen-blanc/…/resultats`. Ces routes sont gardées côté
+serveur par `requireSession()` — la session existait donc. C'est le fait qui
+oriente le diagnostic : le mismatch touche un utilisateur **authentifié** sur
+une page qui, elle, décide de son rendu à partir de la session **cliente**.
+
+## Cause : `useSession` n'a pas de snapshot serveur neutre
+
+`node_modules/better-auth/dist/client/react/react-store.mjs:41` :
+
+```js
+return useSyncExternalStore(subscribe, get, get)
+```
+
+Le troisième argument est `getServerSnapshot` — celui que React utilise pour le
+**rendu d'hydratation**, côté client. Better Auth y passe `get`, la même
+fonction que le snapshot client : elle renvoie ce que le store nanostores
+contient à cet instant, pas une valeur neutre stable.
+
+Conséquence : si la session est déjà résolue côté client au moment où React
+hydrate (cache cookie Better Auth), le rendu d'hydratation voit
+`{ data: user, isPending: false }` alors que le HTML serveur a été produit avec
+`{ data: null, isPending: true }` — aucune session n'est résolue au SSR. Tout
+composant qui **branche son rendu** sur cette valeur produit deux arbres
+différents.
+
+C'est le mécanisme que `.claude/rules/loading-ui.md` documentait déjà comme
+diagnostiqué le 2026-07-29 sur la capture serveur/client de Sentry. Il est
+désormais confirmé dans la source de la bibliothèque, et pas seulement déduit
+d'une observation.
+
+## Périmètre
+
+Deux consommateurs de `useCurrentUser()` branchent leur rendu sur la session
+alors qu'ils sont rendus côté serveur en premier.
+
+### 1. `PricingGrid` — `/tarifs`
+
+[`app/(marketing)/tarifs/_components/pricing-grid.tsx:32`](<../../../app/(marketing)/tarifs/_components/pricing-grid.tsx>)
+appelle `useCurrentUser()`. Deux usages :
+
+- **ligne 120** : `isAuthenticated && accessStatus && (…)` garde le bandeau
+  « Vos accès actuels ». C'est le branchement de rendu fautif.
+- **lignes 36-41** : `handlePurchase` sort tôt sur `isAuthLoading`, puis
+  redirige vers `/inscription` si non authentifié.
+
+L'information est **déjà présente côté serveur**.
+`features/payments/dal.ts:43-46` : `getAccessStatus()` résout la session et
+renvoie `null` si et seulement s'il n'y en a pas. La page
+`app/(marketing)/tarifs/page.tsx:23-27` appelle déjà ce DAL et passe le résultat
+en prop. Le composant redemande au client une information qu'il tient déjà.
+
+**Défaut collatéral corrigé au passage** : le `if (isAuthLoading) return` de la
+ligne 36 fait qu'un clic sur « Acheter » pendant la résolution de la session ne
+produit **rien** — ni navigation, ni spinner, ni message. Une fois
+`isAuthenticated` connu dès le premier rendu, cette branche disparaît.
+
+### 2. `MarketingHeader` — toutes les pages marketing
+
+[`components/marketing-header/index.tsx:37`](../../../components/marketing-header/index.tsx)
+appelle `useCurrentUser()` et bascule (ligne 147) entre deux arbres DOM
+franchement différents : avatar + `DropdownMenu`, ou deux boutons
+`Connexion`/`Inscription`. `MobileMenu` reçoit `currentUser` et
+`isAuthenticated` en props et fait le même choix.
+
+`/`, `/domaines`, `/a-propos` et `/evaluation` sont en **ISR**
+(`export const revalidate = 3600`) : leur HTML est généré une fois, déconnecté.
+Un visiteur authentifié qui hydrate avec une session en cache y court le même
+risque structurel que sur `/tarifs`.
+
+**Statut honnête de ce second point** : le défaut est prouvé structurellement
+(la bibliothèque ne fournit pas de snapshot serveur neutre), mais **pas** en
+production — aucun événement Sentry sur `/`, `/faq` ou `/domaines`. On le
+corrige comme durcissement, pas parce que les données le désignent. Cette
+distinction doit rester lisible dans le message de commit.
+
+## Design
+
+### `PricingGrid` — descendre l'authentification depuis le serveur
+
+`app/(marketing)/tarifs/page.tsx` résout explicitement la session
+(`getCurrentSession()` de `lib/dal.ts`, déjà appelé en interne par
+`getAccessStatus`, et mis en cache par React `cache()` — pas de requête
+supplémentaire) et passe un booléen `isAuthenticated` à `TarifsPageClient`, qui
+le relaie à `PricingGrid`.
+
+`PricingGrid` perd son import de `useCurrentUser`. Le bandeau lit la prop ;
+`handlePurchase` lit la prop et perd sa branche `isAuthLoading`.
+
+Le booléen est passé **explicitement** plutôt que dérivé de
+`accessStatus !== null`. La dérivation marcherait aujourd'hui, mais elle
+transforme un détail d'implémentation du DAL en contrat de rendu : le jour où
+`getAccessStatus` renverrait un objet pour un visiteur anonyme, le paywall
+s'ouvrirait en silence. Une prop nommée casse à la compilation, une dérivation
+implicite ne casse rien.
+
+### `MarketingHeader` — neutraliser la frame d'hydratation
+
+Le header reste un composant client (il a besoin de `usePathname`,
+`useHeaderScroll`, des dropdowns). Il ne peut pas recevoir la session en prop
+sans faire lire les cookies au layout marketing, ce qui **basculerait les quatre
+pages ISR en dynamique** — régression inacceptable sur des pages marketing.
+
+On garde donc la session cliente, mais on l'empêche de décider quoi que ce soit
+pendant le rendu d'hydratation, avec le pattern déjà éprouvé dans le dépôt
+(`components/shared/theme-toggle.tsx:20`) :
+
+```ts
+const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false)
+```
+
+`getServerSnapshot` renvoie une **constante**, donc le rendu d'hydratation
+reproduit exactement le HTML serveur ; React bascule ensuite en rendu normal,
+hors hydratation. Le branchement devient `mounted && isAuthenticated &&
+currentUser`.
+
+**Ce que voit l'utilisateur pendant cette frame** : la branche déconnectée
+(`Connexion` / `Inscription`), c'est-à-dire exactement ce que le HTML serveur
+contient déjà aujourd'hui. On n'introduit **pas** de squelette ni de
+« Chargement… » : `.claude/rules/loading-ui.md` interdit un état de chargement
+pour la session, et c'est précisément ce motif qui avait causé `NOMAQBANQ-5` sur
+le dashboard. Le comportement visible est donc inchangé — seul son déterminisme
+l'est.
+
+Le helper `emptySubscribe` / le hook `mounted` est dupliqué dans deux fichiers
+(`theme-toggle.tsx` et le header) : on l'extrait dans un hook partagé
+`hooks/use-mounted.ts`, et `theme-toggle.tsx` l'adopte. Trois lignes, un seul
+endroit où la subtilité `getServerSnapshot` est expliquée.
+
+## Tests
+
+Le point dur : un test qui passe que la garde existe ou non ne teste rien. Chaque
+test ci-dessous doit être vérifié **discriminant** — on remet le défaut et le
+test doit échouer.
+
+- **`PricingGrid`** — le bandeau « Vos accès actuels » se rend à partir de la
+  seule prop `isAuthenticated`, sans qu'aucune session cliente ne soit
+  disponible (mock `authClient` absent / session `null`). Discriminance : avec
+  l'ancien `useCurrentUser`, le bandeau ne se rend pas.
+- **`PricingGrid`** — clic sur « Acheter » avec `isAuthenticated={false}` →
+  `router.push("/inscription")` ; avec `true` → `createStripeCheckout` appelé.
+  Couvre la disparition de la branche `isAuthLoading` (aujourd'hui : clic sans
+  effet).
+- **`MarketingHeader`** — sur `getServerSnapshot` (état non monté), le rendu
+  produit la branche déconnectée **même quand `useCurrentUser` renvoie un
+  utilisateur**. C'est le test qui vaut : il constate que la session ne peut
+  plus décider pendant l'hydratation. Discriminance : sans la garde `mounted`,
+  l'avatar apparaît.
+- **`useMounted`** — `false` au snapshot serveur, `true` au snapshot client.
+
+Le seuil de couverture du projet est à 80 % (`vitest.config.ts`) ; ces fichiers
+sont déjà couverts, la refonte ne doit pas faire baisser la barre.
+
+## Vérification en production
+
+Le correctif ne se déclare pas réussi sur un test vert : les trois tentatives
+précédentes passaient leurs tests aussi.
+
+- `NOMAQBANQ-5` et `NOMAQBANQ-1E` sont marquées **résolues** au déploiement.
+  Sentry les rouvre automatiquement si l'erreur réapparaît sur une release
+  postérieure — c'est le signal à surveiller, sur au moins deux semaines.
+- Si `-5` se rouvre sur une page marketing **autre** que `/tarifs`, c'est le
+  header qui était en cause et le correctif H1 aura échoué (ou aura été
+  contourné) : à noter dans l'issue plutôt qu'à redevine.
+
+## Hors périmètre
+
+- **`NOMAQBANQ-1D`** (`Unknown unit of work tag (9227)`,
+  `/tableau-de-bord/examen-blanc/:examId/resultats`) : une occurrence,
+  `handled: yes`, pas de duplication React côté build (`react` et `react-dom`
+  en 19.2.8 uniques, plus le canary vendored par Next 16
+  `19.3.0-canary-3f0b9e61-20260317`). Lead conservé pour un triage ultérieur :
+  le replay de `-1E` contient l'URL du **même examen**
+  (`0c91e8ea-f673-40e8-add7-52a93f1c3cee`) deux heures plus tôt depuis
+  Edge/Windows — vraisemblablement la même personne, PC puis mobile. Une seule
+  occurrence ne justifie pas une campagne.
+- **Les cinq autres consommateurs de `useCurrentUser`**
+  (`nav-secondary`, `onboarding-guard`, `onboarding-form`,
+  `profile-personal-info`, `avatar-uploader`) : tous en zone `(dashboard)`, dont
+  le layout garde déjà la session côté serveur. Risque réel mais non désigné par
+  les données ; un balayage complet + une règle d'architecture ont été
+  explicitement écartés de cette itération.
+- **`Sentry.setUser`** : aucun appel dans le dépôt, donc `user.id` est toujours
+  nul et les visiteurs ne se distinguent que par IP. C'est un angle mort
+  d'observabilité réel — noté ici, pas traité ici.
+
+## Règles à mettre à jour
+
+`.claude/rules/loading-ui.md` porte déjà l'interdiction pour le shell dashboard
+(« ne jamais réintroduire d'`authClient.useSession()` dans le shell »). Elle est
+à généraliser avec le **pourquoi** désormais prouvé : `useSession` ne fournit pas
+de `getServerSnapshot` neutre, donc tout branchement de rendu sur la session
+cliente est un mismatch en puissance, y compris hors dashboard. Les deux issues
+et le fichier `react-store.mjs` sont la preuve à citer.

--- a/docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md
+++ b/docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md
@@ -48,30 +48,107 @@ serveur par `requireSession()` — la session existait donc. C'est le fait qui
 oriente le diagnostic : le mismatch touche un utilisateur **authentifié** sur
 une page qui, elle, décide de son rendu à partir de la session **cliente**.
 
-## Cause : `useSession` n'a pas de snapshot serveur neutre
+## Cause : la session se résout PENDANT une hydratation longue
 
-`node_modules/better-auth/dist/client/react/react-store.mjs:41` :
+> Cette section a été réécrite après une revue adversariale. La première version
+> affirmait que Better Auth exposait une session déjà en cache au rendu
+> d'hydratation. **C'est faux**, et la correction est ci-dessous. Le diagnostic
+> final ne repose plus sur une lecture de la bibliothèque mais sur le replay de
+> l'incident.
 
-```js
-return useSyncExternalStore(subscribe, get, get)
+### Ce que la bibliothèque fait vraiment
+
+`node_modules/better-auth/dist/client/session-atom.mjs:29-35` — l'atome naît à
+`{ data: null, error: null, isPending: true }`. Le seul chemin qui le peuple est
+`onMount` → `setTimeout(…, 0)` → `fetchSession()`, soit un aller-retour réseau
+(`session-atom.mjs:126-133`). Aucune lecture synchrone de cookie ou de
+`localStorage` ne l'amorce ; le `cookieCache` de Better Auth est serveur.
+`react-store.mjs:28,40-41` lit `useRef(store.get())` et renvoie
+`useSyncExternalStore(subscribe, get, get)`.
+
+Une session **déjà résolue** ne peut donc PAS être visible au premier rendu
+client : `onMount` ne se déclenche qu'au premier `listen()`, qui vient du
+`subscribe` de `useSyncExternalStore`, exécuté en effet passif après le commit.
+
+### Ce qui se passe réellement
+
+La session ne précède pas l'hydratation — elle **arrive pendant**. Reconstitué
+depuis les segments d'enregistrement du replay
+`fae19f5bd6594aa6af37e243808e861a` (voir _Preuve_) :
+
+| Instant (vs erreur) | Fait |
+| --- | --- |
+| −963 ms | chargement de `/tarifs` |
+| −826 ms | DOM servi : header en branche **déconnectée** ; badges d'accès des cartes présents (props serveur) ; bandeau de `PricingGrid` **absent** |
+| 0 | `throwOnHydrationMismatch` |
+| +246 ms | React régénère toute la racine ; apparaissent « LC » (initiales d'avatar), « Examens · 93j restants » et la phrase du bandeau |
+
+L'appareil est un Android d'entrée de gamme (`Generic_Android K`, Android 10)
+chargeant ~25 scripts dont un de 560 Ko. L'hydratation s'y étale sur plusieurs
+frames. Le `setTimeout(0)` + l'aller-retour réseau de `fetchSession` se résolvent
+à l'intérieur de cette fenêtre : le store change **entre** le commit d'une
+frontière d'hydratation et l'hydratation de la suivante, et le sous-arbre que
+React s'apprête à hydrater ne rend plus la même chose que le DOM servi.
+
+C'est pour ça que le défaut est rare, qu'il ne touche que des appareils lents, et
+qu'aucune reproduction locale ne l'a jamais montré.
+
+### Conséquence sur le remède
+
+La garde `mounted` n'est PAS un no-op. L'objection « `mounted && isAuthenticated`
+est algébriquement égal à `isAuthenticated` » suppose que `isAuthenticated` ne
+change pas pendant le rendu d'hydratation. Le replay prouve le contraire : c'est
+exactement là qu'il change. `useMounted` renvoie `false` sur toute la durée de
+l'hydratation, quel que soit le moment où le store se résout — c'est précisément
+ce qui rend le balisage déterministe.
+
+## Preuve
+
+Le replay était encore dans la rétention. Les segments s'obtiennent par
+`sentry api "/api/0/projects/khimera-9h/nomaqbanq/replays/<id>/recording-segments/?download=1"`
+(tableau de segments, chacun un tableau d'événements rrweb). Le breadcrumb
+`replay.hydrate-error` ne porte que l'URL — la valeur est dans le **snapshot
+complet antérieur à l'erreur** (le DOM servi) et dans la **mutation de
+récupération** qui suit (ce que React a réinséré).
+
+Diff textuel entre les deux, par chaînes exactes :
+
+```
+présents côté serveur seulement : « Connexion », « Inscription »
+présents côté client seulement  : « LC »,
+                                  « Examens · 93j restants »,
+                                  « Prolongez votre accès avant expiration
+                                    pour cumuler le temps restant… »
 ```
 
-Le troisième argument est `getServerSnapshot` — celui que React utilise pour le
-**rendu d'hydratation**, côté client. Better Auth y passe `get`, la même
-fonction que le snapshot client : elle renvoie ce que le store nanostores
-contient à cet instant, pas une valeur neutre stable.
+**Rien d'autre ne diverge.** L'écart est exactement l'interface conditionnée par
+la session : la branche d'authentification du header et le bandeau de
+`PricingGrid`.
 
-Conséquence : si la session est déjà résolue côté client au moment où React
-hydrate (cache cookie Better Auth), le rendu d'hydratation voit
-`{ data: user, isPending: false }` alors que le HTML serveur a été produit avec
-`{ data: null, isPending: true }` — aucune session n'est résolue au SSR. Tout
-composant qui **branche son rendu** sur cette valeur produit deux arbres
-différents.
+### Hypothèses concurrentes écartées, sur preuve
 
-C'est le mécanisme que `.claude/rules/loading-ui.md` documentait déjà comme
-diagnostiqué le 2026-07-29 sur la capture serveur/client de Sentry. Il est
-désormais confirmé dans la source de la bibliothèque, et pas seulement déduit
-d'une observation.
+- **Formatage de devise** (`formatCurrency`, `Intl.NumberFormat("fr-CA")` — un
+  U+00A0 côté Node contre un U+202F côté navigateur récent) : réfutée par
+  l'incident lui-même. Les montants sont identiques des deux côtés, code point
+  par code point — `350⟨U+00A0⟩$`, `600⟨U+00A0⟩$`, `250⟨U+00A0⟩$`,
+  `200⟨U+00A0⟩$`, `50⟨U+00A0⟩$` avant comme après.
+- **`next-themes` sur `<html>`** : `app/layout.tsx:135` porte déjà
+  `suppressHydrationWarning`. Le `<style>` de `disableTransitionOnChange` visible
+  dans la mutation est une conséquence de la régénération, pas sa cause.
+- **Navigation cliente** : le `navigation.push` vers `/tarifs` relevé dans
+  l'activité du replay vient du lien « Tarifs » de la barre de navigation ; une
+  navigation cliente n'hydrate pas. Les deux snapshots postérieurs à l'erreur
+  sont les re-captures que Sentry effectue au flush du buffer, pas de nouveaux
+  chargements.
+
+### Degré de confiance, explicitement
+
+- **Prouvé** : l'unique divergence serveur/client est l'interface conditionnée
+  par la session ; la session s'est résolue avant que React ne régénère l'arbre.
+- **Non prouvé** : que le store ait muté à la tick exacte du rendu d'hydratation
+  plutôt qu'entre deux frames de celui-ci. La distinction ne change pas le
+  remède — les deux se corrigent en retirant la session du chemin de décision
+  du rendu — mais elle doit rester écrite plutôt que lissée.
 
 ## Périmètre
 
@@ -112,11 +189,18 @@ franchement différents : avatar + `DropdownMenu`, ou deux boutons
 Un visiteur authentifié qui hydrate avec une session en cache y court le même
 risque structurel que sur `/tarifs`.
 
-**Statut honnête de ce second point** : le défaut est prouvé structurellement
-(la bibliothèque ne fournit pas de snapshot serveur neutre), mais **pas** en
-production — aucun événement Sentry sur `/`, `/faq` ou `/domaines`. On le
-corrige comme durcissement, pas parce que les données le désignent. Cette
-distinction doit rester lisible dans le message de commit.
+**Statut de ce second point — révisé.** La première version de ce document le
+classait en durcissement non désigné par les données. Le replay a tranché
+l'inverse : « Connexion » et « Inscription » sont les DEUX seules chaînes
+présentes côté serveur et absentes côté client, et « LC » (les initiales
+d'avatar du header) est la première apparue côté client. **Le header est un
+contributeur prouvé du mismatch, au même titre que `PricingGrid`** — pas un
+durcissement spéculatif.
+
+Ce qui reste non désigné par les données, c'est le risque sur les autres pages
+marketing : aucun événement Sentry sur `/`, `/faq` ou `/domaines`. Le correctif
+les couvre par construction, ce n'est pas une raison de prétendre qu'elles
+étaient cassées.
 
 ## Design
 
@@ -232,7 +316,16 @@ précédentes passaient leurs tests aussi.
 
 `.claude/rules/loading-ui.md` porte déjà l'interdiction pour le shell dashboard
 (« ne jamais réintroduire d'`authClient.useSession()` dans le shell »). Elle est
-à généraliser avec le **pourquoi** désormais prouvé : `useSession` ne fournit pas
-de `getServerSnapshot` neutre, donc tout branchement de rendu sur la session
-cliente est un mismatch en puissance, y compris hors dashboard. Les deux issues
-et le fichier `react-store.mjs` sont la preuve à citer.
+à généraliser avec le **pourquoi** désormais établi : la session Better Auth se
+résout par un aller-retour réseau déclenché au montage, et sur un appareil lent
+elle atterrit **pendant** l'hydratation. Tout branchement de rendu sur elle est
+donc un mismatch en puissance, y compris hors dashboard — d'autant plus rare et
+d'autant plus difficile à reproduire que la machine de développement est rapide.
+
+Deux corollaires à écrire dans la règle :
+
+- ce n'est **pas** un défaut de la bibliothèque à contourner, c'est le
+  comportement normal d'un état asynchrone client ; le remède est de ne pas le
+  laisser décider du balisage initial ;
+- une reproduction locale qui échoue ne prouve rien. Le levier est le **temps
+  d'hydratation** : throttling CPU/réseau, ou un appareil réel d'entrée de gamme.

--- a/docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md
+++ b/docs/superpowers/specs/2026-08-12-hydratation-session-tarifs-header-design.md
@@ -202,6 +202,14 @@ marketing : aucun événement Sentry sur `/`, `/faq` ou `/domaines`. Le correcti
 les couvre par construction, ce n'est pas une raison de prétendre qu'elles
 étaient cassées.
 
+**Précision relevée à la vérification navigateur.** `proxy.ts:62-64` redirige un
+visiteur **connecté** depuis `/`, `/a-propos` et `/domaines` vers
+`/tableau-de-bord` (`PUBLIC_ONLY`). Ces trois pages ne rendent donc JAMAIS la
+branche connectée du header, et sortent du risque. Les pages où un utilisateur
+authentifié voit réellement le header marketing sont `/tarifs`, `/evaluation`
+(la seule page ISR concernée), `/faq` et les pages légales. La surface exposée
+est donc plus petite que ce que la première rédaction laissait entendre.
+
 ## Design
 
 ### `PricingGrid` — descendre l'authentification depuis le serveur

--- a/hooks/use-mounted.ts
+++ b/hooks/use-mounted.ts
@@ -1,0 +1,21 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+const emptySubscribe = () => () => {}
+const getSnapshot = () => true
+const getServerSnapshot = () => false
+
+/**
+ * `false` pendant le rendu serveur ET pendant le rendu d'hydratation, `true`
+ * ensuite. `getServerSnapshot` renvoie une constante : React l'emprunte à
+ * l'hydratation, le rendu client reproduit donc exactement le HTML serveur.
+ *
+ * Sert à empêcher un état exclusivement client de décider du balisage pendant
+ * l'hydratation. La session Better Auth en a besoin parce qu'elle se résout par
+ * un aller-retour réseau déclenché au montage : sur un appareil lent elle
+ * atterrit AU MILIEU de l'hydratation, et un balisage qui en dépend cesse alors
+ * de correspondre au HTML servi.
+ */
+export const useMounted = () =>
+  useSyncExternalStore(emptySubscribe, getSnapshot, getServerSnapshot)

--- a/tests/components/MarketingHeader.test.tsx
+++ b/tests/components/MarketingHeader.test.tsx
@@ -1,0 +1,106 @@
+import { act } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { hydrateRoot } from "react-dom/client"
+import { renderToString } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { MarketingHeader } from "@/components/marketing-header"
+import { useCurrentUser } from "@/hooks/useCurrentUser"
+
+vi.mock("motion/react", async () => {
+  const { motionMockFactory } = await import("../helpers/motion-mock")
+  return motionMockFactory
+})
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/tarifs",
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light", setTheme: vi.fn() }),
+}))
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { signOut: vi.fn() },
+}))
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: vi.fn(),
+}))
+
+type Session = ReturnType<typeof useCurrentUser>
+
+const deconnecte = {
+  currentUser: null,
+  isLoading: true,
+  isAuthenticated: false,
+  refetch: vi.fn(),
+} as unknown as Session
+
+const connecte = {
+  currentUser: {
+    name: "Awa Diallo",
+    email: "awa@example.test",
+    image: null,
+  },
+  isLoading: false,
+  isAuthenticated: true,
+  refetch: vi.fn(),
+} as unknown as Session
+
+describe("MarketingHeader", () => {
+  it("hydrate proprement quand la session se résout entre le HTML serveur et l'hydratation", async () => {
+    // 1. HTML serveur : aucune session résolue côté serveur.
+    vi.mocked(useCurrentUser).mockReturnValue(deconnecte)
+    const html = renderToString(<MarketingHeader />)
+    expect(html).toContain("Connexion")
+
+    // 2. La session arrive AVANT qu'on hydrate — la fenêtre de l'incident.
+    vi.mocked(useCurrentUser).mockReturnValue(connecte)
+
+    const container = document.createElement("div")
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const recoverable: unknown[] = []
+    await act(async () => {
+      hydrateRoot(container, <MarketingHeader />, {
+        onRecoverableError: (err) => recoverable.push(err),
+      })
+    })
+
+    // 3. Sans la garde, React signale ici un mismatch d'hydratation.
+    expect(recoverable).toEqual([])
+  })
+
+  it("affiche l'utilisateur une fois l'hydratation terminée", async () => {
+    vi.mocked(useCurrentUser).mockReturnValue(deconnecte)
+    const html = renderToString(<MarketingHeader />)
+
+    vi.mocked(useCurrentUser).mockReturnValue(connecte)
+    const container = document.createElement("div")
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    await act(async () => {
+      hydrateRoot(container, <MarketingHeader />)
+    })
+
+    // Le nom complet ne vit que dans le contenu du DropdownMenu, fermé par
+    // défaut : la branche connectée se reconnaît aux initiales de l'avatar.
+    expect(container.textContent).toContain("AD")
+    expect(container.textContent).not.toContain("Connexion")
+  })
+})

--- a/tests/components/payments/PricingGrid.test.tsx
+++ b/tests/components/payments/PricingGrid.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { PricingGrid } from "@/app/(marketing)/tarifs/_components/pricing-grid"
+
+vi.mock("motion/react", async () => {
+  const { motionMockFactory } = await import("../../helpers/motion-mock")
+  return motionMockFactory
+})
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh: vi.fn() }),
+}))
+
+const createStripeCheckout = vi.fn()
+vi.mock("@/features/payments/actions", () => ({
+  createStripeCheckout: (...args: unknown[]) => createStripeCheckout(...args),
+}))
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock("@/lib/format", () => ({
+  formatCurrency: (amount: number) => `${(amount / 100).toFixed(0)} $`,
+  formatExpiration: (ts: number) => `exp-${ts}`,
+}))
+
+const products = [
+  {
+    id: "prod_1",
+    code: "exam_access" as const,
+    name: "Accès Examens 30 jours",
+    description: "Accès complet aux examens simulés",
+    priceCAD: 5000,
+    durationDays: 30,
+    accessType: "exam" as const,
+    isCombo: false,
+    stripeProductId: "prod_test",
+    stripePriceId: "price_test",
+  },
+]
+
+const accessStatus = {
+  examAccess: { expiresAt: 1_800_000_000_000, daysRemaining: 12 },
+  trainingAccess: null,
+}
+
+describe("PricingGrid", () => {
+  beforeEach(() => {
+    createStripeCheckout.mockResolvedValue({
+      checkoutUrl: "https://stripe.test/x",
+    })
+  })
+
+  it("rend le bandeau d'accès à partir de la prop serveur, sans session cliente", () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={accessStatus}
+        isAuthenticated
+      />,
+    )
+
+    expect(screen.getByText("Vos accès actuels")).toBeInTheDocument()
+  })
+
+  it("n'affiche pas le bandeau pour un visiteur non authentifié", () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={null}
+        isAuthenticated={false}
+      />,
+    )
+
+    expect(screen.queryByText("Vos accès actuels")).not.toBeInTheDocument()
+  })
+
+  it("redirige vers l'inscription quand le visiteur n'est pas authentifié", async () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={null}
+        isAuthenticated={false}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/inscription"))
+    expect(createStripeCheckout).not.toHaveBeenCalled()
+  })
+
+  it("ouvre le checkout Stripe dès le premier clic d'un visiteur authentifié", async () => {
+    render(
+      <PricingGrid
+        products={products}
+        accessStatus={{ examAccess: null, trainingAccess: null }}
+        isAuthenticated
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+
+    await waitFor(() =>
+      expect(createStripeCheckout).toHaveBeenCalledWith({
+        productCode: "exam_access",
+        successPath: "/tableau-de-bord/paiement/succes",
+        cancelPath: "/tarifs",
+      }),
+    )
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/payments/PricingGrid.test.tsx
+++ b/tests/components/payments/PricingGrid.test.tsx
@@ -30,7 +30,10 @@ vi.mock("@/features/payments/actions", () => ({
   createStripeCheckout: (...args: unknown[]) => createStripeCheckout(...args),
 }))
 
-vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }))
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: vi.fn() },
+}))
 
 vi.mock("@/lib/format", () => ({
   formatCurrency: (amount: number) => `${(amount / 100).toFixed(0)} $`,
@@ -51,6 +54,22 @@ const products = [
     stripePriceId: "price_test",
   },
 ]
+
+const trainingProduct = {
+  ...products[0],
+  id: "prod_2",
+  code: "training_access" as const,
+  name: "Accès Entraînement 30 jours",
+  accessType: "training" as const,
+}
+
+const premiumProduct = {
+  ...products[0],
+  id: "prod_3",
+  code: "premium_access" as const,
+  name: "Accès Premium",
+  isCombo: true,
+}
 
 const accessStatus = {
   examAccess: { expiresAt: 1_800_000_000_000, daysRemaining: 12 },
@@ -122,5 +141,88 @@ describe("PricingGrid", () => {
       }),
     )
     expect(push).not.toHaveBeenCalled()
+  })
+
+  it("affiche l'erreur métier renvoyée par l'action, sans rediriger", async () => {
+    createStripeCheckout.mockResolvedValue({ error: "Produit mal configuré" })
+    render(
+      <PricingGrid products={products} accessStatus={null} isAuthenticated />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("Produit mal configuré"),
+    )
+  })
+
+  it("distingue une panne réseau d'une erreur générique", async () => {
+    createStripeCheckout.mockRejectedValue(new Error("Failed to fetch"))
+    const onLine = vi.spyOn(navigator, "onLine", "get").mockReturnValue(false)
+
+    const { unmount } = render(
+      <PricingGrid products={products} accessStatus={null} isAuthenticated />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Pas de connexion internet. Vérifiez votre réseau.",
+      ),
+    )
+    unmount()
+
+    onLine.mockReturnValue(true)
+    render(
+      <PricingGrid products={products} accessStatus={null} isAuthenticated />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /Acheter maintenant/ }))
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Une erreur est survenue. Veuillez réessayer.",
+      ),
+    )
+  })
+
+  it("affiche un état vide quand aucun produit n'est disponible", () => {
+    render(
+      <PricingGrid products={[]} accessStatus={null} isAuthenticated={false} />,
+    )
+
+    expect(screen.getByText("Aucune offre disponible")).toBeInTheDocument()
+  })
+
+  it("sort le produit combo de la grille pour le mettre en avant", () => {
+    render(
+      <PricingGrid
+        products={[...products, premiumProduct]}
+        accessStatus={accessStatus}
+        isAuthenticated
+      />,
+    )
+
+    expect(screen.getByText("Accès Premium")).toBeInTheDocument()
+    expect(screen.getByText("Accès Examens 30 jours")).toBeInTheDocument()
+  })
+
+  it("filtre la grille par type d'accès", () => {
+    render(
+      <PricingGrid
+        products={[...products, trainingProduct]}
+        accessStatus={accessStatus}
+        isAuthenticated
+      />,
+    )
+
+    expect(screen.getByText("Accès Entraînement 30 jours")).toBeInTheDocument()
+
+    // Radix TabsTrigger commute sur mousedown, pas sur un click synthétique.
+    fireEvent.mouseDown(
+      screen.getByRole("tab", { name: /Filtrer par examens/ }),
+    )
+
+    expect(
+      screen.queryByText("Accès Entraînement 30 jours"),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText("Accès Examens 30 jours")).toBeInTheDocument()
   })
 })

--- a/tests/helpers/motion-mock.tsx
+++ b/tests/helpers/motion-mock.tsx
@@ -94,6 +94,13 @@ export const motionMockFactory = {
       const filtered = filterMotionProps(props)
       return <circle {...filtered}>{children}</circle>
     },
+    header: ({
+      children,
+      ...props
+    }: ComponentPropsWithoutRef<"header"> & Record<string, unknown>) => {
+      const filtered = filterMotionProps(props)
+      return <header {...filtered}>{children}</header>
+    },
   },
   AnimatePresence: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>

--- a/tests/hooks/useMounted.test.tsx
+++ b/tests/hooks/useMounted.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from "@testing-library/react"
+import { renderToString } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { useMounted } from "@/hooks/use-mounted"
+
+const Probe = () => <span>{useMounted() ? "monté" : "non monté"}</span>
+
+describe("useMounted", () => {
+  it("vaut false au snapshot serveur (donc au rendu d'hydratation)", () => {
+    expect(renderToString(<Probe />)).toContain("non monté")
+  })
+
+  it("vaut true côté client", () => {
+    const { result } = renderHook(() => useMounted())
+    expect(result.current).toBe(true)
+  })
+})


### PR DESCRIPTION
Corrige le résidu de `NOMAQBANQ-5` et la nouvelle `NOMAQBANQ-1E`, toutes deux sur `/tarifs`. C'est la quatrième tentative sur cette issue — les trois précédentes (#127, #130, #133) visaient du formatage. Cette fois la cause vient du replay de l'incident, pas d'un raisonnement par élimination.

## La cause, établie sur les données

Le replay `fae19f5b…` était encore dans la rétention. Les segments d'enregistrement portent le snapshot du DOM servi **et** la mutation par laquelle React régénère l'arbre après le mismatch. Le diff textuel entre les deux ne montre qu'un seul écart :

```
côté serveur seulement : « Connexion », « Inscription »
côté client seulement  : « LC » (initiales d'avatar),
                         « Examens · 93j restants »,
                         « Prolongez votre accès avant expiration… »
```

C'est exactement l'interface conditionnée par la session : la branche d'authentification du header et le bandeau d'accès de `PricingGrid`. Rien d'autre ne diverge.

**Le mécanisme n'est pas celui qu'on croyait.** L'atome de session Better Auth n'est jamais pré-rempli : il naît à `{ data: null, isPending: true }` et n'est peuplé que par `onMount` → `setTimeout(…, 0)` → aller-retour réseau. La session n'arrive donc pas *avant* l'hydratation, elle arrive **pendant**, quand l'hydratation dure assez longtemps. L'appareil de l'incident est un Android 10 d'entrée de gamme chargeant ~25 scripts dont un de 560 Ko ; le store change entre deux frames et le sous-arbre que React s'apprête à hydrater ne rend plus le DOM servi.

D'où le fait que ça ne se reproduise sur aucune machine de développement : **le levier est la durée d'hydratation, pas l'état**.

### Hypothèses concurrentes écartées, sur preuve

- **Formatage de devise** (`Intl.NumberFormat("fr-CA")`, U+00A0 contre U+202F) : réfutée par l'incident lui-même — les montants sont identiques des deux côtés, code point par code point (`350⟨U+00A0⟩$`, `50⟨U+00A0⟩$`…).
- **`next-themes` sur `<html>`** : `app/layout.tsx:135` porte déjà `suppressHydrationWarning`.
- **`NOMAQBANQ-1E` porterait le diff serveur/client de React** : non. L'événement n'a que `exception, breadcrumbs, request, debugmeta` — ni `componentStack`, ni `Server:`/`Client:`.

## Le correctif

**`/tarifs`** — la page est déjà dynamique et détient l'information : `isAuthenticated` descend en prop explicite depuis le Server Component. La prop est nommée plutôt que dérivée de `accessStatus !== null` : une dérivation implicite ouvrirait le paywall en silence si le DAL changeait, une prop casse à la compilation. Effet de bord corrigé : un clic « Acheter » pendant la résolution de la session ne restait **sans aucun effet**.

**Header marketing** — il reste client (pathname, scroll, dropdowns) et ne peut pas recevoir la session en prop sans faire lire les cookies au layout, ce qui basculerait en dynamique les quatre pages en `revalidate = 3600`. La garde `useMounted` neutralise donc la session le temps de l'hydratation. Le hook est extrait dans `hooks/use-mounted.ts` et `ThemeToggle`, qui dupliquait le motif, l'adopte.

Le comportement visible est inchangé — seul son déterminisme l'est.

## Tests

Le point dur : les trois tentatives précédentes passaient leurs tests aussi. Chaque correctif porte donc un **contrôle de discriminance** vérifié.

- **`MarketingHeader`** — le test rejoue la fenêtre de l'incident : HTML serveur produit déconnecté, session basculée sur connectée, *puis* `hydrateRoot`. Sans la garde, `onRecoverableError` reçoit l'erreur (`expected [ …(1) ] to deeply equal []`). **Le mismatch est reproduit en test unitaire.** Un test qui fige la session à une valeur constante — la première version — passait garde ou pas.
- **`PricingGrid`** — bandeau rendu depuis la seule prop serveur ; achat au premier clic. En réinjectant `useCurrentUser`, exactement ces deux tests tombent.

Vérifications : `bun run check` ✅ · frontend **1300 tests / 114 fichiers** ✅ · intégration **328 tests / 34 fichiers** ✅ sur branche Neon éphémère · couverture **80,54 %** de branches (base : 80,36 %).

**Piège de couverture rencontré.** `coverage.include` n'ajoute que les fichiers *jamais exécutés* ; `exclude` seul filtre les fichiers exécutés. Écrire un test sur `pricing-grid.tsx` l'a donc **fait entrer** dans le rapport à 59 % de branches, faisant tomber l'agrégat sous le seuil alors que la base était verte. Corrigé en couvrant réellement les branches d'erreur du parcours d'achat (erreur métier, hors-ligne vs erreur générique), l'état vide, la mise en avant du combo et le filtre — pas en excluant le fichier.

## Vérification navigateur

Parcours rejoué connecté et déconnecté : bandeau servi par le serveur, avatar après résolution, achat au premier clic (→ `cs_test_…`), redirection vers `/inscription` en déconnecté, `/evaluation` et `/faq` sans erreur console.

**Le contrôle négatif n'a pas reproduit la régression en local** — correctif retiré, console toujours à 0 erreur. C'est attendu (durée d'hydratation) et c'est dit franchement : la preuve du correctif est le test unitaire, pas le navigateur.

Découverte au passage : `proxy.ts:62-64` redirige un visiteur connecté depuis `/`, `/a-propos` et `/domaines` vers `/tableau-de-bord`. Ces pages ne rendent jamais la branche connectée du header ; la surface réellement exposée est plus étroite que la première rédaction du spec ne le disait, et le document a été corrigé.

## Suivi après déploiement

Marquer `NOMAQBANQ-5` et `NOMAQBANQ-1E` résolues. Sentry les rouvre si l'erreur revient sur une release postérieure — **c'est le seul verdict qui compte**, à surveiller deux semaines. Une réouverture sur une page marketing autre que `/tarifs` signifierait que la garde du header a été contournée.

`NOMAQBANQ-1D` (`Unknown unit of work tag`) reste ouverte, hors périmètre : une occurrence, `handled: yes`, aucune duplication React côté build.

Spec et plan : `docs/superpowers/{specs,plans}/2026-08-12-hydratation-session-tarifs-header*`. Le spec porte un encadré signalant que sa première version décrivait une cause fausse, et une section séparant explicitement ce qui est prouvé de ce qui ne l'est pas.
