### PR TITLE
chore(deps): aligner les overrides des types React sur les dépendances directes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,8 +104,8 @@
     },
   },
   "overrides": {
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
   },
   "packages": {
@@ -819,9 +819,9 @@
 
     "@types/pg": ["@types/pg@8.20.3", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "overrides": {
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3"
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4"
   }
 }


### PR DESCRIPTION
## Pourquoi

Le workflow **Dependabot Updates** échoue à chaque passage sur deux paquets,
et ce bien avant le resserrement des groupes (déjà le 17 août) :

```
| Dependency       | Error Type    |
| @types/react     | unknown_error |
| @types/react-dom | unknown_error |
```

Le bloc `overrides` a été créé pour `xlsx` (forcer la tarball SheetJS), puis
`@types/react` / `@types/react-dom` y ont été ajoutés pour forcer les paquets
qui déclarent `@types/react: "*"` — Radix, Testing Library — sur une version
unique. Il était tenu à jour à la main (dernier alignement le 1ᵉʳ mars, 19.2.10
→ 19.2.14), jusqu'à ce que Dependabot prenne le relais sur `devDependencies`.

Or Dependabot sait bumper `devDependencies`, **pas** `overrides`. Les deux ont
divergé :

| | `devDependencies` | `overrides` | installé |
|---|---|---|---|
| `@types/react` | 19.2.18 | 19.2.14 | **19.2.14** |
| `@types/react-dom` | 19.2.4 | 19.2.3 | **19.2.3** |

Deux conséquences : la version lue dans `package.json` n'était pas celle
installée, et Dependabot retentait la mise à jour à chaque passage en échouant.

## Ce que ça change

Les `overrides` repassent sur les versions des dépendances directes — ce que
la ligne installée aurait dû être. Aucun code applicatif touché.

Vérifié en local sur cette branche : `tsc --noEmit`, `eslint --max-warnings 0`,
`prettier --check`, et 1300 tests sur 114 fichiers — tout passe.

> La divergence se reformera au prochain bump de `@types/react` par Dependabot.
> Si elle revient, l'option de repli est d'ignorer ces deux paquets dans
> `dependabot.yml` et de tenir la paire à la main, comme avant mars.
