### PR TITLE
chore(ci): resserrer les groupes Dependabot et auto-merger l'outillage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,51 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Montreal"
-    open-pull-requests-limit: 10
-    # Grouper les mises à jour pour éviter trop de PRs.
+    open-pull-requests-limit: 5
+    # Laisser retomber les publications fraîches : une release cassée est
+    # généralement corrigée en quelques jours, avant d'entrer dans une PR.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     # Ordre = priorité : une dépendance va dans le PREMIER groupe qui la capture.
     groups:
-      # Framework critique en premier : isolé, toutes versions, pour review attentive
+      # Le linter et les types React doivent monter EN MÊME TEMPS que le
+      # framework : décalés, ils appliquent les règles d'une version de Next
+      # qui n'est pas celle installée.
       nextjs:
         patterns:
           - "next"
           - "react"
           - "react-dom"
-      # Tout le reste en minor + patch : 1 seule PR (idéale pour l'auto-merge)
-      minor-and-patch:
+          - "eslint-config-next"
+          - "@next/*"
+          - "@types/react"
+          - "@types/react-dom"
+      # Outillage sans effet sur le bundle livré : candidat à l'auto-merge
+      # (cf. .github/workflows/dependabot-auto-merge.yml).
+      tooling:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-plugin-*"
+          - "eslint-config-*"
+          - "prettier"
+          - "prettier-plugin-*"
+          - "@trivago/prettier-plugin-*"
+          - "typescript"
+          - "@types/*"
+          - "vitest"
+          - "@vitest/*"
+          - "@vitejs/*"
+          - "happy-dom"
+          - "@testing-library/*"
+          - "playwright"
+          - "@playwright/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Tout ce qui part en production, en minor + patch : relecture humaine.
+      runtime:
         patterns:
           - "*"
         update-types:
@@ -43,6 +76,10 @@ updates:
       # Retirer quand Vitest embarquera Vite 8 (v6 importe vite/internal, absent de Vite 7)
       - dependency-name: "@vitejs/plugin-react"
         update-types: ["version-update:semver-major"]
+      # Le SDK AWS publie quasi quotidiennement ; ses patchs n'apportent rien
+      # aux trois clients utilisés ici (S3, SESv2, presigned POST).
+      - dependency-name: "@aws-sdk/*"
+        update-types: ["version-update:semver-patch"]
     labels:
       - "dependencies"
       - "automated"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# pull_request_target (et non pull_request) : sur une PR de Dependabot, le
+# GITHUB_TOKEN d'un run `pull_request` est en lecture seule et ne peut pas
+# activer l'auto-merge. Aucun code de la PR n'est récupéré ni exécuté ici.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge outillage
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Métadonnées Dependabot
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      # L'auto-merge attend les checks requis par la règle de branche
+      # (Quality Checks + Integration Tests) : rien ne part sur un CI rouge.
+      - name: Activer l'auto-merge
+        if: >-
+          steps.meta.outputs.dependency-group == 'tooling'
+          && steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pourquoi

Les trois PRs Dependabot ouvertes ont exposé deux défauts de la configuration.

**1. `eslint-config-next` hors du groupe `nextjs`.** Le groupe ne capturait que
`next`, `react` et `react-dom` ; le linter tombait donc dans le fourre-tout
minor+patch et pouvait monter en 16.3.1 alors que `next` restait en 16.2.12
(cf. #144, qui échoue sur une règle ESLint que la version installée de Next
n'a pas). `@types/react` / `@types/react-dom`, qui doivent suivre React,
étaient dans le même cas.

**2. Un lot minor+patch de 20 paquets.** Un seul paquet fautif bloque les 19
autres.

## Ce que ça change

- `nextjs` capture aussi `eslint-config-next`, `@next/*`, `@types/react`,
  `@types/react-dom`.
- Le lot minor+patch est scindé :
  - `tooling` — lint, format, TS, tests : aucun effet sur le bundle livré,
    **auto-mergé** une fois le CI vert (nouveau workflow) ;
  - `runtime` — tout ce qui part en production : relecture humaine.
- `cooldown` de 3 jours (7 pour les majors) : une release publiée hier n'entre
  pas dans une PR aujourd'hui.
- Les patchs `@aws-sdk/*` sont ignorés (publication quasi quotidienne).
- `open-pull-requests-limit` : 10 → 5.

## Auto-merge — périmètre

Le workflow n'agit que sur le groupe `tooling`, hors major, et se contente
d'activer l'auto-merge : GitHub attend les checks requis par la règle de
branche (**Quality Checks** + **Integration Tests**) avant de merger. Rien ne
part sur un CI rouge.

Il utilise `pull_request_target` — le `GITHUB_TOKEN` d'un run `pull_request`
sur une PR Dependabot est en lecture seule — sans jamais récupérer ni exécuter
le code de la PR.

Pour le désactiver : supprimer le fichier, ou passer le `if:` du job à `false`.

> `pull_request_target` s'exécute depuis la branche de base : le workflow ne
> prendra effet qu'une fois cette PR mergée.
