### PR TITLE
Paiements Stripe : catalogue résolu par lookup_key et traçabilité Adaptive Pricing (#138) + retry du pool Neon (NOMAQBANQ-1F)

### DIFF
--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -70,12 +70,16 @@ storagePath,order}` pour rester assignable aux composants partagés
   **requis** : ils se résolvent AVANT d'ouvrir la transaction (voir la règle
   suivante), et un oubli casse la compilation au lieu du silence.
 - **Jamais d'appel au `db` global depuis une fonction exécutée dans une
-  transaction** : le pool est à `max: 5` **sans** `connectionTimeoutMillis`
+  transaction** : le pool est à `max: 5` avec `connectionTimeoutMillis: 10_000`
   (`db/index.ts`), donc réclamer une 2ᵉ connexion pendant qu'on en détient une
-  fige la requête indéfiniment — et cinq transactions concurrentes figent
-  l'application entière, pas seulement la fonctionnalité fautive. Ce qu'une
-  transaction doit lire ailleurs se résout avant de l'ouvrir et se passe en
-  paramètre (`hasAccess` et `resolveRevisionLock` dans `createTrainingSession`).
+  bloque 10 s puis échoue — mieux qu'avant (blocage indéfini), mais toujours un
+  bug à corriger à la source. Ce qu'une transaction doit lire ailleurs se résout
+  avant de l'ouvrir et se passe en paramètre (`hasAccess` et
+  `resolveRevisionLock` dans `createTrainingSession`). Le pool retente par
+  ailleurs l'**acquisition** sur les erreurs de réveil Neon 53300/57P03
+  (`db/retry-pool.ts`, post-mortem NOMAQBANQ-1F) — sûr car aucune requête n'est
+  encore partie ; ne JAMAIS étendre ce retry aux requêtes elles-mêmes ni au
+  timeout de file local (sans code pg), que retenter aggraverait.
 - **Narrowing TS** : renvoyer la valeur DEPUIS le callback de transaction
   (`const r = await db.transaction(async tx => { … return v })`), PAS via un
   `let` capturé dans la closure — TS ne le narrow pas après un garde `if (!r)`

--- a/.claude/rules/payments.md
+++ b/.claude/rules/payments.md
@@ -55,19 +55,43 @@ voit rien — le `captureServerError` explicite est la SEULE trace Sentry.
   deux mécanismes est en jeu.
 - **La réconciliation ne doit jamais faire échouer un paiement valide.** Montant
   ou devise inexploitables → on conserve les valeurs provisoires et on logue.
+- **`presentment_details` est persisté** (`transactions.presentment_amount` /
+  `presentment_currency`, nullables, devise en texte libre — la conversion couvre
+  plus de 150 pays, l'enum `currency` n'en connaît que deux). C'est la seule façon
+  de recouper un client qui écrit « j'ai payé 228 000 FCFA ». Ces colonnes ne sont
+  PAS comptables : `amountPaid`/`currency` restent l'encaissement. Le hash n'est
+  présent que si le client a payé en devise locale — la doc n'énonce pas la
+  réciproque, donc le taux de lignes non nulles est une BORNE BASSE de la
+  proportion de conversions, pas une mesure exacte.
 
 ## Catalogue produits
 
 - **Le prix affiché et le prix facturé viennent de deux sources.**
   `products.priceCad` (Postgres) alimente la grille tarifaire et les paywalls ;
-  `products.stripePriceId` détermine ce que Stripe facture réellement. Modifier
-  un prix au dashboard Stripe SANS mettre à jour la ligne `products` fait
-  diverger les deux en silence — le client voit un montant et en paie un autre.
-- **Les préfixes `price_` / `prod_` sont identiques en test et en live.** Un
-  identifiant du mauvais mode ne se voit qu'à la création de la session, en
-  `resource_missing` — d'où le message dédié « produit mal configuré » plutôt
-  qu'une erreur réseau générique. C'est le seul signal existant : le vérifier
-  avant de conclure à une panne Stripe.
+  Stripe facture le prix résolu au checkout depuis
+  `products.stripePriceLookupKey`. Modifier un prix au dashboard Stripe SANS
+  mettre à jour la ligne `products` fait diverger les deux. Deux garde-fous
+  alertent dans Sentry : la comparaison au checkout et la tâche cron
+  `auditProductPriceDrift` (qui couvre les produits que personne n'achète).
+- **Devise et montant ne se traitent PAS pareil dans cette comparaison.** La
+  devise d'un prix Stripe est immuable (on ne modifie pas un prix, on en crée un
+  autre et on lui transfère la clé) : une devise ≠ `cad` n'est jamais un état
+  transitoire légitime → la vente est REFUSÉE. Un montant, lui, diverge
+  normalement le temps que l'`UPDATE` de `priceCad` suive → on alerte SANS
+  bloquer. Couper les ventes sur un écart de montant coûte plus cher que l'écart,
+  d'autant que Checkout affiche le montant au client avant qu'il ne confirme.
+- **Une `lookup_key` est identique en test et en live**, contrairement aux
+  identifiants `price_…` / `prod_…` dont les préfixes n'encodent pas le mode.
+  C'est ce qui rend impossible la classe « identifiant du mauvais mode » : la clé
+  résout le prix de test sous une clé de test, le prix live sous une clé live.
+  Changer un tarif se fait par `transfer_lookup_key=true`.
+- **Repli transitoire (phase expand/contract)** : tant que `stripe_price_id`
+  existe, une `lookup_key` qui ne résout rien retombe dessus et alerte, au lieu
+  de couper la vente. Le silence de cette alerte en production est ce qui
+  autorise le `DROP COLUMN` — après quoi une clé introuvable redevient un refus.
+- **La résolution du prix exige `prices:read` sur la clé Stripe runtime.** Créer
+  une session avec un price ID ne le demandait pas ; `prices.list` si. Une clé
+  restreinte sans ce droit casse TOUS les checkouts en `permission_error`.
 - **Adaptive Pricing exige que la devise des prix soit une devise de règlement**
   du compte. Les prix restent donc en CAD ; ne pas créer de prix en devise
   locale « pour aider », ça désactive la conversion automatique.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ constants/index.tsx        # Routes centralisees, MEDICAL_DOMAINS
 - **Icons** : `lucide-react` (primaire — utilisé partout), `@tabler/icons-react` (secondaire — surtout admin/dashboard et profil)
 - **Auth** : Better Auth (`lib/auth.ts`, route `app/api/auth/[...all]`) ; client `authClient` (`lib/auth-client.ts`)
 - **Webhooks** : Stripe -> `app/api/stripe/webhook` (signature verifiee, 500 sur erreur -> retry)
-- **Stripe en dev** : mode TEST (profil CLI `nomaqbanq`) ; webhooks locaux via `stripe listen --forward-to localhost:3000/api/stripe/webhook`. Base dev : seul `exam_access` pointe sur un prix test — les 4 autres produits portent des price IDs LIVE → créer le prix test + UPDATE `products.stripe_price_id` avant de tester leur achat. Code promo test −100 % : `E2EPROMO100`
+- **Stripe en dev** : mode TEST (profil CLI `nomaqbanq`) ; webhooks locaux via `stripe listen --forward-to localhost:3000/api/stripe/webhook`. Le prix est résolu au checkout par `products.stripe_price_lookup_key`, identique en test et en live → les 5 produits sont achetables en local sans configuration. Code promo test −100 % : `E2EPROMO100`
 - **Routes centralisees** : Modifier `constants/index.tsx` pour ajouter/changer URLs
 - **Hauteur uniforme cards** : Utiliser `h-full` + reserver espace pour elements optionnels
 - **URL state** : Deriver l'etat de l'URL, pas useState+useEffect

--- a/app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx
+++ b/app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx
@@ -36,7 +36,12 @@ import type {
   SelectableUser,
   UserPanelData,
 } from "@/features/users/dal"
-import { formatExpiration, formatMediumDate } from "@/lib/format"
+import {
+  formatCurrency,
+  formatExpiration,
+  formatMediumDate,
+  formatPresentmentAmount,
+} from "@/lib/format"
 import { cn } from "@/lib/utils"
 
 // Lazy-load ManualPaymentModal to reduce initial bundle size
@@ -163,15 +168,6 @@ function AccessCard({
 }
 
 function TransactionItem({ transaction }: { transaction: PanelTransaction }) {
-  const formatCurrency = (amount: number, currency: string) => {
-    return new Intl.NumberFormat("fr-CA", {
-      style: "currency",
-      currency: currency === "XAF" ? "XAF" : "CAD",
-      minimumFractionDigits: 0,
-      maximumFractionDigits: currency === "XAF" ? 0 : 2,
-    }).format(amount / 100)
-  }
-
   const statusConfig = {
     completed: {
       icon: Check,
@@ -213,9 +209,21 @@ function TransactionItem({ transaction }: { transaction: PanelTransaction }) {
           </p>
         </div>
       </div>
-      <span className="text-sm font-semibold text-gray-900 dark:text-white">
-        +{formatCurrency(transaction.amountPaid, transaction.currency)}
-      </span>
+      <div className="text-right">
+        <span className="text-sm font-semibold text-gray-900 dark:text-white">
+          +{formatCurrency(transaction.amountPaid, transaction.currency)}
+        </span>
+        {transaction.presentmentCurrency !== null &&
+          transaction.presentmentAmount !== null && (
+            <p className="text-xs text-gray-500">
+              présenté :{" "}
+              {formatPresentmentAmount(
+                transaction.presentmentAmount,
+                transaction.presentmentCurrency,
+              )}
+            </p>
+          )}
+      </div>
     </div>
   )
 }

--- a/app/api/cron/close-expired/route.ts
+++ b/app/api/cron/close-expired/route.ts
@@ -90,19 +90,23 @@ export async function GET(request: Request) {
     { deletedCount: 0 },
   )
 
-  const priceDrift = await run(
-    "dérive des prix catalogue",
-    "[cron:price-drift]",
-    auditProductPriceDrift,
-    { checked: 0, drifted: 0, failed: false },
-  )
-
   // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
   const notifications = await run(
     "notifications",
     "[cron:notifications]",
     sendPendingNotifications,
     { examResultsSent: 0, accessRemindersSent: 0 },
+  )
+
+  // EN DERNIER : seule tâche purement informative du lot, et seule à faire un
+  // aller-retour réseau hors Neon. L'appelant coupe à `--max-time 60` — ce qui
+  // peut être perdu ici est un rapport de dérive, pas une clôture d'examen ni un
+  // email en attente.
+  const priceDrift = await run(
+    "dérive des prix catalogue",
+    "[cron:price-drift]",
+    auditProductPriceDrift,
+    { checked: 0, drifted: 0, failed: false },
   )
 
   if (failed) return new Response("Cron handler error", { status: 500 })

--- a/app/api/cron/close-expired/route.ts
+++ b/app/api/cron/close-expired/route.ts
@@ -1,5 +1,6 @@
 import { closeExpiredExamParticipations } from "@/features/exams/cron"
 import { sendPendingNotifications } from "@/features/notifications/cron"
+import { auditProductPriceDrift } from "@/features/payments/cron"
 import { closeExpiredTrainingSessions } from "@/features/training/cron"
 import { anonymizeExpiredDeletedAccounts } from "@/features/users/cron"
 import { env } from "@/lib/env/server"
@@ -10,8 +11,9 @@ import { cleanupQuizRateLimits } from "@/lib/quiz-rate-limit"
 export const runtime = "nodejs"
 
 /**
- * Cron : ferme les participations d'examen et les sessions d'entraînement
- * expirées. Une seule route pour les deux tâches.
+ * Cron : clôtures (examens, entraînements), anonymisation RGPD, purge du
+ * rate-limit quiz, notifications en attente et audit de dérive des prix
+ * catalogue. Une seule route pour l'ensemble.
  *
  * Sécurité : l'appelant doit envoyer `Authorization: Bearer ${CRON_SECRET}`.
  * Fail-closed : sans `CRON_SECRET` configuré, on répond 401 (jamais ouvert).
@@ -88,6 +90,13 @@ export async function GET(request: Request) {
     { deletedCount: 0 },
   )
 
+  const priceDrift = await run(
+    "dérive des prix catalogue",
+    "[cron:price-drift]",
+    auditProductPriceDrift,
+    { checked: 0, drifted: 0, failed: false },
+  )
+
   // APRÈS les clôtures (pour inclure les `auto_submitted` du même run).
   const notifications = await run(
     "notifications",
@@ -120,5 +129,6 @@ export async function GET(request: Request) {
     anonymizedAccounts,
     notifications,
     quizRateLimitCleanup,
+    priceDrift,
   })
 }

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -77,9 +77,17 @@ export async function POST(request: Request) {
                 ? checkoutSession.payment_intent
                 : "",
             stripeEventId: event.id,
-            // Montant/devise réellement facturés (promo, Adaptive Pricing).
+            // Montant réellement facturé : un code promo fait diverger
+            // `amount_total` du prix catalogue. (Adaptive Pricing, lui, ne change
+            // PAS la devise de la session — voir `presentment_details` juste en
+            // dessous.)
             amountTotal: checkoutSession.amount_total,
             currency: checkoutSession.currency,
+            // Ce que le client a réellement vu et payé dans sa devise locale.
+            presentmentAmount:
+              checkoutSession.presentment_details?.presentment_amount,
+            presentmentCurrency:
+              checkoutSession.presentment_details?.presentment_currency,
           })
           if (result.status === "not_found") {
             // Transaction fantôme (payé sans pending en base) : anomalie réelle,

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,12 +1,18 @@
 import { attachDatabasePool } from "@vercel/functions"
 import { drizzle } from "drizzle-orm/node-postgres"
-import { Pool } from "pg"
 import { env } from "@/lib/env/server"
+import { NeonRetryPool } from "./retry-pool"
 import * as schema from "./schema"
 
 // One pool created at module scope, reused across requests (Vercel Fluid Compute).
 // Use the POOLED (-pooler) connection string for the runtime.
-const pool = new Pool({ connectionString: env.DATABASE_URL, max: 5 })
+// connectionTimeoutMillis borne l'acquisition (réveil Neon lent, file du pool
+// saturé) : erreur franche à 10 s au lieu d'un blocage indéfini.
+const pool = new NeonRetryPool({
+  connectionString: env.DATABASE_URL,
+  max: 5,
+  connectionTimeoutMillis: 10_000,
+})
 
 // Sans listener, une connexion idle coupée par Neon (reprise d'instance, reset
 // réseau) émet `error` sur le pool → uncaughtException fatale. Le pool remplace

--- a/db/retry-pool.ts
+++ b/db/retry-pool.ts
@@ -1,0 +1,62 @@
+import { Pool, type PoolClient, type PoolConfig } from "pg"
+
+// Codes pg émis par le proxy Neon pendant un réveil de compute : le refus de
+// « permit » (53300) et « the database system is starting up » (57P03). Ces
+// erreurs surviennent AVANT qu'une requête soit envoyée : rejouer l'acquisition
+// ne peut rien dupliquer, écritures comprises. Ne pas étendre ce retry aux
+// requêtes elles-mêmes — lui seul est inconditionnellement idempotent.
+const NEON_WAKEUP_CODES = new Set(["53300", "57P03"])
+
+export const isNeonWakeupError = (err: unknown): boolean =>
+  typeof err === "object" &&
+  err !== null &&
+  "code" in err &&
+  NEON_WAKEUP_CODES.has(String((err as { code: unknown }).code))
+
+const sleep = (ms: number) =>
+  ms > 0 ? new Promise((r) => setTimeout(r, ms)) : Promise.resolve()
+
+type RetryOptions = {
+  /** Attentes entre tentatives ; la longueur fixe le nombre de retries. */
+  backoffsMs?: readonly number[]
+}
+
+type ConnectCallback = (
+  err: Error | undefined,
+  client?: PoolClient,
+  release?: PoolClient["release"],
+) => void
+
+export class NeonRetryPool extends Pool {
+  private readonly backoffsMs: readonly number[]
+
+  constructor(config: PoolConfig, retry: RetryOptions = {}) {
+    super(config)
+    this.backoffsMs = retry.backoffsMs ?? [250, 1000]
+  }
+
+  private async connectWithRetry(): Promise<PoolClient> {
+    for (const backoff of this.backoffsMs) {
+      try {
+        return await super.connect()
+      } catch (err) {
+        if (!isNeonWakeupError(err)) throw err
+        await sleep(backoff)
+      }
+    }
+    return super.connect()
+  }
+
+  // `pool.query` (donc toute requête Drizzle one-shot) passe par la forme
+  // callback avec le contrat cb(undefined, client, client.release)
+  // (pg-pool/index.js:449) — à préserver à l'identique.
+  override connect(): Promise<PoolClient>
+  override connect(cb: ConnectCallback): void
+  override connect(cb?: ConnectCallback): Promise<PoolClient> | void {
+    if (!cb) return this.connectWithRetry()
+    this.connectWithRetry().then(
+      (client) => cb(undefined, client, client.release),
+      (err: Error) => cb(err),
+    )
+  }
+}

--- a/db/schema/payments.ts
+++ b/db/schema/payments.ts
@@ -32,6 +32,11 @@ export const products = pgTable(
     durationDays: integer("duration_days").notNull(),
     accessType: accessType("access_type").notNull(),
     stripeProductId: text("stripe_product_id").notNull(),
+    // Clé de prix Stripe, IDENTIQUE en test et en live — contrairement aux
+    // `price_…`, dont le préfixe n'encode pas le mode. C'est elle qui résout le
+    // prix au checkout ; `stripePriceId` n'est plus qu'un repli le temps de la
+    // bascule.
+    stripePriceLookupKey: text("stripe_price_lookup_key").notNull(),
     stripePriceId: text("stripe_price_id").notNull(),
     isActive: boolean("is_active").default(true).notNull(),
     isCombo: boolean("is_combo").default(false).notNull(),
@@ -66,6 +71,13 @@ export const transactions = pgTable(
     status: transactionStatus("status").notNull(),
     amountPaid: integer("amount_paid").notNull(), // cents
     currency: currency("currency").notNull(),
+    // Montant réellement présenté au client par Adaptive Pricing, dans SA devise.
+    // Texte libre et non l'enum `currency` : la conversion couvre plus de 150 pays,
+    // contraindre ici perdrait la donnée qu'on cherche à capturer. Nul quand le
+    // client a payé dans la devise d'intégration. Ces colonnes ne sont PAS
+    // comptables : `amountPaid`/`currency` restent le montant d'encaissement.
+    presentmentAmount: integer("presentment_amount"),
+    presentmentCurrency: text("presentment_currency"),
     stripeSessionId: text("stripe_session_id"),
     stripePaymentIntentId: text("stripe_payment_intent_id"),
     stripeEventId: text("stripe_event_id"), // idempotence (unique below)

--- a/docs/superpowers/plans/2026-08-18-pool-neon-retry.md
+++ b/docs/superpowers/plans/2026-08-18-pool-neon-retry.md
@@ -1,0 +1,278 @@
+# Résilience du pool pg aux réveils Neon — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retenter l'acquisition de connexion sur les erreurs de réveil Neon (53300/57P03) et borner tout connect à 10 s, pour que `NOMAQBANQ-1F` devienne un délai de ~300 ms au lieu d'un écran d'erreur.
+
+**Architecture:** `db/retry-pool.ts` expose `NeonRetryPool extends Pool` (surcharge de `connect()`, promesse ET callback) + le prédicat `isNeonWakeupError`. `db/index.ts` l'instancie avec `connectionTimeoutMillis: 10_000`. Aucun autre fichier applicatif ne change.
+
+**Tech Stack:** pg / pg-pool 3.x · Drizzle · Vitest (projet frontend).
+
+**Spec :** `docs/superpowers/specs/2026-08-18-pool-neon-retry-design.md`
+**Branche :** `fix/pool-neon-retry`
+
+---
+
+## Task 1 : `NeonRetryPool`
+
+**Files:**
+- Create: `db/retry-pool.ts`
+- Test: `tests/db/RetryPool.test.ts` (créer)
+- Modify: `db/index.ts:9`
+
+- [ ] **Step 1 : Écrire les tests qui échouent**
+
+```ts
+import { Pool } from "pg"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NeonRetryPool, isNeonWakeupError } from "@/db/retry-pool"
+
+const pgError = (code: string) =>
+  Object.assign(new Error(`pg ${code}`), { code })
+
+// Client minimal : seule `release` est consommée par pg-pool/drizzle.
+const fakeClient = () => ({ release: vi.fn() }) as never
+
+const makePool = () =>
+  new NeonRetryPool(
+    { connectionString: "postgres://test@localhost/test" },
+    { backoffsMs: [0, 0] },
+  )
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("isNeonWakeupError", () => {
+  it("reconnaît 53300 et 57P03, refuse le reste", () => {
+    expect(isNeonWakeupError(pgError("53300"))).toBe(true)
+    expect(isNeonWakeupError(pgError("57P03"))).toBe(true)
+    expect(isNeonWakeupError(pgError("28P01"))).toBe(false)
+    expect(isNeonWakeupError(new Error("timeout exceeded"))).toBe(false)
+    expect(isNeonWakeupError(null)).toBe(false)
+  })
+})
+
+describe("NeonRetryPool", () => {
+  it("réussit au 3e essai quand Neon refuse deux permits", async () => {
+    const client = fakeClient()
+    const spy = vi
+      .spyOn(Pool.prototype, "connect")
+      .mockRejectedValueOnce(pgError("53300"))
+      .mockRejectedValueOnce(pgError("53300"))
+      .mockResolvedValueOnce(client)
+
+    await expect(makePool().connect()).resolves.toBe(client)
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  it("abandonne après épuisement des retries", async () => {
+    const spy = vi
+      .spyOn(Pool.prototype, "connect")
+      .mockRejectedValue(pgError("53300"))
+
+    await expect(makePool().connect()).rejects.toMatchObject({ code: "53300" })
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  it("ne retente pas une erreur étrangère au réveil", async () => {
+    const spy = vi
+      .spyOn(Pool.prototype, "connect")
+      .mockRejectedValue(pgError("28P01"))
+
+    await expect(makePool().connect()).rejects.toMatchObject({ code: "28P01" })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it("retente aussi 57P03 (database system is starting up)", async () => {
+    const client = fakeClient()
+    vi.spyOn(Pool.prototype, "connect")
+      .mockRejectedValueOnce(pgError("57P03"))
+      .mockResolvedValueOnce(client)
+
+    await expect(makePool().connect()).resolves.toBe(client)
+  })
+
+  it("préserve le contrat callback de pg-pool après un retry", async () => {
+    const client = fakeClient()
+    vi.spyOn(Pool.prototype, "connect")
+      .mockRejectedValueOnce(pgError("53300"))
+      .mockResolvedValueOnce(client)
+
+    const cb = vi.fn()
+    makePool().connect(cb)
+
+    await vi.waitFor(() =>
+      expect(cb).toHaveBeenCalledWith(undefined, client, client.release),
+    )
+  })
+
+  it("propage l'échec à la forme callback", async () => {
+    vi.spyOn(Pool.prototype, "connect").mockRejectedValue(pgError("53300"))
+
+    const cb = vi.fn()
+    makePool().connect(cb)
+
+    await vi.waitFor(() =>
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({ code: "53300" })),
+    )
+  })
+})
+```
+
+> Le stub porte sur `Pool.prototype.connect` (le `super.connect` de la
+> sous-classe) : aucun réseau, aucun fake timer — les backoffs injectés valent 0.
+
+- [ ] **Step 2 : Vérifier l'échec**
+
+```bash
+bunx vitest run --project frontend tests/db/RetryPool.test.ts
+```
+
+Attendu : ÉCHEC — `Cannot find module '@/db/retry-pool'`.
+
+- [ ] **Step 3 : Écrire `db/retry-pool.ts`**
+
+```ts
+import { Pool, type PoolClient, type PoolConfig } from "pg"
+
+// Codes pg émis par le proxy Neon pendant un réveil de compute : le refus de
+// « permit » (53300, prouvé sur NOMAQBANQ-1F) et « the database system is
+// starting up » (57P03). Ces erreurs surviennent AVANT qu'une requête soit
+// envoyée : rejouer l'acquisition ne peut rien dupliquer, écritures comprises.
+const NEON_WAKEUP_CODES = new Set(["53300", "57P03"])
+
+export const isNeonWakeupError = (err: unknown): boolean =>
+  typeof err === "object" &&
+  err !== null &&
+  "code" in err &&
+  NEON_WAKEUP_CODES.has(String((err as { code: unknown }).code))
+
+const sleep = (ms: number) =>
+  ms > 0 ? new Promise((r) => setTimeout(r, ms)) : Promise.resolve()
+
+type RetryOptions = {
+  /** Attentes entre tentatives ; la longueur fixe le nombre de retries. */
+  backoffsMs?: readonly number[]
+}
+
+type ConnectCallback = (
+  err: Error | undefined,
+  client?: PoolClient,
+  release?: PoolClient["release"],
+) => void
+
+export class NeonRetryPool extends Pool {
+  private readonly backoffsMs: readonly number[]
+
+  constructor(config: PoolConfig, retry: RetryOptions = {}) {
+    super(config)
+    this.backoffsMs = retry.backoffsMs ?? [250, 1000]
+  }
+
+  private async connectWithRetry(): Promise<PoolClient> {
+    for (const backoff of this.backoffsMs) {
+      try {
+        return await super.connect()
+      } catch (err) {
+        if (!isNeonWakeupError(err)) throw err
+        await sleep(backoff)
+      }
+    }
+    return super.connect()
+  }
+
+  // pg-pool appelle connect(cb) depuis pool.query (pg-pool/index.js:449) avec
+  // le contrat cb(undefined, client, client.release) — à préserver à
+  // l'identique, sinon toutes les requêtes one-shot de Drizzle cassent.
+  override connect(): Promise<PoolClient>
+  override connect(cb: ConnectCallback): void
+  override connect(cb?: ConnectCallback): Promise<PoolClient> | void {
+    if (!cb) return this.connectWithRetry()
+    this.connectWithRetry().then(
+      (client) => cb(undefined, client, client.release),
+      (err: Error) => cb(err),
+    )
+  }
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+bunx vitest run --project frontend tests/db/RetryPool.test.ts
+```
+
+Attendu : 7 tests PASS.
+
+- [ ] **Step 5 : Discriminance**
+
+Dans `retry-pool.ts`, remplacer temporairement le corps de `connectWithRetry`
+par `return super.connect()`. Attendu : les tests « réussit au 3e essai »,
+« retente aussi 57P03 » et les deux tests callback ÉCHOUENT. Restaurer.
+
+- [ ] **Step 6 : Brancher `db/index.ts`**
+
+```diff
+-import { Pool } from "pg"
++import { NeonRetryPool } from "@/db/retry-pool"
+ …
+-const pool = new Pool({ connectionString: env.DATABASE_URL, max: 5 })
++// connectionTimeoutMillis borne l'acquisition (réveil Neon lent, file du pool
++// saturé) : erreur franche à 10 s au lieu d'un blocage indéfini.
++const pool = new NeonRetryPool({
++  connectionString: env.DATABASE_URL,
++  max: 5,
++  connectionTimeoutMillis: 10_000,
++})
+```
+
+(adapter à la forme exacte du fichier ; `pool.on("error")` et
+`attachDatabasePool` restent inchangés)
+
+- [ ] **Step 7 : Gate + suites + commit**
+
+```bash
+bun run check
+bun run test
+bun run test:integration
+git add db/ tests/db/
+git commit -m "fix(db): retenter l'acquisition de connexion sur réveil Neon (53300/57P03)"
+```
+
+L'intégration valide le pool réel sur branche Neon éphémère (le retry est
+transparent quand tout va bien).
+
+## Task 2 : Règle + validation finale
+
+**Files:**
+- Modify: `.claude/rules/data-layer.md` (règle « jamais d'appel au db global »)
+
+- [ ] **Step 1 : Mettre à jour la règle**
+
+Dans la règle « Jamais d'appel au `db` global depuis une fonction exécutée dans
+une transaction », remplacer « le pool est à `max: 5` **sans**
+`connectionTimeoutMillis` (`db/index.ts`), donc réclamer une 2ᵉ connexion
+pendant qu'on en détient une fige la requête indéfiniment » par :
+
+```markdown
+le pool est à `max: 5` avec `connectionTimeoutMillis: 10_000` (`db/index.ts`),
+donc réclamer une 2ᵉ connexion pendant qu'on en détient une bloque 10 s puis
+échoue — mieux qu'avant (blocage indéfini), mais toujours un bug à corriger à
+la source. Le pool retente par ailleurs l'ACQUISITION sur les erreurs de réveil
+Neon 53300/57P03 (`db/retry-pool.ts`) — sûr car aucune requête n'est encore
+partie ; ne pas étendre ce retry aux requêtes elles-mêmes
+```
+
+- [ ] **Step 2 : Format + commit**
+
+```bash
+bun run format:check
+git add .claude/rules/data-layer.md
+git commit -m "docs(rules): pool borné à 10 s + retry d'acquisition Neon"
+```
+
+- [ ] **Step 3 : Après merge + déploiement**
+
+`sentry issue resolve NOMAQBANQ-1F`. Signal de succès : plus de 500
+« Failed query … 53300 » dans les logs Vercel aux réveils. Rappel : le trou
+Sentry serveur n'étant pas encore bouché, croiser avec les logs Vercel
+(rétention ~1 h), pas seulement avec Sentry.

--- a/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
+++ b/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
@@ -51,10 +51,21 @@
     `exam_access_promo` 20000 · `training_access_promo` 20000 · `exam_access` 5000
     · `training_access` 5000. Croisé avec la base de dev : **aucune dérive**, et
     les 5 `stripe_price_id` de dev sont bien des prix de test.
-  - ⛔ **MODE LIVE — non vérifié.** Le profil CLI `nomaqbanq` n'a pas de clé live
-    (`stripe whoami` → `live_mode_key.available: false`) et le serveur MCP Stripe
-    n'est pas authentifié. **C'est le seul prérequis encore ouvert**, et c'est
-    celui qui compte : la migration s'appliquera à la base de production.
+  - ✅ **MODE LIVE — vérifié, conforme.** 5 prix actifs, les 5 `lookup_key`
+    attendues, tous en `cad`, montants identiques au mode test. Les `prod_…`
+    correspondent au tableau du commentaire d'issue du 2026-08-06 : la prémisse de
+    la migration est établie.
+  - ⚠️ **Non vérifié : `products.price_cad` en PRODUCTION.** Seule la base de dev a
+    été croisée (aucune dérive). Les montants live de Stripe concordent avec la
+    base de dev, donc la prod est conforme *si* sa table `products` porte les mêmes
+    valeurs — ce qui n'a pas été établi faute d'accès à cette base. Sans
+    conséquence sur la migration (le backfill ne dépend que de `code`) : c'est la
+    tâche cron qui le dira dès le premier passage.
+
+- [x] **Permission `prices:read` — vérifiée le 2026-08-21.** La clé restreinte live
+  utilisée par l'application (`nomaqbanq-prod-app`) a reçu « Prices Read » ; la
+  lecture ci-dessus, faite avec elle, le prouve. Reste à confirmer que c'est bien
+  cette clé qui alimente `STRIPE_SECRET_KEY` sur Vercel en production.
 
 - [ ] **Vérifier la permission de la clé Stripe runtime.** `prices.list` exige la lecture sur Prices, ce que la création d'une session avec un price ID n'exigeait pas. Si `STRIPE_SECRET_KEY` (Vercel + `.env.local`) porte une clé restreinte `rk_`, ajouter `prices:read` **avant** de déployer, sinon tous les checkouts tombent en `permission_error`. Une clé `sk_` a la permission par défaut.
 

--- a/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
+++ b/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
@@ -38,12 +38,23 @@
   Attendu : dans CHACUNE des deux listes, un prix actif dont `lookup_key` vaut
   exactement `exam_access`, `training_access`, `exam_access_promo`,
   `training_access_promo`, `premium_access`. Noter aussi les `unit_amount` — ce
-  sont eux qui devront concorder avec `products.price_cad` (attendu au 2026-08-06 :
-  35000 / 20000 / 20000 / 5000 / 5000 en cents).
+  sont eux qui devront concorder avec `products.price_cad`.
 
   **Si une seule clé manque ou diffère : ne pas lancer la migration.** Poser la
   `lookup_key` manquante sur le prix concerné (`transfer_lookup_key=true` si elle
   est portée par un ancien prix), puis recommencer la vérification.
+
+  **État au 2026-08-21 :**
+
+  - ✅ **MODE TEST — vérifié, conforme.** 5 prix actifs, portant exactement les 5
+    `lookup_key` attendues, tous en `cad`, montants `premium_access` 35000 ·
+    `exam_access_promo` 20000 · `training_access_promo` 20000 · `exam_access` 5000
+    · `training_access` 5000. Croisé avec la base de dev : **aucune dérive**, et
+    les 5 `stripe_price_id` de dev sont bien des prix de test.
+  - ⛔ **MODE LIVE — non vérifié.** Le profil CLI `nomaqbanq` n'a pas de clé live
+    (`stripe whoami` → `live_mode_key.available: false`) et le serveur MCP Stripe
+    n'est pas authentifié. **C'est le seul prérequis encore ouvert**, et c'est
+    celui qui compte : la migration s'appliquera à la base de production.
 
 - [ ] **Vérifier la permission de la clé Stripe runtime.** `prices.list` exige la lecture sur Prices, ce que la création d'une session avec un price ID n'exigeait pas. Si `STRIPE_SECRET_KEY` (Vercel + `.env.local`) porte une clé restreinte `rk_`, ajouter `prices:read` **avant** de déployer, sinon tous les checkouts tombent en `permission_error`. Une clé `sk_` a la permission par défaut.
 

--- a/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
+++ b/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
@@ -1,0 +1,1430 @@
+# Catalogue Stripe par `lookup_key` — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendre impossible la classe de bug « identifiant Stripe du mauvais mode », détecter automatiquement la dérive entre le prix affiché et le prix facturé, et persister le montant réellement présenté au client par Adaptive Pricing.
+
+**Architecture:** Le checkout ne lit plus un `stripe_price_id` opaque en base : il résout le prix via `prices.list({ lookup_keys })`, une clé identique en test et en live. La comparaison `unit_amount` ↔ `products.priceCad` devient gratuite à cet endroit, et une tâche cron la rejoue sur les produits que personne n'achète. En parallèle, `checkoutSession.presentment_details` est persisté au fulfillment dans deux colonnes nullables et affiché au panneau admin.
+
+**Tech Stack:** Next.js 16 (App Router) · Drizzle ORM · Neon Postgres · Stripe SDK 22.4.0 (API `2026-07-29.dahlia`) · Vitest · Sentry.
+
+**Spec:** [`docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md`](../specs/2026-08-21-stripe-catalogue-lookup-key-design.md) · Issue [#138](https://github.com/RinKhimera/NOMAQbanq/issues/138)
+
+**Branche:** `feat/stripe-catalogue-lookup-key` (déjà créée, le spec y est commité).
+
+---
+
+## Prérequis avant de commencer
+
+- [ ] **Vérifier la permission de la clé Stripe runtime.** `prices.list` exige la lecture sur Prices, ce que la création d'une session avec un price ID n'exigeait pas. Si `STRIPE_SECRET_KEY` (Vercel + `.env.local`) porte une clé restreinte `rk_`, ajouter `prices:read` **avant** de déployer, sinon tous les checkouts tombent en `permission_error`. Une clé `sk_` a la permission par défaut.
+
+Cette vérification ne bloque pas l'écriture du code (les tests moquent Stripe), mais elle bloque le déploiement.
+
+---
+
+## Structure des fichiers
+
+| Fichier | Responsabilité | Action |
+| --- | --- | --- |
+| `db/schema/payments.ts` | Colonnes `stripe_price_lookup_key`, `presentment_amount`, `presentment_currency` | Modifier |
+| `drizzle/0013_*.sql` | Migration : ajout + backfill + `SET NOT NULL` | Créer (généré puis édité) |
+| `features/payments/catalog.ts` | Résolution d'un prix par `lookup_key` et description d'une dérive. Deux fonctions, aucune dépendance à la base | Créer |
+| `features/payments/actions.ts` | `createStripeCheckout` résout le prix et signale la dérive | Modifier |
+| `features/payments/cron.ts` | Tâche `auditProductPriceDrift` : dérive sur les produits actifs | Créer |
+| `app/api/cron/close-expired/route.ts` | Branchement de la tâche dans le dispatcher | Modifier |
+| `features/payments/stripe.ts` | `completeStripeTransaction` persiste `presentment_*` | Modifier |
+| `app/api/stripe/webhook/route.ts` | Transmet `presentment_details` au fulfillment | Modifier |
+| `lib/format.ts` | `formatPresentmentAmount` (unité mineure d'une devise arbitraire) | Modifier |
+| `features/users/dal.ts` | `PanelTransaction` porte les deux champs | Modifier |
+| `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx` | Affiche le montant présenté | Modifier |
+| `features/payments/dal.ts` | `ProductView` perd `stripePriceId` / `stripeProductId` | Modifier |
+
+`catalog.ts` est un module neuf plutôt qu'un ajout à `lib.ts` : ses deux fonctions ne touchent ni la base ni la session, elles ne parlent qu'à Stripe. Les garder isolées les rend testables sans monter le moindre mock de Drizzle, et `lib.ts` est déjà le module de l'octroi d'accès — une responsabilité sans rapport.
+
+---
+
+## Task 1 : Colonnes et migration
+
+**Files:**
+- Modify: `db/schema/payments.ts:35` (products), `db/schema/payments.ts:66-70` (transactions)
+- Create: `drizzle/0013_<nom-généré>.sql`
+- Modify: tous les inserts `products` des tests (~20 fichiers)
+
+- [ ] **Step 1 : Ajouter les trois colonnes au schéma**
+
+Dans `db/schema/payments.ts`, table `products`, juste après `stripeProductId` :
+
+```ts
+    stripeProductId: text("stripe_product_id").notNull(),
+    stripePriceLookupKey: text("stripe_price_lookup_key").notNull(),
+    stripePriceId: text("stripe_price_id").notNull(),
+```
+
+`stripePriceId` reste : sa suppression est un PR de suivi (expand/contract — voir la section Déploiement en fin de plan).
+
+Dans la même table `transactions`, juste après `currency` :
+
+```ts
+    currency: currency("currency").notNull(),
+    // Montant réellement présenté au client par Adaptive Pricing, dans SA devise.
+    // Texte libre et non l'enum `currency` : la conversion couvre plus de
+    // 150 pays, contraindre ici perdrait la donnée qu'on cherche à capturer.
+    // Nul quand le client a payé dans la devise d'intégration (CAD).
+    presentmentAmount: integer("presentment_amount"),
+    presentmentCurrency: text("presentment_currency"),
+```
+
+- [ ] **Step 2 : Générer la migration**
+
+Run: `bun run db:generate`
+Expected: création de `drizzle/0013_<mot>_<mot>.sql` et mise à jour de `drizzle/meta/_journal.json`.
+
+- [ ] **Step 3 : Corriger la migration à la main**
+
+Drizzle génère `ADD COLUMN "stripe_price_lookup_key" text NOT NULL`, qui **échoue** sur une table non vide. Remplacer intégralement le contenu du fichier généré par :
+
+```sql
+-- `lookup_key` : clé de prix Stripe, IDENTIQUE en test et en live (contrairement
+-- aux `price_…`). Le catalogue Stripe a été annoté avec la même chaîne que
+-- `products.code` dans les deux modes, d'où le backfill ci-dessous.
+ALTER TABLE "products" ADD COLUMN "stripe_price_lookup_key" text;--> statement-breakpoint
+UPDATE "products" SET "stripe_price_lookup_key" = "code"::text;--> statement-breakpoint
+ALTER TABLE "products" ALTER COLUMN "stripe_price_lookup_key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "presentment_amount" integer;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "presentment_currency" text;
+```
+
+Le `::text` n'est pas décoratif : `code` est de type `product_code` (enum Postgres), et l'affectation directe d'un enum à une colonne `text` n'est pas garantie sans cast explicite.
+
+Ne pas toucher à `drizzle/meta/_journal.json` ni au dossier `drizzle/meta/` : le fichier est déjà enregistré par `db:generate`.
+
+- [ ] **Step 4 : Mettre à jour les inserts `products` des tests**
+
+Les tests d'intégration tournent sur une branche Neon migrée : la colonne `NOT NULL` casse tous leurs inserts. Ajouter le champ partout, avec la même valeur que `stripePriceId` (aucun test de cette vague ne résout de prix, la valeur n'a pas d'importance) :
+
+Run:
+```bash
+find tests -name '*.ts' -exec sed -i -E 's/^(\s*)stripePriceId: (.+),$/\1stripePriceId: \2,\n\1stripePriceLookupKey: \2,/' {} +
+```
+
+Expected: ~20 fichiers modifiés. Vérifier avec `git diff --stat tests/`.
+
+`tests/components/payments/PricingGrid.test.tsx` n'est **pas** touché (extension `.tsx`) : il moque un `ProductView`, dont les champs Stripe disparaissent en Task 7.
+
+- [ ] **Step 5 : Appliquer la migration en dev**
+
+Run: `bun run db:migrate`
+Expected: `[✓] migrations applied successfully!`
+
+- [ ] **Step 6 : Vérifier le backfill**
+
+Run:
+```bash
+bun -e 'import {db} from "./db"; import {products} from "./db/schema"; console.table(await db.select({code: products.code, lk: products.stripePriceLookupKey}).from(products))'
+```
+Expected: 5 lignes, `lk` égal à `code` sur chacune (`exam_access`, `training_access`, `exam_access_promo`, `training_access_promo`, `premium_access`).
+
+- [ ] **Step 7 : Type-check**
+
+Run: `bunx tsc --noEmit`
+Expected: aucune erreur.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add db/schema/payments.ts drizzle/ tests/
+git commit -m "feat(db): lookup_key de prix Stripe et colonnes presentment"
+```
+
+---
+
+## Task 2 : Module `catalog.ts` — résolution et dérive
+
+**Files:**
+- Create: `features/payments/catalog.ts`
+- Test: `tests/features/payments-catalog.test.ts`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `tests/features/payments-catalog.test.ts` :
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+import {
+  describePriceDrift,
+  resolveStripePrice,
+} from "@/features/payments/catalog"
+
+// `describePriceDrift` est pur : c'est lui qui décide si le prix affiché en base
+// et le prix que Stripe facturera racontent la même chose. Chaque cas est écrit
+// par paire — une version qui concorde, une version qui diverge — sinon rien ne
+// prouve que la comparaison mord réellement.
+const PRICE = {
+  id: "price_1",
+  unit_amount: 5000,
+  currency: "cad",
+} as const
+
+describe("describePriceDrift", () => {
+  it("montant et devise concordants → aucune dérive", () => {
+    expect(describePriceDrift(5000, PRICE)).toBeNull()
+  })
+
+  it("montant divergent → dérive décrite avec les deux valeurs", () => {
+    const drift = describePriceDrift(3000, PRICE)
+    expect(drift).toContain("5000")
+    expect(drift).toContain("3000")
+  })
+
+  it("devise du prix Stripe ≠ cad → dérive", () => {
+    expect(describePriceDrift(5000, { ...PRICE, currency: "usd" })).toContain(
+      "usd",
+    )
+  })
+
+  it("unit_amount null (prix à montant libre) → dérive, pas de crash", () => {
+    expect(
+      describePriceDrift(5000, { ...PRICE, unit_amount: null }),
+    ).not.toBeNull()
+  })
+})
+
+describe("resolveStripePrice", () => {
+  it("interroge Stripe sur la clé, en prix actifs seulement", async () => {
+    const list = vi.fn(async () => ({ data: [PRICE] }))
+    const stripe = { prices: { list } } as never
+
+    const price = await resolveStripePrice(stripe, "exam_access")
+
+    expect(price).toEqual(PRICE)
+    expect(list).toHaveBeenCalledWith({
+      lookup_keys: ["exam_access"],
+      active: true,
+      limit: 2,
+    })
+  })
+
+  it("aucun prix actif pour la clé → null (et non une exception)", async () => {
+    const stripe = { prices: { list: async () => ({ data: [] }) } } as never
+    expect(await resolveStripePrice(stripe, "inconnu")).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `bun run test tests/features/payments-catalog.test.ts`
+Expected: FAIL — `Failed to resolve import "@/features/payments/catalog"`.
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Créer `features/payments/catalog.ts` :
+
+```ts
+import "server-only"
+import type Stripe from "stripe"
+
+type PriceShape = Pick<Stripe.Price, "id" | "unit_amount" | "currency">
+
+/**
+ * Résout le prix Stripe d'un produit par sa `lookup_key`. Contrairement à un
+ * `price_…`, une `lookup_key` est identique en test et en live : c'est ce qui
+ * rend impossible l'usage d'un identifiant du mauvais mode. Stripe garantit
+ * l'unicité de la clé parmi les prix actifs (`transfer_lookup_key` la déplace
+ * sur le nouveau prix lors d'un changement de tarif) — `limit: 2` laisse
+ * néanmoins voir une éventuelle anomalie plutôt que de la masquer.
+ *
+ * `null` = aucun prix actif ne porte cette clé dans le mode de la clé API.
+ */
+export const resolveStripePrice = async (
+  stripe: Stripe,
+  lookupKey: string,
+): Promise<Stripe.Price | null> => {
+  const { data } = await stripe.prices.list({
+    lookup_keys: [lookupKey],
+    active: true,
+    limit: 2,
+  })
+  return data[0] ?? null
+}
+
+/**
+ * Écart entre le prix AFFICHÉ (`products.priceCad`, en cents, lu par la grille
+ * tarifaire et les paywalls) et le prix que Stripe FACTURERA. Les deux vivent
+ * dans des systèmes différents ; sans cette comparaison, une modification de
+ * tarif au dashboard non répercutée en base laisse le client lire un montant et
+ * en payer un autre.
+ *
+ * `null` = ils concordent. Sinon, une description prête à partir dans Sentry.
+ */
+export const describePriceDrift = (
+  priceCad: number,
+  price: PriceShape,
+): string | null => {
+  const parts: string[] = []
+  if (price.currency !== "cad") {
+    parts.push(`devise Stripe ${price.currency} ≠ cad`)
+  }
+  if (price.unit_amount !== priceCad) {
+    parts.push(`montant Stripe ${price.unit_amount ?? "null"} ≠ base ${priceCad}`)
+  }
+  return parts.length > 0 ? `${price.id} : ${parts.join(" · ")}` : null
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `bun run test tests/features/payments-catalog.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add features/payments/catalog.ts tests/features/payments-catalog.test.ts
+git commit -m "feat(payments): résolution de prix Stripe par lookup_key et détection de dérive"
+```
+
+---
+
+## Task 3 : Checkout — résolution par `lookup_key`
+
+**Files:**
+- Modify: `features/payments/actions.ts:335-415`
+- Test: `tests/features/payments-actions.test.ts`, `tests/integration/payments-checkout.test.ts`
+
+- [ ] **Step 1 : Étendre les mocks du test unitaire**
+
+Dans `tests/features/payments-actions.test.ts`, ajouter au bloc `vi.hoisted` (après `checkoutCreate`) :
+
+```ts
+    pricesList:
+      vi.fn<
+        () => Promise<{
+          data: { id: string; unit_amount: number | null; currency: string }[]
+        }>
+      >(),
+```
+
+Étendre le mock du client Stripe :
+
+```ts
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    checkout: { sessions: { create: mocks.checkoutCreate } },
+    customers: { list: mocks.customersList },
+    billingPortal: { sessions: { create: mocks.portalCreate } },
+    prices: { list: mocks.pricesList },
+  }),
+}))
+```
+
+Remplacer `stripePriceId` par `stripePriceLookupKey` dans `ACTIVE_PRODUCT` :
+
+```ts
+const ACTIVE_PRODUCT = {
+  id: "p1",
+  stripePriceLookupKey: "exam_access",
+  priceCad: 5000,
+  accessType: "exam",
+  durationDays: 90,
+  isCombo: false,
+  isActive: true,
+}
+```
+
+Et donner une résolution par défaut dans le `beforeEach` existant (`clearMocks: true` efface les appels, pas l'implémentation posée ici) :
+
+```ts
+beforeEach(() => {
+  mocks.productRows.current = [ACTIVE_PRODUCT]
+  mocks.pricesList.mockResolvedValue({
+    data: [{ id: "price_resolved", unit_amount: 5000, currency: "cad" }],
+  })
+})
+```
+
+- [ ] **Step 2 : Écrire les tests qui échouent**
+
+Ajouter dans le `describe("createStripeCheckout", …)` de `tests/features/payments-actions.test.ts` :
+
+```ts
+  it("facture le prix résolu par lookup_key, pas un identifiant stocké", async () => {
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+    await createStripeCheckout(input)
+
+    expect(mocks.pricesList).toHaveBeenCalledWith({
+      lookup_keys: ["exam_access"],
+      active: true,
+      limit: 2,
+    })
+    const arg = mocks.checkoutCreate.mock.calls[0]![0] as unknown as {
+      line_items: { price: string }[]
+    }
+    expect(arg.line_items[0].price).toBe("price_resolved")
+  })
+
+  it("lookup_key sans prix actif → produit mal configuré, aucune session", async () => {
+    mocks.pricesList.mockResolvedValue({ data: [] })
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({
+      error: "Ce produit est mal configuré. Contactez le support.",
+    })
+    expect(mocks.checkoutCreate).not.toHaveBeenCalled()
+    expect(mocks.insertValues).not.toHaveBeenCalled()
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  // Le prix affiché vient de la base, le prix facturé vient de Stripe. Un écart
+  // doit ALERTER sans bloquer : couper les ventes d'un produit sur une erreur
+  // d'ops coûte plus cher que l'écart lui-même.
+  it("prix Stripe divergent → alerte mais la vente aboutit", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [{ id: "price_resolved", unit_amount: 9900, currency: "cad" }],
+    })
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/pay" })
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  it("prix Stripe conforme → aucune alerte", async () => {
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+    await createStripeCheckout(input)
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 3 : Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `bun run test tests/features/payments-actions.test.ts`
+Expected: FAIL — `mocks.pricesList` jamais appelé, `line_items[0].price` vaut `undefined`.
+
+- [ ] **Step 4 : Implémenter**
+
+Dans `features/payments/actions.ts`, ajouter l'import (bloc `@/` de l'ordre Prettier) :
+
+```ts
+import { describePriceDrift, resolveStripePrice } from "./catalog"
+```
+
+Remplacer le champ sélectionné (`features/payments/actions.ts:341`) :
+
+```ts
+      stripePriceLookupKey: products.stripePriceLookupKey,
+```
+
+Dans le `try`, entre `const base = appBase()` et `stripe.checkout.sessions.create` :
+
+```ts
+    const price = await resolveStripePrice(
+      stripe,
+      product.stripePriceLookupKey,
+    )
+    if (!price) {
+      captureServerError(
+        "[createStripeCheckout]",
+        new Error("aucun prix actif pour cette lookup_key"),
+        {
+          userId: session.user.id,
+          detail: `lookup_key ${product.stripePriceLookupKey} absente du mode de la clé active (produit ${productCode})`,
+        },
+      )
+      return { error: "Ce produit est mal configuré. Contactez le support." }
+    }
+
+    // Le client a vu `priceCad` sur la grille tarifaire ; Stripe encaissera
+    // `price.unit_amount`. On alerte sans bloquer : une vente refusée sur une
+    // erreur de configuration coûte plus cher que l'écart.
+    const drift = describePriceDrift(product.priceCad, price)
+    if (drift) {
+      captureServerError(
+        "[createStripeCheckout]",
+        new Error("prix affiché divergent du prix Stripe"),
+        { userId: session.user.id, detail: `produit ${productCode} · ${drift}` },
+      )
+    }
+```
+
+Puis remplacer la ligne `line_items` :
+
+```ts
+      line_items: [{ price: price.id, quantity: 1 }],
+```
+
+Enfin, remplacer le commentaire du bloc `isStripeResourceMissing` (`features/payments/actions.ts:399-404`) — il décrit un mécanisme qui n'existe plus :
+
+```ts
+    // `resource_missing` à la CRÉATION de la session (≠ verifyStripeCheckout, où
+    // il vient d'une URL périmée). Le prix étant désormais résolu en amont, ce
+    // cas ne peut plus venir d'un identifiant du mauvais mode : il signale un
+    // objet Stripe supprimé entre la résolution et la création.
+```
+
+- [ ] **Step 5 : Lancer les tests pour vérifier qu'ils passent**
+
+Run: `bun run test tests/features/payments-actions.test.ts`
+Expected: PASS, tous les tests du fichier — y compris les anciens (`safePath`, produit désactivé…), qui doivent continuer à passer sans modification.
+
+- [ ] **Step 6 : Adapter le test d'intégration du checkout**
+
+Dans `tests/integration/payments-checkout.test.ts` :
+
+Ajouter le mock de `prices.list` au bloc `vi.hoisted` :
+
+```ts
+    pricesList: vi.fn(async () => ({
+      data: [{ id: "price_resolved", unit_amount: 5000, currency: "cad" }],
+    })),
+```
+
+Étendre le mock Stripe :
+
+```ts
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    checkout: { sessions: { create: mocks.create } },
+    prices: { list: mocks.pricesList },
+  }),
+}))
+```
+
+Le `db.insert(products)` du `beforeAll` porte déjà `stripePriceLookupKey` depuis la Task 1 — vérifier que c'est bien le cas, sinon l'ajouter.
+
+Ajouter le test qui prouve qu'aucun `pending` n'est créé quand la clé ne résout rien :
+
+```ts
+  it("lookup_key sans prix actif → aucune transaction pending créée", async () => {
+    mocks.create.mockClear()
+    mocks.pricesList.mockResolvedValueOnce({ data: [] })
+
+    const before = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_ID))
+
+    const res = await createStripeCheckout({
+      productCode: "exam_access",
+      successPath: "/tableau-de-bord",
+      cancelPath: "/tarifs",
+    })
+
+    expect(res).toEqual({
+      error: "Ce produit est mal configuré. Contactez le support.",
+    })
+    expect(mocks.create).not.toHaveBeenCalled()
+
+    const after = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_ID))
+    expect(after.length).toBe(before.length)
+  })
+```
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add features/payments/actions.ts tests/features/payments-actions.test.ts tests/integration/payments-checkout.test.ts
+git commit -m "feat(payments): résoudre le prix au checkout par lookup_key et alerter sur la dérive"
+```
+
+---
+
+## Task 4 : Tâche cron d'audit de dérive
+
+**Files:**
+- Create: `features/payments/cron.ts`
+- Modify: `app/api/cron/close-expired/route.ts`
+- Test: `tests/features/payments-cron.test.ts`, `tests/features/cron-close-expired.test.ts`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `tests/features/payments-cron.test.ts` :
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { auditProductPriceDrift } from "@/features/payments/cron"
+
+// La vérification au checkout ne voit que les produits qu'on achète. Cette tâche
+// couvre ceux qui dorment — un produit peu demandé peut dériver des semaines.
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    productRows: { current: [] as unknown[] },
+    pricesList:
+      vi.fn<
+        () => Promise<{
+          data: {
+            id: string
+            lookup_key: string | null
+            unit_amount: number | null
+            currency: string
+          }[]
+        }>
+      >(),
+    env: { STRIPE_SECRET_KEY: "sk_test_x" as string | undefined },
+  },
+}))
+
+const selectChain = () => {
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    limit: async () => mocks.productRows.current,
+  }
+  return chain
+}
+
+vi.mock("@/db", () => ({ db: { select: () => selectChain() } }))
+vi.mock("@/db/schema", () => ({
+  products: { code: {}, priceCad: {}, stripePriceLookupKey: {}, isActive: {} },
+}))
+vi.mock("@/lib/env/server", () => ({ env: mocks.env }))
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({ prices: { list: mocks.pricesList } }),
+}))
+
+// Les clés sont celles de l'ALIAS du `select` Drizzle (`lookupKey`), pas les noms
+// de colonnes : c'est ce que la vraie requête retourne.
+const PRODUCT = {
+  code: "exam_access",
+  priceCad: 5000,
+  lookupKey: "exam_access",
+}
+
+beforeEach(() => {
+  mocks.env.STRIPE_SECRET_KEY = "sk_test_x"
+  mocks.productRows.current = [PRODUCT]
+  vi.spyOn(console, "error").mockImplementation(() => {})
+})
+
+describe("auditProductPriceDrift", () => {
+  it("prix conforme → aucune alerte", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [
+        {
+          id: "price_1",
+          lookup_key: "exam_access",
+          unit_amount: 5000,
+          currency: "cad",
+        },
+      ],
+    })
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 1, drifted: 0 })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("prix divergent → une alerte, le produit est compté comme dérivé", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [
+        {
+          id: "price_1",
+          lookup_key: "exam_access",
+          unit_amount: 9900,
+          currency: "cad",
+        },
+      ],
+    })
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 1, drifted: 1 })
+    expect(mocks.captureServerError).toHaveBeenCalledTimes(1)
+  })
+
+  it("lookup_key sans prix actif → alerte dédiée", async () => {
+    mocks.pricesList.mockResolvedValue({ data: [] })
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 1, drifted: 1 })
+    expect(mocks.captureServerError).toHaveBeenCalledTimes(1)
+  })
+
+  // `lookup_keys` accepte 10 clés par requête : au-delà, une seule liste
+  // tronquerait en silence et les produits surnuméraires passeraient pour
+  // « sans prix actif ».
+  it("plus de 10 produits → découpage en plusieurs appels", async () => {
+    mocks.productRows.current = Array.from({ length: 12 }, (_, i) => ({
+      code: `p${i}`,
+      priceCad: 5000,
+      lookupKey: `key_${i}`,
+    }))
+    mocks.pricesList.mockImplementation(async () => ({
+      data: mocks.productRows.current.map((r) => {
+        const row = r as { lookupKey: string }
+        return {
+          id: `price_${row.lookupKey}`,
+          lookup_key: row.lookupKey,
+          unit_amount: 5000,
+          currency: "cad",
+        }
+      }),
+    }))
+
+    const res = await auditProductPriceDrift()
+
+    expect(mocks.pricesList).toHaveBeenCalledTimes(2)
+    expect(res).toEqual({ checked: 12, drifted: 0 })
+  })
+
+  it("Stripe non configuré → tâche neutre, aucun appel", async () => {
+    mocks.env.STRIPE_SECRET_KEY = undefined
+    const res = await auditProductPriceDrift()
+    expect(res).toEqual({ checked: 0, drifted: 0 })
+    expect(mocks.pricesList).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `bun run test tests/features/payments-cron.test.ts`
+Expected: FAIL — `Failed to resolve import "@/features/payments/cron"`.
+
+- [ ] **Step 3 : Implémenter**
+
+Créer `features/payments/cron.ts` :
+
+```ts
+import { eq } from "drizzle-orm"
+import "server-only"
+import type Stripe from "stripe"
+import { db } from "@/db"
+import { products } from "@/db/schema"
+import { env } from "@/lib/env/server"
+import { captureServerError } from "@/lib/observability"
+import { getStripe } from "@/lib/stripe"
+import { describePriceDrift } from "./catalog"
+
+export type PriceDriftResult = { checked: number; drifted: number }
+
+// Borne de l'API Stripe : `prices.list` accepte au plus 10 `lookup_keys` par
+// requête. Au-delà, la liste serait tronquée en silence et les produits
+// surnuméraires passeraient pour « sans prix actif ».
+const LOOKUP_KEYS_PER_CALL = 10
+
+/**
+ * Compare le prix AFFICHÉ (`products.priceCad`) au prix que Stripe FACTURERAIT,
+ * pour tous les produits actifs. Le contrôle équivalent au checkout ne couvre
+ * que les produits qu'on achète : un produit peu demandé peut dériver des
+ * semaines sans que personne ne l'apprenne.
+ *
+ * Lecture seule : aucune écriture en base, aucune écriture chez Stripe.
+ */
+export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
+  if (!env.STRIPE_SECRET_KEY) return { checked: 0, drifted: 0 }
+
+  const rows = await db
+    .select({
+      code: products.code,
+      priceCad: products.priceCad,
+      lookupKey: products.stripePriceLookupKey,
+    })
+    .from(products)
+    .where(eq(products.isActive, true))
+    .limit(50)
+  if (rows.length === 0) return { checked: 0, drifted: 0 }
+
+  const stripe = getStripe()
+  const byLookupKey = new Map<string, Stripe.Price>()
+  for (let i = 0; i < rows.length; i += LOOKUP_KEYS_PER_CALL) {
+    const { data } = await stripe.prices.list({
+      lookup_keys: rows
+        .slice(i, i + LOOKUP_KEYS_PER_CALL)
+        .map((r) => r.lookupKey),
+      active: true,
+      limit: LOOKUP_KEYS_PER_CALL,
+    })
+    for (const price of data) {
+      if (price.lookup_key) byLookupKey.set(price.lookup_key, price)
+    }
+  }
+
+  let drifted = 0
+  for (const row of rows) {
+    const price = byLookupKey.get(row.lookupKey)
+    if (!price) {
+      drifted++
+      captureServerError(
+        "[cron:price-drift]",
+        new Error("aucun prix actif pour cette lookup_key"),
+        { detail: `produit ${row.code} · lookup_key ${row.lookupKey}` },
+      )
+      continue
+    }
+    const drift = describePriceDrift(row.priceCad, price)
+    if (drift) {
+      drifted++
+      captureServerError(
+        "[cron:price-drift]",
+        new Error("prix affiché divergent du prix Stripe"),
+        { detail: `produit ${row.code} · ${drift}` },
+      )
+    }
+  }
+
+  return { checked: rows.length, drifted }
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `bun run test tests/features/payments-cron.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5 : Brancher la tâche dans le dispatcher**
+
+Dans `app/api/cron/close-expired/route.ts`, ajouter l'import :
+
+```ts
+import { auditProductPriceDrift } from "@/features/payments/cron"
+```
+
+Ajouter l'appel après `quizRateLimitCleanup` et avant le bloc `notifications` :
+
+```ts
+  const priceDrift = await run(
+    "dérive des prix catalogue",
+    "[cron:price-drift]",
+    auditProductPriceDrift,
+    { checked: 0, drifted: 0 },
+  )
+```
+
+Ajouter la clé au `Response.json` final :
+
+```ts
+  return Response.json({
+    examParticipations,
+    trainingSessions,
+    anonymizedAccounts,
+    notifications,
+    quizRateLimitCleanup,
+    priceDrift,
+  })
+```
+
+Ne PAS toucher au `console.log` conditionnel : une dérive alerte déjà par Sentry, l'ajouter au log de synthèse ferait doublon.
+
+Mettre à jour le JSDoc de la route, qui annonce aujourd'hui deux tâches :
+
+```ts
+/**
+ * Cron : clôtures (examens, entraînements), anonymisation RGPD, purge du
+ * rate-limit quiz, notifications en attente et audit de dérive des prix
+ * catalogue. Une seule route pour l'ensemble.
+```
+
+- [ ] **Step 6 : Étendre le test d'isolation de la route**
+
+Dans `tests/features/cron-close-expired.test.ts`, ajouter au bloc `vi.hoisted` :
+
+```ts
+    auditProductPriceDrift: vi.fn(async () => ({ checked: 0, drifted: 0 })),
+```
+
+Et le mock du module :
+
+```ts
+vi.mock("@/features/payments/cron", () => ({
+  auditProductPriceDrift: mocks.auditProductPriceDrift,
+}))
+```
+
+Ajouter le test qui prouve l'isolation — l'invariant du fichier :
+
+```ts
+  it("échec de l'audit de prix → les autres tâches tournent quand même", async () => {
+    mocks.auditProductPriceDrift.mockRejectedValueOnce(new Error("Stripe down"))
+
+    const res = await call("Bearer s3cret")
+
+    expect(res.status).toBe(500)
+    expect(mocks.anonymizeExpiredDeletedAccounts).toHaveBeenCalled()
+    expect(mocks.sendPendingNotifications).toHaveBeenCalled()
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 7 : Lancer les deux fichiers de test**
+
+Run: `bun run test tests/features/payments-cron.test.ts tests/features/cron-close-expired.test.ts`
+Expected: PASS sur les deux fichiers.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add features/payments/cron.ts app/api/cron/close-expired/route.ts tests/features/payments-cron.test.ts tests/features/cron-close-expired.test.ts
+git commit -m "feat(payments): tâche cron d'audit de dérive des prix catalogue"
+```
+
+---
+
+## Task 5 : Fulfillment — persistance de `presentment_details`
+
+**Files:**
+- Modify: `features/payments/stripe.ts:52-70` (signature + JSDoc), `features/payments/stripe.ts:140-155` (UPDATE)
+- Modify: `app/api/stripe/webhook/route.ts:70-80`
+- Test: `tests/integration/payments-stripe.test.ts`
+
+- [ ] **Step 1 : Écrire les tests qui échouent**
+
+Dans `tests/integration/payments-stripe.test.ts`, étendre le helper `txStatus` avec les deux colonnes :
+
+```ts
+const txStatus = (id: string) =>
+  db
+    .select({
+      status: transactions.status,
+      completedAt: transactions.completedAt,
+      eventId: transactions.stripeEventId,
+      pi: transactions.stripePaymentIntentId,
+      accessExpiresAt: transactions.accessExpiresAt,
+      amountPaid: transactions.amountPaid,
+      currency: transactions.currency,
+      presentmentAmount: transactions.presentmentAmount,
+      presentmentCurrency: transactions.presentmentCurrency,
+    })
+    .from(transactions)
+    .where(eq(transactions.id, id))
+    .limit(1)
+    .then((r) => r[0])
+```
+
+Ajouter deux identifiants d'utilisateur au tableau `U` (passer `length: 11` à `length: 13`) et à la déstructuration :
+
+```ts
+const U = Array.from({ length: 13 }, () => createId())
+const [
+  U_HAPPY,
+  U_CUMUL,
+  U_COMBO,
+  U_FAIL,
+  U_FAILDONE,
+  U_PROMO,
+  U_XAF,
+  U_DEGNULL,
+  U_DEGUSD,
+  U_PROMO100,
+  U_RACE,
+  U_PRESENT,
+  U_NOPRESENT,
+] = U
+```
+
+Ajouter les deux tests dans le `describe("completeStripeTransaction", …)` :
+
+```ts
+  // Adaptive Pricing : le client voit des FCFA, l'événement arrive en CAD. Le
+  // montant local ne vit que dans `presentment_details` — sans persistance,
+  // un client qui écrit « j'ai payé 228 000 FCFA » n'est recoupable par personne.
+  it("persiste le montant présenté sans toucher au montant encaissé", async () => {
+    const txId = createId()
+    const sid = `sess_present_${suffix}`
+    await seedPending({
+      id: txId,
+      userId: U_PRESENT,
+      productId: PEXAM,
+      sessionId: sid,
+      accessType: "exam",
+      durationDays: 90,
+    })
+
+    await completeStripeTransaction({
+      stripeSessionId: sid,
+      stripePaymentIntentId: "pi_present",
+      stripeEventId: `evt_present_${suffix}`,
+      amountTotal: 5000,
+      currency: "cad",
+      presentmentAmount: 2280000,
+      presentmentCurrency: "xaf",
+    })
+
+    const tx = await txStatus(txId)
+    expect(tx?.presentmentAmount).toBe(2280000)
+    expect(tx?.presentmentCurrency).toBe("XAF")
+    // Invariant comptable : l'encaissement reste le CAD.
+    expect(tx?.amountPaid).toBe(5000)
+    expect(tx?.currency).toBe("CAD")
+  })
+
+  it("client sans conversion (pas de presentment_details) → colonnes nulles", async () => {
+    const txId = createId()
+    const sid = `sess_nopresent_${suffix}`
+    await seedPending({
+      id: txId,
+      userId: U_NOPRESENT,
+      productId: PEXAM,
+      sessionId: sid,
+      accessType: "exam",
+      durationDays: 90,
+    })
+
+    await completeStripeTransaction({
+      stripeSessionId: sid,
+      stripePaymentIntentId: "pi_nopresent",
+      stripeEventId: `evt_nopresent_${suffix}`,
+      amountTotal: 5000,
+      currency: "cad",
+    })
+
+    const tx = await txStatus(txId)
+    expect(tx?.presentmentAmount).toBeNull()
+    expect(tx?.presentmentCurrency).toBeNull()
+    expect(tx?.amountPaid).toBe(5000)
+  })
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `bun run test:integration tests/integration/payments-stripe.test.ts`
+Expected: FAIL — TypeScript refuse `presentmentAmount` dans les paramètres de `completeStripeTransaction`.
+
+> Ce script crée, migre et détruit une branche Neon éphémère. Il est plus lent que les tests frontend ; ne le lancer que sur le fichier concerné pendant l'itération.
+
+- [ ] **Step 3 : Implémenter dans le fulfillment**
+
+Dans `features/payments/stripe.ts`, étendre les paramètres :
+
+```ts
+export async function completeStripeTransaction(params: {
+  stripeSessionId: string
+  stripePaymentIntentId: string
+  stripeEventId: string
+  amountTotal?: number | null
+  currency?: string | null
+  presentmentAmount?: number | null
+  presentmentCurrency?: string | null
+}): Promise<CompleteStripeResult> {
+```
+
+Ajouter, juste après le bloc `reconcile` / `console.error` existant :
+
+```ts
+    // Adaptive Pricing : présent UNIQUEMENT si le client a payé dans sa devise
+    // locale. Absent pour un client canadien — les colonnes restent nulles, et
+    // c'est ce qui rend la proportion de conversions mesurable. Ne jamais faire
+    // échouer un paiement valide sur de la traçabilité : valeurs partielles
+    // ⇒ on n'écrit rien.
+    const presentment =
+      params.presentmentAmount != null && params.presentmentCurrency
+        ? {
+            presentmentAmount: params.presentmentAmount,
+            presentmentCurrency: params.presentmentCurrency.toUpperCase(),
+          }
+        : null
+```
+
+Et l'ajouter au `set` du même `UPDATE` (aucune écriture supplémentaire) :
+
+```ts
+      .set({
+        status: "completed",
+        stripePaymentIntentId: params.stripePaymentIntentId || null,
+        stripeEventId: params.stripeEventId,
+        accessExpiresAt: txAccessExpiresAt,
+        completedAt: now,
+        ...(reconcile ?? {}),
+        ...(presentment ?? {}),
+      })
+```
+
+- [ ] **Step 4 : Transmettre depuis le webhook**
+
+Dans `app/api/stripe/webhook/route.ts`, dans l'appel à `completeStripeTransaction`, remplacer le commentaire trompeur et ajouter les deux champs :
+
+```ts
+            // Montant réellement facturé : un code promo fait diverger
+            // `amount_total` du prix catalogue. (Adaptive Pricing, lui, ne
+            // change PAS la devise de la session — voir `presentment_details`
+            // juste en dessous.)
+            amountTotal: checkoutSession.amount_total,
+            currency: checkoutSession.currency,
+            // Ce que le client a réellement vu et payé dans sa devise locale.
+            presentmentAmount:
+              checkoutSession.presentment_details?.presentment_amount,
+            presentmentCurrency:
+              checkoutSession.presentment_details?.presentment_currency,
+```
+
+- [ ] **Step 5 : Lancer les tests pour vérifier qu'ils passent**
+
+Run: `bun run test:integration tests/integration/payments-stripe.test.ts`
+Expected: PASS — y compris les tests existants de réconciliation (`U_XAF`, `U_DEGNULL`, `U_DEGUSD`, `U_PROMO`), qui ne doivent pas bouger.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add features/payments/stripe.ts app/api/stripe/webhook/route.ts tests/integration/payments-stripe.test.ts
+git commit -m "feat(payments): persister le montant présenté par Adaptive Pricing"
+```
+
+---
+
+## Task 6 : Affichage du montant présenté au panneau admin
+
+**Files:**
+- Modify: `lib/format.ts:32-55`
+- Test: `tests/lib/format.test.ts`
+- Modify: `features/users/dal.ts:586-595` (type), `features/users/dal.ts:637-680` (requête + mapping)
+- Modify: `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx:165-222`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter dans `tests/lib/format.test.ts` :
+
+```ts
+import { formatPresentmentAmount } from "@/lib/format"
+
+describe("formatPresentmentAmount", () => {
+  // Le piège : `formatCurrency` divise toujours par 100. Le XAF n'a pas de
+  // sous-unité — 228 000 FCFA s'afficheraient en « 2 280 ».
+  it("devise zéro-décimal : l'unité mineure EST l'unité", () => {
+    const out = formatPresentmentAmount(2280000, "xaf")
+    expect(out).toContain("2 280 000")
+    expect(out).not.toContain("22 800")
+  })
+
+  it("devise à deux décimales : division par 100", () => {
+    expect(formatPresentmentAmount(5000, "cad")).toContain("50")
+  })
+
+  it("code de devise inconnu d'Intl → repli lisible, pas d'exception", () => {
+    expect(formatPresentmentAmount(1234, "zz")).toBe("1234 ZZ")
+  })
+})
+```
+
+Les espaces des séparateurs de milliers produits par `Intl` sont des espaces insécables étroites : les assertions ci-dessus utilisent `toContain` sur des fragments sans séparateur ambigu. Si `toContain("2 280 000")` échoue, comparer via `out.replace(/\s/g, " ")`.
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `bun run test tests/lib/format.test.ts`
+Expected: FAIL — `formatPresentmentAmount is not a function`.
+
+- [ ] **Step 3 : Implémenter le formateur**
+
+Ajouter dans `lib/format.ts`, juste après `formatCurrency` :
+
+```ts
+/**
+ * Montant présenté au client par Adaptive Pricing, dans SA devise.
+ *
+ * Ne pas confondre avec `formatCurrency`, qui divise toujours par 100 parce que
+ * l'app stocke ses montants en centièmes. Ici la devise est arbitraire (plus de
+ * 150 pays) et peut être zéro-décimal — XAF, JPY : l'unité mineure y EST
+ * l'unité. Le facteur se dérive d'`Intl` plutôt que d'une liste de devises
+ * zéro-décimal écrite en dur, qui vieillirait sans que rien ne le signale.
+ */
+export const formatPresentmentAmount = (
+  minorUnits: number,
+  currency: string,
+): string => {
+  const code = currency.toUpperCase()
+  try {
+    const formatter = new Intl.NumberFormat("fr-CA", {
+      style: "currency",
+      currency: code,
+    })
+    const digits = formatter.resolvedOptions().maximumFractionDigits ?? 2
+    return formatter.format(minorUnits / 10 ** digits)
+  } catch {
+    // Intl lève un RangeError sur un code non conforme : mieux vaut un affichage
+    // brut qu'un panneau admin qui plante sur une devise exotique.
+    return `${minorUnits} ${code}`
+  }
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `bun run test tests/lib/format.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5 : Exposer les champs dans le DAL admin**
+
+Dans `features/users/dal.ts`, étendre le type `PanelTransaction` :
+
+```ts
+export type PanelTransaction = {
+  id: string
+  type: "stripe" | "manual"
+  status: (typeof transactions.status.enumValues)[number]
+  amountPaid: number
+  currency: "CAD" | "XAF"
+  /** Unité mineure de `presentmentCurrency`. Nul hors Adaptive Pricing. */
+  presentmentAmount: number | null
+  presentmentCurrency: string | null
+  /** Epoch ms. */
+  createdAt: number
+  product: { name: string } | null
+}
+```
+
+Ajouter les deux colonnes au `select` des transactions du panneau :
+
+```ts
+        amountPaid: transactions.amountPaid,
+        currency: transactions.currency,
+        presentmentAmount: transactions.presentmentAmount,
+        presentmentCurrency: transactions.presentmentCurrency,
+        createdAt: transactions.createdAt,
+```
+
+Et au mapping `recentTransactions` :
+
+```ts
+    recentTransactions: txRows.map((r) => ({
+      id: r.id,
+      type: r.type,
+      status: r.status,
+      amountPaid: r.amountPaid,
+      currency: r.currency,
+      presentmentAmount: r.presentmentAmount,
+      presentmentCurrency: r.presentmentCurrency,
+      createdAt: r.createdAt.getTime(),
+      product: r.productName ? { name: r.productName } : null,
+    })),
+```
+
+- [ ] **Step 6 : Afficher dans le panneau**
+
+Dans `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx`, étendre l'import de `lib/format` :
+
+```ts
+import {
+  formatCurrency,
+  formatExpiration,
+  formatMediumDate,
+  formatPresentmentAmount,
+} from "@/lib/format"
+```
+
+Supprimer le `formatCurrency` local défini dans `TransactionItem` (lignes 166-172) : c'est une copie divergente de celui de `lib/format.ts`, et on vient d'ajouter son jumeau juste à côté. Le composant commence désormais par :
+
+```tsx
+function TransactionItem({ transaction }: { transaction: PanelTransaction }) {
+  const statusConfig = {
+```
+
+Remplacer le bloc du montant (ligne ~216) :
+
+```tsx
+      <div className="text-right">
+        <span className="text-sm font-semibold text-gray-900 dark:text-white">
+          +{formatCurrency(transaction.amountPaid, transaction.currency)}
+        </span>
+        {transaction.presentmentCurrency !== null &&
+          transaction.presentmentAmount !== null && (
+            <p className="text-xs text-gray-500">
+              présenté :{" "}
+              {formatPresentmentAmount(
+                transaction.presentmentAmount,
+                transaction.presentmentCurrency,
+              )}
+            </p>
+          )}
+      </div>
+```
+
+- [ ] **Step 7 : Vérifier la suite frontend et le type-check**
+
+Run: `bun run test && bunx tsc --noEmit`
+Expected: PASS et aucune erreur de type. Aucun test ne construit de `PanelTransaction` littéral (`tests/features/users-dal.test.ts` et `tests/integration/users-admin-dal.test.ts` ne font que lire le résultat) : les deux nouveaux champs n'y demandent rien.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add lib/format.ts tests/lib/format.test.ts features/users/dal.ts "app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx"
+git commit -m "feat(admin): afficher le montant présenté au client dans le panneau utilisateur"
+```
+
+---
+
+## Task 7 : Commentaires trompeurs, documentation et `ProductView`
+
+Cette tâche ne change aucun comportement. Elle existe parce que trois commentaires du dépôt affirment aujourd'hui le contraire de la documentation Stripe : le prochain lecteur « réparerait » une branche saine.
+
+**Files:**
+- Modify: `features/payments/stripe.ts:46-50`, `scripts/audit-stripe-transactions.ts:1-6`
+- Modify: `features/payments/dal.ts:107-140`
+- Modify: `tests/components/payments/PricingGrid.test.tsx:54`
+- Modify: `.claude/rules/payments.md`, `AGENTS.md`
+
+- [ ] **Step 1 : Corriger le JSDoc du fulfillment**
+
+Dans `features/payments/stripe.ts`, remplacer le dernier paragraphe du bloc JSDoc de `completeStripeTransaction` :
+
+```
+ * `amountTotal`/`currency` (session Checkout) écrasent les valeurs provisoires du
+ * pending (prix catalogue CAD) : seuls les CODES PROMO font effectivement diverger
+ * le montant facturé du prix catalogue. Adaptive Pricing, lui, ne change ni la
+ * devise ni le montant de la session — le montant local vit dans
+ * `presentment_details`, persisté à part. La conversion XAF ×100 ci-dessous reste
+ * correcte (le XAF est zéro-décimal chez Stripe) mais n'est atteinte que si un
+ * prix est RÉELLEMENT libellé en XAF. Valeurs inexploitables (`amount_total`
+ * null, devise hors enum) → on conserve le provisoire et on logue — un paiement
+ * valide ne doit jamais échouer pour un problème de réconciliation.
+```
+
+- [ ] **Step 2 : Corriger l'en-tête du script d'audit**
+
+Dans `scripts/audit-stripe-transactions.ts`, remplacer les trois premières lignes du bloc :
+
+```
+/**
+ * Audit LECTURE SEULE des transactions Stripe historiques. Compare
+ * `amountPaid`/`currency` en base avec `amount_total`/`currency` des sessions
+ * Checkout réelles. Source de divergence attendue : les CODES PROMO. Adaptive
+ * Pricing n'en est PAS une — il laisse la session dans la devise d'intégration
+ * (le montant local vit dans `presentment_details`). AUCUNE écriture : selects
+ * et GET Stripe.
+```
+
+- [ ] **Step 3 : Retirer les identifiants Stripe de `ProductView`**
+
+Dans `features/payments/dal.ts`, supprimer les deux champs du type :
+
+```ts
+export type ProductView = {
+  id: string
+  code: (typeof products.code.enumValues)[number]
+  name: string
+  description: string
+  /** En cents. Casse `priceCAD` conservée pour l'UI existante. */
+  priceCAD: number
+  durationDays: number
+  accessType: "exam" | "training"
+  isCombo: boolean
+}
+```
+
+et du `select` de `getAvailableProducts` (supprimer les lignes `stripeProductId:` et `stripePriceId:`). Ces deux champs traversaient la frontière serveur → client sans qu'aucun composant ne les lise.
+
+Dans `tests/components/payments/PricingGrid.test.tsx:53-54`, supprimer les deux lignes :
+
+```ts
+    stripeProductId: "prod_test",
+    stripePriceId: "price_test",
+```
+
+- [ ] **Step 4 : Mettre à jour la règle projet**
+
+Dans `.claude/rules/payments.md`, remplacer les deux premières puces de la section « Catalogue produits » :
+
+```markdown
+- **Le prix affiché et le prix facturé viennent de deux sources.**
+  `products.priceCad` (Postgres) alimente la grille tarifaire et les paywalls ;
+  Stripe facture le prix résolu au checkout depuis
+  `products.stripePriceLookupKey`. Modifier un prix au dashboard Stripe SANS
+  mettre à jour la ligne `products` fait diverger les deux — le client voit un
+  montant et en paie un autre. Deux garde-fous alertent (Sentry, sans bloquer la
+  vente) : la comparaison au checkout et la tâche cron `auditProductPriceDrift`.
+- **Une `lookup_key` est IDENTIQUE en test et en live**, contrairement aux
+  identifiants `price_…` / `prod_…` dont les préfixes ne trahissent pas le mode.
+  C'est ce qui rend impossible la classe « identifiant du mauvais mode » : la clé
+  résout le prix de test sous une clé de test, le prix live sous une clé live.
+  Changer un tarif se fait par `transfer_lookup_key=true` (Stripe ne modifie
+  jamais le montant d'un prix : il en crée un nouveau et déplace la clé).
+```
+
+Ajouter à la section « Montants et devises », après la puce Adaptive Pricing :
+
+```markdown
+- **`presentment_details` est persisté** (`transactions.presentment_amount` /
+  `presentment_currency`, nullables) et affiché au panneau admin. C'est la seule
+  façon de recouper un client qui écrit « j'ai payé 228 000 FCFA ». Ces colonnes
+  ne sont PAS comptables : `amountPaid`/`currency` restent l'encaissement.
+```
+
+- [ ] **Step 5 : Mettre à jour `AGENTS.md`**
+
+Dans la section « Gotchas », remplacer la puce « Stripe en dev » :
+
+```markdown
+- **Stripe en dev** : mode TEST (profil CLI `nomaqbanq`) ; webhooks locaux via `stripe listen --forward-to localhost:3000/api/stripe/webhook`. Le prix est résolu au checkout par `products.stripe_price_lookup_key`, identique en test et en live → les 5 produits sont achetables en local sans configuration. Code promo test −100 % : `E2EPROMO100`
+```
+
+- [ ] **Step 6 : Vérifier**
+
+Run: `bun run check`
+Expected: prettier, tsc et eslint passent.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add features/payments/stripe.ts features/payments/dal.ts scripts/audit-stripe-transactions.ts tests/components/payments/PricingGrid.test.tsx .claude/rules/payments.md AGENTS.md
+git commit -m "docs(payments): aligner les commentaires Adaptive Pricing sur la doc officielle"
+```
+
+---
+
+## Task 8 : Vérification complète
+
+- [ ] **Step 1 : Suite frontend + couverture**
+
+Run: `bun run test:coverage`
+Expected: PASS, seuil de 80 % (statements/branches/functions/lines) tenu. Les nouveaux modules (`catalog.ts`, `cron.ts`) sont couverts par leurs tests dédiés.
+
+- [ ] **Step 2 : Suite d'intégration complète**
+
+Run: `bun run test:integration`
+Expected: PASS. C'est ici que la migration est réellement éprouvée — le script crée une branche Neon neuve, y applique toutes les migrations, puis la détruit.
+
+- [ ] **Step 3 : Vérification statique**
+
+Run: `bun run check`
+Expected: aucune erreur.
+
+- [ ] **Step 4 : Test manuel du checkout en devise locale**
+
+Nécessite le serveur de dev. **Ne pas le lancer soi-même** — demander à l'utilisateur de démarrer `bun dev` et de donner le port.
+
+Modifier temporairement `customer_email` dans `createStripeCheckout` en
+`"test+location_CM@example.com"`, acheter un produit, et vérifier que la page
+Stripe s'affiche en FCFA. Après paiement (carte de test `4242 4242 4242 4242`),
+vérifier en base que `presentment_amount` / `presentment_currency` sont
+renseignés et qu'`amount_paid` reste le montant CAD. **Annuler la modification
+de `customer_email` avant de committer.**
+
+- [ ] **Step 5 : Commit final s'il reste des ajustements**
+
+```bash
+git add -A
+git commit -m "test: vérification complète du catalogue par lookup_key"
+```
+
+---
+
+## Déploiement
+
+1. **Vérifier la permission `prices:read`** sur la clé Stripe de production (voir Prérequis). C'est le seul point qui casse tout le checkout s'il est manqué.
+2. Merger ce PR. La migration s'applique au build Vercel (`build:vercel` → `migrate-deploy`), avant l'activation du déploiement — d'où le maintien de `stripe_price_id` : l'ancien code tourne encore pendant le build et continue de lire cette colonne.
+3. Après vérification en production (un achat réel, ou l'absence d'alerte `[cron:price-drift]` pendant 24 h), ouvrir le PR de suivi : `DROP COLUMN stripe_price_id`, retrait du champ de `db/schema/payments.ts` et de tous les inserts de tests.
+
+## Hors périmètre — ne pas dériver
+
+- Aucun prix en XAF (couperait la conversion Adaptive Pricing sur cette devise).
+- Aucun backfill de `presentment_details` sur l'historique.
+- Aucun affichage dans la table transactions admin ni dans l'historique client.
+- Aucun blocage de vente sur dérive de prix.
+- Aucun cache sur la résolution du prix.

--- a/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
+++ b/docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md
@@ -16,9 +16,39 @@
 
 ## Prérequis avant de commencer
 
+- [ ] **BLOQUANT — vérifier que les `lookup_key` existent réellement, dans les deux modes.**
+
+  Toute la migration repose sur une affirmation extérieure au dépôt : un commentaire
+  d'issue du 2026-08-06 disant que les 5 `lookup_key` Stripe portent exactement la
+  même chaîne que `products.code`, en test comme en live. **Personne ne l'a
+  revérifiée depuis.** Le backfill remplace un pointeur connu-bon en production
+  (`stripe_price_id`) par un pointeur jamais éprouvé : si la clé d'un seul produit
+  diffère, son checkout part en repli (voir Task 3) et l'alerte Sentry se déclenche
+  à chaque achat.
+
+  Lecture seule, aucune écriture, aucun objet créé :
+
+  ```bash
+  # LIVE
+  stripe prices list --limit 20 --live -d "active=true"
+  # TEST
+  stripe prices list --limit 20 -d "active=true"
+  ```
+
+  Attendu : dans CHACUNE des deux listes, un prix actif dont `lookup_key` vaut
+  exactement `exam_access`, `training_access`, `exam_access_promo`,
+  `training_access_promo`, `premium_access`. Noter aussi les `unit_amount` — ce
+  sont eux qui devront concorder avec `products.price_cad` (attendu au 2026-08-06 :
+  35000 / 20000 / 20000 / 5000 / 5000 en cents).
+
+  **Si une seule clé manque ou diffère : ne pas lancer la migration.** Poser la
+  `lookup_key` manquante sur le prix concerné (`transfer_lookup_key=true` si elle
+  est portée par un ancien prix), puis recommencer la vérification.
+
 - [ ] **Vérifier la permission de la clé Stripe runtime.** `prices.list` exige la lecture sur Prices, ce que la création d'une session avec un price ID n'exigeait pas. Si `STRIPE_SECRET_KEY` (Vercel + `.env.local`) porte une clé restreinte `rk_`, ajouter `prices:read` **avant** de déployer, sinon tous les checkouts tombent en `permission_error`. Une clé `sk_` a la permission par défaut.
 
-Cette vérification ne bloque pas l'écriture du code (les tests moquent Stripe), mais elle bloque le déploiement.
+La première vérification bloque l'écriture du code — elle valide la prémisse de la
+migration. La seconde bloque le déploiement seulement (les tests moquent Stripe).
 
 ---
 
@@ -170,43 +200,61 @@ describe("describePriceDrift", () => {
     expect(describePriceDrift(5000, PRICE)).toBeNull()
   })
 
-  it("montant divergent → dérive décrite avec les deux valeurs", () => {
+  // Un montant diverge légalement : `transfer_lookup_key` déplace la clé sur un
+  // nouveau prix quand le tarif change. On alerte, on ne bloque pas.
+  it("montant divergent → dérive NON bloquante, décrite avec les deux valeurs", () => {
     const drift = describePriceDrift(3000, PRICE)
-    expect(drift).toContain("5000")
-    expect(drift).toContain("3000")
+    expect(drift?.currencyMismatch).toBe(false)
+    expect(drift?.message).toContain("5000")
+    expect(drift?.message).toContain("3000")
   })
 
-  it("devise du prix Stripe ≠ cad → dérive", () => {
-    expect(describePriceDrift(5000, { ...PRICE, currency: "usd" })).toContain(
-      "usd",
-    )
+  // La devise d'un prix Stripe est immuable : elle ne peut pas avoir « changé ».
+  // Une devise ≠ cad signifie que la clé pointe sur le mauvais prix.
+  it("devise du prix Stripe ≠ cad → dérive bloquante", () => {
+    const drift = describePriceDrift(5000, { ...PRICE, currency: "usd" })
+    expect(drift?.currencyMismatch).toBe(true)
+    expect(drift?.message).toContain("usd")
   })
 
-  it("unit_amount null (prix à montant libre) → dérive, pas de crash", () => {
-    expect(
-      describePriceDrift(5000, { ...PRICE, unit_amount: null }),
-    ).not.toBeNull()
+  it("unit_amount null (prix à montant libre) → dérive non bloquante", () => {
+    const drift = describePriceDrift(5000, { ...PRICE, unit_amount: null })
+    expect(drift).not.toBeNull()
+    expect(drift?.currencyMismatch).toBe(false)
   })
 })
 
 describe("resolveStripePrice", () => {
-  it("interroge Stripe sur la clé, en prix actifs seulement", async () => {
+  it("interroge Stripe sur la clé, en prix actifs seulement, requête bornée", async () => {
     const list = vi.fn(async () => ({ data: [PRICE] }))
     const stripe = { prices: { list } } as never
 
     const price = await resolveStripePrice(stripe, "exam_access")
 
     expect(price).toEqual(PRICE)
-    expect(list).toHaveBeenCalledWith({
-      lookup_keys: ["exam_access"],
-      active: true,
-      limit: 2,
-    })
+    expect(list).toHaveBeenCalledWith(
+      { lookup_keys: ["exam_access"], active: true, limit: 2 },
+      { timeout: 8000, maxNetworkRetries: 1 },
+    )
   })
 
   it("aucun prix actif pour la clé → null (et non une exception)", async () => {
     const stripe = { prices: { list: async () => ({ data: [] }) } } as never
     expect(await resolveStripePrice(stripe, "inconnu")).toBeNull()
+  })
+
+  // `limit: 2` n'a d'intérêt que si quelqu'un lit le second élément : sans ça,
+  // une clé portée par deux prix actifs se réglerait au hasard, en silence.
+  it("deux prix actifs pour la même clé → anomalie signalée", async () => {
+    const onAmbiguous = vi.fn()
+    const stripe = {
+      prices: { list: async () => ({ data: [PRICE, { ...PRICE, id: "price_2" }] }) },
+    } as never
+
+    const price = await resolveStripePrice(stripe, "exam_access", onAmbiguous)
+
+    expect(price).toEqual(PRICE)
+    expect(onAmbiguous).toHaveBeenCalledWith("exam_access", 2)
   })
 })
 ```
@@ -227,55 +275,79 @@ import type Stripe from "stripe"
 type PriceShape = Pick<Stripe.Price, "id" | "unit_amount" | "currency">
 
 /**
+ * Requête bornée. Le SDK Stripe attend 80 s par défaut et réessaie 2 fois
+ * (`stripe.core.js`) : un appel qui pend peut donc durer ~4 min. C'est
+ * inacceptable sur le chemin du checkout, où l'utilisateur attend, comme dans le
+ * cron, dont l'appelant GitHub Actions coupe à `--max-time 60` puis relance
+ * (`--retry-all-errors`) — soit jusqu'à 4 exécutions complètes du cron par heure.
+ */
+const PRICE_REQUEST_OPTIONS = { timeout: 8000, maxNetworkRetries: 1 }
+
+/**
  * Résout le prix Stripe d'un produit par sa `lookup_key`. Contrairement à un
  * `price_…`, une `lookup_key` est identique en test et en live : c'est ce qui
- * rend impossible l'usage d'un identifiant du mauvais mode. Stripe garantit
- * l'unicité de la clé parmi les prix actifs (`transfer_lookup_key` la déplace
- * sur le nouveau prix lors d'un changement de tarif) — `limit: 2` laisse
- * néanmoins voir une éventuelle anomalie plutôt que de la masquer.
+ * rend impossible l'usage d'un identifiant du mauvais mode.
+ *
+ * `onAmbiguous` est appelé si PLUSIEURS prix actifs portent la clé — cas que
+ * Stripe n'est pas censé produire, et qu'on refuse de trancher au hasard en
+ * silence. Le premier prix est renvoyé quand même : alerter ne doit pas couper
+ * la vente.
  *
  * `null` = aucun prix actif ne porte cette clé dans le mode de la clé API.
  */
 export const resolveStripePrice = async (
   stripe: Stripe,
   lookupKey: string,
+  onAmbiguous?: (lookupKey: string, count: number) => void,
 ): Promise<Stripe.Price | null> => {
-  const { data } = await stripe.prices.list({
-    lookup_keys: [lookupKey],
-    active: true,
-    limit: 2,
-  })
+  const { data } = await stripe.prices.list(
+    { lookup_keys: [lookupKey], active: true, limit: 2 },
+    PRICE_REQUEST_OPTIONS,
+  )
+  if (data.length > 1) onAmbiguous?.(lookupKey, data.length)
   return data[0] ?? null
+}
+
+export type PriceDrift = {
+  /**
+   * La devise du prix Stripe n'est pas le CAD. Traité à part du montant : la
+   * devise d'un prix Stripe est IMMUABLE (on ne modifie pas un prix, on en crée
+   * un autre), donc elle ne peut pas avoir « changé » légitimement — c'est une
+   * erreur de configuration, pas un état transitoire. Un montant, lui, diverge
+   * normalement le temps qu'un `transfer_lookup_key` soit répercuté en base.
+   */
+  currencyMismatch: boolean
+  message: string
 }
 
 /**
  * Écart entre le prix AFFICHÉ (`products.priceCad`, en cents, lu par la grille
  * tarifaire et les paywalls) et le prix que Stripe FACTURERA. Les deux vivent
  * dans des systèmes différents ; sans cette comparaison, une modification de
- * tarif au dashboard non répercutée en base laisse le client lire un montant et
- * en payer un autre.
+ * tarif au dashboard non répercutée en base passe inaperçue.
  *
- * `null` = ils concordent. Sinon, une description prête à partir dans Sentry.
+ * `null` = ils concordent.
  */
 export const describePriceDrift = (
   priceCad: number,
   price: PriceShape,
-): string | null => {
+): PriceDrift | null => {
+  const currencyMismatch = price.currency !== "cad"
   const parts: string[] = []
-  if (price.currency !== "cad") {
-    parts.push(`devise Stripe ${price.currency} ≠ cad`)
-  }
+  if (currencyMismatch) parts.push(`devise Stripe ${price.currency} ≠ cad`)
   if (price.unit_amount !== priceCad) {
     parts.push(`montant Stripe ${price.unit_amount ?? "null"} ≠ base ${priceCad}`)
   }
-  return parts.length > 0 ? `${price.id} : ${parts.join(" · ")}` : null
+  return parts.length > 0
+    ? { currencyMismatch, message: `${price.id} : ${parts.join(" · ")}` }
+    : null
 }
 ```
 
 - [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
 
 Run: `bun run test tests/features/payments-catalog.test.ts`
-Expected: PASS, 6 tests.
+Expected: PASS, 7 tests.
 
 - [ ] **Step 5 : Commit**
 
@@ -318,11 +390,13 @@ vi.mock("@/lib/stripe", () => ({
 }))
 ```
 
-Remplacer `stripePriceId` par `stripePriceLookupKey` dans `ACTIVE_PRODUCT` :
+**Ajouter** `stripePriceLookupKey` à `ACTIVE_PRODUCT` en conservant `stripePriceId`
+(le repli de phase 1 le lit) :
 
 ```ts
 const ACTIVE_PRODUCT = {
   id: "p1",
+  stripePriceId: "price_1",
   stripePriceLookupKey: "exam_access",
   priceCad: 5000,
   accessType: "exam",
@@ -366,22 +440,28 @@ Ajouter dans le `describe("createStripeCheckout", …)` de `tests/features/payme
     expect(arg.line_items[0].price).toBe("price_resolved")
   })
 
-  it("lookup_key sans prix actif → produit mal configuré, aucune session", async () => {
+  // Phase 1 : la lookup_key n'est pas encore éprouvée en production, le pointeur
+  // historique l'est. Une clé qui ne résout rien alerte mais ne coupe pas la vente.
+  it("lookup_key sans prix actif → repli sur stripe_price_id, vente conservée", async () => {
     mocks.pricesList.mockResolvedValue({ data: [] })
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+
     const res = await createStripeCheckout(input)
 
-    expect(res).toEqual({
-      error: "Ce produit est mal configuré. Contactez le support.",
-    })
-    expect(mocks.checkoutCreate).not.toHaveBeenCalled()
-    expect(mocks.insertValues).not.toHaveBeenCalled()
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/pay" })
+    const arg = mocks.checkoutCreate.mock.calls[0]![0] as unknown as {
+      line_items: { price: string }[]
+    }
+    expect(arg.line_items[0].price).toBe("price_1")
     expect(mocks.captureServerError).toHaveBeenCalled()
   })
 
-  // Le prix affiché vient de la base, le prix facturé vient de Stripe. Un écart
-  // doit ALERTER sans bloquer : couper les ventes d'un produit sur une erreur
-  // d'ops coûte plus cher que l'écart lui-même.
-  it("prix Stripe divergent → alerte mais la vente aboutit", async () => {
+  // Un montant diverge légalement le temps qu'un changement de tarif Stripe soit
+  // répercuté en base : alerter suffit, couper les ventes coûterait plus cher.
+  it("montant Stripe divergent → alerte mais la vente aboutit", async () => {
     mocks.pricesList.mockResolvedValue({
       data: [{ id: "price_resolved", unit_amount: 9900, currency: "cad" }],
     })
@@ -393,6 +473,23 @@ Ajouter dans le `describe("createStripeCheckout", …)` de `tests/features/payme
     const res = await createStripeCheckout(input)
 
     expect(res).toEqual({ checkoutUrl: "https://stripe.test/pay" })
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  // La devise d'un prix Stripe est immuable : un écart de devise n'est jamais un
+  // état transitoire légitime, c'est une clé qui pointe sur le mauvais prix.
+  it("devise Stripe ≠ cad → refus, aucune session ni pending", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [{ id: "price_resolved", unit_amount: 5000, currency: "usd" }],
+    })
+
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({
+      error: "Ce produit est mal configuré. Contactez le support.",
+    })
+    expect(mocks.checkoutCreate).not.toHaveBeenCalled()
+    expect(mocks.insertValues).not.toHaveBeenCalled()
     expect(mocks.captureServerError).toHaveBeenCalled()
   })
 
@@ -419,9 +516,12 @@ Dans `features/payments/actions.ts`, ajouter l'import (bloc `@/` de l'ordre Pret
 import { describePriceDrift, resolveStripePrice } from "./catalog"
 ```
 
-Remplacer le champ sélectionné (`features/payments/actions.ts:341`) :
+**Ajouter** le champ sélectionné (`features/payments/actions.ts:341`) sans retirer
+`stripePriceId` — il porte le repli de phase 1 ci-dessous, et disparaîtra avec lui
+en phase 2 :
 
 ```ts
+      stripePriceId: products.stripePriceId,
       stripePriceLookupKey: products.stripePriceLookupKey,
 ```
 
@@ -431,45 +531,90 @@ Dans le `try`, entre `const base = appBase()` et `stripe.checkout.sessions.creat
     const price = await resolveStripePrice(
       stripe,
       product.stripePriceLookupKey,
+      (lookupKey, count) =>
+        captureServerError(
+          "[createStripeCheckout]",
+          new Error("plusieurs prix actifs pour une même lookup_key"),
+          { userId: session.user.id, detail: `${lookupKey} · ${count} prix` },
+        ),
     )
+
+    // Repli de phase 1 (expand/contract). `stripe_price_id` est le pointeur
+    // historique, éprouvé en production ; la `lookup_key` ne l'est pas encore.
+    // Tant que la colonne existe, une clé qui ne résout rien ne doit PAS couper
+    // la vente — elle alerte. Ce repli disparaît en phase 2, avec la colonne :
+    // tant que l'alerte ne se déclenche pas, la bascule est vérifiée.
     if (!price) {
       captureServerError(
         "[createStripeCheckout]",
-        new Error("aucun prix actif pour cette lookup_key"),
+        new Error("aucun prix actif pour cette lookup_key — repli sur stripe_price_id"),
         {
           userId: session.user.id,
           detail: `lookup_key ${product.stripePriceLookupKey} absente du mode de la clé active (produit ${productCode})`,
         },
       )
-      return { error: "Ce produit est mal configuré. Contactez le support." }
     }
+    resolvedPriceId = price?.id ?? product.stripePriceId
 
-    // Le client a vu `priceCad` sur la grille tarifaire ; Stripe encaissera
-    // `price.unit_amount`. On alerte sans bloquer : une vente refusée sur une
-    // erreur de configuration coûte plus cher que l'écart.
-    const drift = describePriceDrift(product.priceCad, price)
+    // Devise et montant ne se traitent PAS de la même façon. La devise d'un prix
+    // Stripe est immuable : elle ne peut pas avoir changé légitimement, donc une
+    // devise ≠ cad signifie que la clé pointe sur le mauvais prix → refus. Un
+    // montant, lui, diverge normalement le temps qu'un changement de tarif soit
+    // répercuté en base → alerte seule. Le client voit de toute façon le montant
+    // sur Checkout avant de confirmer.
+    const drift = price ? describePriceDrift(product.priceCad, price) : null
     if (drift) {
       captureServerError(
         "[createStripeCheckout]",
-        new Error("prix affiché divergent du prix Stripe"),
-        { userId: session.user.id, detail: `produit ${productCode} · ${drift}` },
+        new Error(
+          drift.currencyMismatch
+            ? "devise du prix Stripe inattendue"
+            : "prix affiché divergent du prix Stripe",
+        ),
+        {
+          userId: session.user.id,
+          detail: `produit ${productCode} · ${drift.message}`,
+        },
       )
+      if (drift.currencyMismatch) {
+        return { error: "Ce produit est mal configuré. Contactez le support." }
+      }
     }
 ```
 
 Puis remplacer la ligne `line_items` :
 
 ```ts
-      line_items: [{ price: price.id, quantity: 1 }],
+      line_items: [{ price: resolvedPriceId, quantity: 1 }],
 ```
 
-Enfin, remplacer le commentaire du bloc `isStripeResourceMissing` (`features/payments/actions.ts:399-404`) — il décrit un mécanisme qui n'existe plus :
+Enfin, reprendre le bloc `isStripeResourceMissing`
+(`features/payments/actions.ts:399-410`) : son commentaire décrit un mécanisme qui
+n'existe plus, et sa ligne `detail:` désigne un `stripe_price_id` qui n'est plus
+celui qu'on a envoyé à Stripe — le prix réellement facturé est `resolvedPriceId`,
+qui peut venir de la résolution comme du repli. Remplacer le bloc entier par :
 
 ```ts
     // `resource_missing` à la CRÉATION de la session (≠ verifyStripeCheckout, où
     // il vient d'une URL périmée). Le prix étant désormais résolu en amont, ce
     // cas ne peut plus venir d'un identifiant du mauvais mode : il signale un
     // objet Stripe supprimé entre la résolution et la création.
+    if (isStripeResourceMissing(error)) {
+      captureServerError("[createStripeCheckout]", error, {
+        userId: session.user.id,
+        detail: `prix ${resolvedPriceId ?? "non résolu"} (lookup_key ${product.stripePriceLookupKey}) introuvable (produit ${productCode})`,
+      })
+      return { error: "Ce produit est mal configuré. Contactez le support." }
+    }
+```
+
+`price` est déclaré **dans** le `try` : il n'est pas visible depuis le `catch`.
+D'où la variable de portée supérieure, à déclarer juste avant le `try` (et à
+affecter après la résolution, à l'étape suivante) :
+
+```ts
+  let resolvedPriceId: string | null = null
+  try {
 ```
 
 - [ ] **Step 5 : Lancer les tests pour vérifier qu'ils passent**
@@ -502,12 +647,15 @@ vi.mock("@/lib/stripe", () => ({
 
 Le `db.insert(products)` du `beforeAll` porte déjà `stripePriceLookupKey` depuis la Task 1 — vérifier que c'est bien le cas, sinon l'ajouter.
 
-Ajouter le test qui prouve qu'aucun `pending` n'est créé quand la clé ne résout rien :
+Ajouter le test qui prouve qu'aucun `pending` n'est créé quand la vente est
+refusée — le seul cas de refus restant est la devise :
 
 ```ts
-  it("lookup_key sans prix actif → aucune transaction pending créée", async () => {
+  it("devise Stripe ≠ cad → aucune transaction pending créée", async () => {
     mocks.create.mockClear()
-    mocks.pricesList.mockResolvedValueOnce({ data: [] })
+    mocks.pricesList.mockResolvedValueOnce({
+      data: [{ id: "price_resolved", unit_amount: 5000, currency: "usd" }],
+    })
 
     const before = await db
       .select({ id: transactions.id })
@@ -628,7 +776,7 @@ describe("auditProductPriceDrift", () => {
 
     const res = await auditProductPriceDrift()
 
-    expect(res).toEqual({ checked: 1, drifted: 0 })
+    expect(res).toEqual({ checked: 1, drifted: 0, failed: false })
     expect(mocks.captureServerError).not.toHaveBeenCalled()
   })
 
@@ -646,7 +794,7 @@ describe("auditProductPriceDrift", () => {
 
     const res = await auditProductPriceDrift()
 
-    expect(res).toEqual({ checked: 1, drifted: 1 })
+    expect(res).toEqual({ checked: 1, drifted: 1, failed: false })
     expect(mocks.captureServerError).toHaveBeenCalledTimes(1)
   })
 
@@ -655,7 +803,7 @@ describe("auditProductPriceDrift", () => {
 
     const res = await auditProductPriceDrift()
 
-    expect(res).toEqual({ checked: 1, drifted: 1 })
+    expect(res).toEqual({ checked: 1, drifted: 1, failed: false })
     expect(mocks.captureServerError).toHaveBeenCalledTimes(1)
   })
 
@@ -683,14 +831,46 @@ describe("auditProductPriceDrift", () => {
     const res = await auditProductPriceDrift()
 
     expect(mocks.pricesList).toHaveBeenCalledTimes(2)
-    expect(res).toEqual({ checked: 12, drifted: 0 })
+    expect(res).toEqual({ checked: 12, drifted: 0, failed: false })
   })
 
   it("Stripe non configuré → tâche neutre, aucun appel", async () => {
     mocks.env.STRIPE_SECRET_KEY = undefined
     const res = await auditProductPriceDrift()
-    expect(res).toEqual({ checked: 0, drifted: 0 })
+    expect(res).toEqual({ checked: 0, drifted: 0, failed: false })
     expect(mocks.pricesList).not.toHaveBeenCalled()
+  })
+
+  // Invariant capital : un audit informatif ne doit JAMAIS faire répondre 500 au
+  // cron. L'appelant GitHub Actions relance sur erreur — une panne Stripe
+  // rejouerait clôtures et notifications jusqu'à 4 fois par heure.
+  it("Stripe en panne → échec signalé, aucune exception propagée", async () => {
+    mocks.pricesList.mockRejectedValue(new Error("Stripe down"))
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 0, drifted: 0, failed: true })
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  it("borne la requête Stripe (le SDK attend 80 s et réessaie 2 fois par défaut)", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [
+        {
+          id: "price_1",
+          lookup_key: "exam_access",
+          unit_amount: 5000,
+          currency: "cad",
+        },
+      ],
+    })
+
+    await auditProductPriceDrift()
+
+    expect(mocks.pricesList).toHaveBeenCalledWith(expect.anything(), {
+      timeout: 8000,
+      maxNetworkRetries: 1,
+    })
   })
 })
 ```
@@ -715,7 +895,11 @@ import { captureServerError } from "@/lib/observability"
 import { getStripe } from "@/lib/stripe"
 import { describePriceDrift } from "./catalog"
 
-export type PriceDriftResult = { checked: number; drifted: number }
+export type PriceDriftResult = {
+  checked: number
+  drifted: number
+  failed: boolean
+}
 
 // Borne de l'API Stripe : `prices.list` accepte au plus 10 `lookup_keys` par
 // requête. Au-delà, la liste serait tronquée en silence et les produits
@@ -729,9 +913,15 @@ const LOOKUP_KEYS_PER_CALL = 10
  * semaines sans que personne ne l'apprenne.
  *
  * Lecture seule : aucune écriture en base, aucune écriture chez Stripe.
+ *
+ * **Ne lève JAMAIS.** Une panne Stripe ferait répondre 500 au dispatcher, or
+ * l'appelant GitHub Actions relance sur erreur (`--retry 3 --retry-all-errors`) :
+ * un audit informatif provoquerait jusqu'à 4 exécutions complètes du cron par
+ * heure, clôtures et notifications comprises. L'échec se signale par `failed`
+ * et par Sentry, pas par une exception.
  */
 export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
-  if (!env.STRIPE_SECRET_KEY) return { checked: 0, drifted: 0 }
+  if (!env.STRIPE_SECRET_KEY) return { checked: 0, drifted: 0, failed: false }
 
   const rows = await db
     .select({
@@ -742,21 +932,33 @@ export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
     .from(products)
     .where(eq(products.isActive, true))
     .limit(50)
-  if (rows.length === 0) return { checked: 0, drifted: 0 }
+  if (rows.length === 0) return { checked: 0, drifted: 0, failed: false }
 
-  const stripe = getStripe()
   const byLookupKey = new Map<string, Stripe.Price>()
-  for (let i = 0; i < rows.length; i += LOOKUP_KEYS_PER_CALL) {
-    const { data } = await stripe.prices.list({
-      lookup_keys: rows
-        .slice(i, i + LOOKUP_KEYS_PER_CALL)
-        .map((r) => r.lookupKey),
-      active: true,
-      limit: LOOKUP_KEYS_PER_CALL,
-    })
-    for (const price of data) {
-      if (price.lookup_key) byLookupKey.set(price.lookup_key, price)
+  try {
+    const stripe = getStripe()
+    for (let i = 0; i < rows.length; i += LOOKUP_KEYS_PER_CALL) {
+      const { data } = await stripe.prices.list(
+        {
+          lookup_keys: rows
+            .slice(i, i + LOOKUP_KEYS_PER_CALL)
+            .map((r) => r.lookupKey),
+          active: true,
+          limit: LOOKUP_KEYS_PER_CALL,
+        },
+        // Mêmes bornes qu'au checkout : le SDK attend 80 s et réessaie 2 fois par
+        // défaut, contre un `--max-time 60` côté appelant.
+        { timeout: 8000, maxNetworkRetries: 1 },
+      )
+      for (const price of data) {
+        if (price.lookup_key) byLookupKey.set(price.lookup_key, price)
+      }
     }
+  } catch (error) {
+    captureServerError("[cron:price-drift]", error, {
+      detail: `lecture des prix Stripe impossible (${rows.length} produits non audités)`,
+    })
+    return { checked: 0, drifted: 0, failed: true }
   }
 
   let drifted = 0
@@ -776,20 +978,24 @@ export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
       drifted++
       captureServerError(
         "[cron:price-drift]",
-        new Error("prix affiché divergent du prix Stripe"),
-        { detail: `produit ${row.code} · ${drift}` },
+        new Error(
+          drift.currencyMismatch
+            ? "devise du prix Stripe inattendue"
+            : "prix affiché divergent du prix Stripe",
+        ),
+        { detail: `produit ${row.code} · ${drift.message}` },
       )
     }
   }
 
-  return { checked: rows.length, drifted }
+  return { checked: rows.length, drifted, failed: false }
 }
 ```
 
 - [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
 
 Run: `bun run test tests/features/payments-cron.test.ts`
-Expected: PASS, 5 tests.
+Expected: PASS, 7 tests.
 
 - [ ] **Step 5 : Brancher la tâche dans le dispatcher**
 
@@ -806,7 +1012,7 @@ Ajouter l'appel après `quizRateLimitCleanup` et avant le bloc `notifications` :
     "dérive des prix catalogue",
     "[cron:price-drift]",
     auditProductPriceDrift,
-    { checked: 0, drifted: 0 },
+    { checked: 0, drifted: 0, failed: false },
   )
 ```
 
@@ -839,7 +1045,11 @@ Mettre à jour le JSDoc de la route, qui annonce aujourd'hui deux tâches :
 Dans `tests/features/cron-close-expired.test.ts`, ajouter au bloc `vi.hoisted` :
 
 ```ts
-    auditProductPriceDrift: vi.fn(async () => ({ checked: 0, drifted: 0 })),
+    auditProductPriceDrift: vi.fn(async () => ({
+      checked: 0,
+      drifted: 0,
+      failed: false,
+    })),
 ```
 
 Et le mock du module :
@@ -850,7 +1060,24 @@ vi.mock("@/features/payments/cron", () => ({
 }))
 ```
 
-Ajouter le test qui prouve l'isolation — l'invariant du fichier :
+**Mettre à jour l'assertion exacte du compte-rendu** (`tests/features/cron-close-expired.test.ts:92-98`).
+C'est un `toEqual` strict : ajouter une clé au `Response.json` de la route le fait
+échouer. Remplacer par :
+
+```ts
+    await expect(res.json()).resolves.toEqual({
+      examParticipations: { closedCount: 2 },
+      trainingSessions: { closedCount: 0 },
+      anonymizedAccounts: { anonymizedCount: 0 },
+      notifications: { examResultsSent: 3, accessRemindersSent: 1 },
+      quizRateLimitCleanup: { deletedCount: 0 },
+      priceDrift: { checked: 0, drifted: 0, failed: false },
+    })
+```
+
+Ajouter le test qui prouve l'isolation — l'invariant du fichier. La tâche est
+écrite pour ne jamais lever, mais le dispatcher doit rester la ceinture de
+sécurité si un jour elle le fait :
 
 ```ts
   it("échec de l'audit de prix → les autres tâches tournent quand même", async () => {
@@ -1417,14 +1644,31 @@ git commit -m "test: vérification complète du catalogue par lookup_key"
 
 ## Déploiement
 
-1. **Vérifier la permission `prices:read`** sur la clé Stripe de production (voir Prérequis). C'est le seul point qui casse tout le checkout s'il est manqué.
-2. Merger ce PR. La migration s'applique au build Vercel (`build:vercel` → `migrate-deploy`), avant l'activation du déploiement — d'où le maintien de `stripe_price_id` : l'ancien code tourne encore pendant le build et continue de lire cette colonne.
-3. Après vérification en production (un achat réel, ou l'absence d'alerte `[cron:price-drift]` pendant 24 h), ouvrir le PR de suivi : `DROP COLUMN stripe_price_id`, retrait du champ de `db/schema/payments.ts` et de tous les inserts de tests.
+Deux choses cassent le checkout si elles sont manquées, pas une : la permission
+`prices:read` **et** une `lookup_key` erronée. Les deux sont couvertes par les
+Prérequis — les refaire ici, sur la cible de production, avant de merger.
+
+1. **Vérifier la permission `prices:read`** sur la clé Stripe de production.
+2. **Rejouer la vérification des `lookup_key` en mode live** (`stripe prices list --live`).
+   Le repli de phase 1 amortit une erreur, il ne la répare pas.
+3. Merger ce PR. La migration s'applique au build Vercel (`build:vercel` →
+   `migrate-deploy`), avant l'activation du déploiement — d'où le maintien de
+   `stripe_price_id` : l'ancien code tourne encore pendant le build et continue de
+   lire cette colonne.
+4. **Surveiller Sentry pendant 24 à 48 h.** Le tag `[createStripeCheckout]` avec le
+   message « repli sur stripe_price_id » est le signal que la bascule a échoué pour
+   un produit. Silence = les `lookup_key` sont bonnes en production.
+5. Seulement alors, ouvrir le PR de suivi (phase 2) : retrait du repli
+   `price?.id ?? product.stripePriceId` dans `actions.ts`, retrait du champ du
+   `select`, `DROP COLUMN stripe_price_id`, retrait de `db/schema/payments.ts` et
+   de tous les inserts de tests. Le refus sur `lookup_key` introuvable redevient
+   alors le comportement (« Ce produit est mal configuré »), et le test de repli de
+   la Task 3 est réécrit en ce sens.
 
 ## Hors périmètre — ne pas dériver
 
 - Aucun prix en XAF (couperait la conversion Adaptive Pricing sur cette devise).
 - Aucun backfill de `presentment_details` sur l'historique.
 - Aucun affichage dans la table transactions admin ni dans l'historique client.
-- Aucun blocage de vente sur dérive de prix.
+- Aucun blocage de vente sur un écart de montant (la devise, elle, refuse).
 - Aucun cache sur la résolution du prix.

--- a/docs/superpowers/reviews/2026-08-21-revue-design-stripe-catalogue-lookup-key.md
+++ b/docs/superpowers/reviews/2026-08-21-revue-design-stripe-catalogue-lookup-key.md
@@ -1,0 +1,543 @@
+# Revue adversariale de conception — Catalogue Stripe par `lookup_key`
+
+## 1. En-tête
+
+**Date :** 2026-08-21
+**Nature :** revue **hostile de conception**, avant toute ligne de code. Cible = un spec + un plan écrits, pas un diff.
+
+**Périmètre relu**
+
+| Document | Chemin |
+| --- | --- |
+| Spec | `docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md` (commit `87eeb8f`) |
+| Plan | `docs/superpowers/plans/2026-08-21-stripe-catalogue-lookup-key.md` (commit `1ada0c5`, 1430 lignes) |
+| Issue amont | RinKhimera/NOMAQbanq#138 |
+
+**Fichiers réels confrontés au plan** (état de l'arbre au 2026-08-21) :
+`db/schema/payments.ts` · `drizzle/meta/_journal.json` · `features/payments/actions.ts` ·
+`features/payments/stripe.ts` · `features/payments/dal.ts` · `features/users/dal.ts` ·
+`features/users/cron.ts` · `app/api/stripe/webhook/route.ts` ·
+`app/api/cron/close-expired/route.ts` · `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx` ·
+`lib/format.ts` · `lib/stripe.ts` · `lib/stripe-api-version.ts` · `lib/env/schema.ts` · `lib/env/server.ts` ·
+`scripts/audit-stripe-transactions.ts` · `tests/features/payments-actions.test.ts` ·
+`tests/features/cron-close-expired.test.ts` · `tests/features/users-dal.test.ts` ·
+`tests/lib/format.test.ts` · `tests/components/payments/PricingGrid.test.tsx` ·
+`tests/integration/payments-checkout.test.ts` · `tests/integration/payments-stripe.test.ts` ·
+`vercel.json` · `.github/workflows/cron-hourly.yml` · `vitest.config.ts` · `eslint.config.mjs` ·
+`node_modules/stripe/esm/resources/Prices.d.ts` · `node_modules/stripe/esm/resources/Checkout/Sessions.d.ts` ·
+`node_modules/stripe/esm/stripe.core.js` · `.claude/rules/payments.md` · `.claude/rules/data-layer.md` · `AGENTS.md`
+
+**Méthode :** lecture seule. Chaque constat est prouvé par une lecture `fichier:ligne` ou une commande rejouable,
+et a d'abord subi une tentative sincère de réfutation ; ceux qui n'y ont pas survécu sont consignés en §4.
+
+**État de la vérification (base avant implémentation)**
+
+| Commande | Code de sortie |
+| --- | --- |
+| `bun run check` (prettier + tsc + eslint) | **0** ✅ |
+| `bun run test` (suite frontend — hors mandat strict, mais utile au diagnostic) | **0** ✅ — 114 fichiers, 1300 tests |
+
+> ⚠️ Nuance de base : `bun run check` a tourné sur l'arbre de travail courant
+> (`chore/aligner-types-react-overrides` = `origin/main` + 1 commit). La branche
+> `feat/stripe-catalogue-lookup-key` est **4 commits derrière `origin/main`**
+> (`git log --oneline feat/stripe-catalogue-lookup-key..origin/main` → #145, #142, #147, #146 :
+> bumps de dépendances + `tests/helpers/mocks.ts` + `package.json`/`bun.lock`).
+> `git diff --stat HEAD feat/stripe-catalogue-lookup-key` confirme qu'**aucun fichier du périmètre du plan
+> ne diffère** entre les deux arbres : tous les constats ci-dessous valent sur les deux. Rebaser avant
+> d'implémenter reste préférable (le `tsc` de la branche feat tourne sur un Next/React plus ancien).
+
+---
+
+## 2. Tableau des constats
+
+| # | Sév | fichier:ligne | Problème | Régression ? |
+| --- | --- | --- | --- | --- |
+| F1 | 🔴 | `features/payments/actions.ts:408` | Le plan retire `stripePriceId` du `select` (Task 3) mais ne touche pas le `detail:` du bloc `resource_missing`, qui le lit encore → `tsc` casse. Édition incomplète. | NON (build) |
+| F2 | 🔴 | plan §« Prérequis » + Task 1 Step 3 | Le backfill `lookup_key = code` n'est vérifié **nulle part contre le Stripe LIVE** avant migration. Le plan troque un pointeur connu-bon (`stripe_price_id`, en service en prod) contre un pointeur non vérifié, **sans repli**, en un seul déploiement. | OUI (potentielle : 5/5 produits) |
+| F3 | 🟠 | `tests/features/cron-close-expired.test.ts:91-97` | `toEqual` **exact** sur `res.json()` sans `priceDrift`. La Task 4 ajoute la clé au `Response.json` → ce test casse ; le plan ne le mentionne pas et annonce « PASS » au Step 7. | NON (test) |
+| F4 | 🟠 | spec §Fulfillment + `app/api/stripe/webhook/route.ts:83` | « Le hash n'est présent que si le client a payé en devise locale » est une **hypothèse non vérifiée**. Si Stripe peuple `presentment_details` sur toute session, le panneau admin affiche une ligne redondante aux clients CAD **et** la métrique-phare du spec devient fausse. | NON (colonnes neuves) |
+| F5 | 🟠 | `app/api/cron/close-expired/route.ts:50-64` + `.github/workflows/cron-hourly.yml:56-62` + `lib/stripe.ts:14-16` | Une panne/429 Stripe fait échouer la tâche d'audit → `failed = true` → 500 → `curl --retry 3 --retry-all-errors` rejoue **tout le cron** jusqu'à 4×/h. Et l'appel n'a ni `timeout` (défaut **80 000 ms**) ni `maxNetworkRetries: 0` (défaut **2**) → jusqu'à ~240 s pour un `prices.list`, contre `--max-time 60`. | OUI (comportement du cron entier) |
+| F6 | 🟠 | plan Task 2 Step 3 (JSDoc de `resolveStripePrice`) | Le JSDoc affirme que `limit: 2` « laisse voir une éventuelle anomalie plutôt que de la masquer ». Aucun code ne lit `data.length`. Commentaire faux — précisément la classe de bug que la Task 7 existe pour corriger. | NON |
+| F7 | 🟡 | plan Task 3 Step 4 vs `features/payments/actions.ts:23-30` | « ajouter l'import (bloc `@/` de l'ordre Prettier) » : `./catalog` est un import **relatif** (groupe 3, avant `./dal`). Placé dans le bloc `@/`, `prettier --check` échoue. | NON |
+| F8 | 🟡 | plan Task 6 Step 1 / `tests/lib/format.test.ts` | `expect(out).toContain("2 280 000")` **échoue tel quel** : `Intl` produit des U+00A0. Le plan annonce « Expected: PASS » au Step 4. | NON (test) |
+| F9 | 🟡 | `app/(admin)/…/user-side-panel.tsx:166-173` | Le plan dit « lignes 166-172 » : l'accolade fermante est en **173**. Et **aucun test ne rend `TransactionItem`** → la garde d'affichage `presentmentCurrency !== null` n'a pas de paire jumelle, contre la consigne du spec. | NON |
+| F10 | ℹ️ | plan §« Portée collatérale », Tasks 5 et 7 | Chiffres et ancres approximatifs : « ~20 fichiers de tests » = **17** (16 `.ts`, 21 lignes) ; `scripts/audit-stripe-transactions.ts` « trois premières lignes » = **1-5** ; `features/payments/stripe.ts:140-155` (UPDATE) = **148-157**. | NON |
+| F11 | ℹ️ | spec §« Affichage admin » + plan Task 6 | « Code ISO inconnu d'`Intl` (qui lève `RangeError`) » : `Intl` ne lève que sur un code **mal formé**. `"XYZ"` ne lève pas et est divisé par 100. Le test choisit `"zz"` (2 lettres) — il ne couvre pas le cas réaliste. | NON |
+| F12 | ℹ️ | `AGENTS.md` (structure `features/<domaine>/…`) | `catalog.ts` est un type de module absent de la structure documentée ; la Task 7 met à jour `AGENTS.md` mais pas cette ligne. | NON |
+
+---
+
+## 3. Détail par constat
+
+### F1 🔴 — L'édition de la Task 3 ne compile pas : `product.stripePriceId` survit au retrait du `select`
+
+**Code**
+- `features/payments/actions.ts:341` — `stripePriceId: products.stripePriceId,` (le champ que la Task 3 remplace par `stripePriceLookupKey`).
+- `features/payments/actions.ts:363` — `line_items: [{ price: product.stripePriceId, quantity: 1 }]` (remplacé par le plan ✅).
+- `features/payments/actions.ts:399-404` — le commentaire que le plan réécrit ✅.
+- **`features/payments/actions.ts:408`** — ``detail: `price ${product.stripePriceId} absent du mode de la clé active (produit ${productCode})` `` — **jamais mentionné par le plan**.
+
+**Pourquoi c'est un vrai défaut.** Le plan prescrit trois éditions exactes dans ce `try`/`catch` (le champ du `select`, la ligne `line_items`, le commentaire 399-404) et une quatrième ligne lit encore `product.stripePriceId`. Comme le `select` typé Drizzle détermine la forme de `product`, retirer le champ rend la propriété inexistante : `bunx tsc --noEmit` échoue (`TS2339`). L'agent qui suit le plan à la lettre découvre le problème au Step 5 (« Expected: PASS ») et improvise — exactement ce que le format « chaînes exactes » est censé éviter.
+
+**Régression ?** NON — arrêt au build, aucun risque runtime.
+
+**Comment je l'ai prouvé.**
+```
+grep -n "stripePriceId" features/payments/actions.ts
+# 341:      stripePriceId: products.stripePriceId,
+# 363:      line_items: [{ price: product.stripePriceId, quantity: 1 }],
+# 408:        detail: `price ${product.stripePriceId} absent du mode de la clé active (produit ${productCode})`,
+```
+Le plan (Task 3 Step 4) ne cite que 341, 363 et le commentaire 399-404.
+
+**Correctif suggéré.** Ajouter explicitement au Step 4 :
+```ts
+        detail: `lookup_key ${product.stripePriceLookupKey} : objet Stripe absent à la création (produit ${productCode})`,
+```
+
+---
+
+### F2 🔴 — Le backfill repose sur une affirmation invérifiée, sans repli et sans étape bloquante
+
+**Code**
+- Plan, Task 1 Step 3 : `UPDATE "products" SET "stripe_price_lookup_key" = "code"::text;`
+- Plan, §« Prérequis avant de commencer » : le **seul** prérequis listé est la permission `prices:read`.
+- Plan, §« Déploiement » point 1 : « **C'est le seul point qui casse tout le checkout s'il est manqué.** » — affirmation fausse : la présence des 5 `lookup_key` en mode live est un second point, de gravité identique.
+- Chemin d'échec : `features/payments/actions.ts:405-411` (message « Ce produit est mal configuré. Contactez le support. »).
+
+**Pourquoi c'est un vrai défaut.** Aujourd'hui le checkout facture `products.stripePriceId`, une valeur **empiriquement bonne en production** (les paiements passent). Le plan la remplace par une valeur **dérivée d'un commentaire GitHub du 2026-08-06**, jamais revérifiée, et la nouvelle résolution n'a **aucun repli** : `resolveStripePrice` renvoie `null` → retour immédiat, aucune session, aucune transaction. Un seul `lookup_key` manquant ou mal orthographié en live = 0 vente sur ce produit jusqu'à intervention humaine. Le spec présente ce risque comme dissous (« les 5 `lookup_key` existent déjà des deux côtés »), ce qui transforme une hypothèse en postulat.
+
+Deux aggravants concrets :
+1. La migration tourne **au build Vercel, avant activation** (`vercel.json` → `build:vercel` → `migrate-deploy`) : au moment où le nouveau code sert du trafic, la bascule est déjà faite.
+2. La vérification du plan (Task 1 Step 6) ne contrôle que la base (`lk == code`), **jamais Stripe**. Elle ne peut structurellement pas détecter le cas qui coûte de l'argent.
+
+**Régression ?** OUI (potentielle) — sur le chemin de revenu, pour les 5 produits à la fois.
+
+**Comment je l'ai prouvé.** Lecture du plan (Prérequis, Task 1 Steps 3 et 6, §Déploiement) et de `features/payments/actions.ts:335-415` : le seul consommateur de `stripePriceLookupKey` est `resolveStripePrice`, et son `null` mène directement au `return { error: … }` sans autre branche. `cat vercel.json` confirme l'ordre migration → activation. Aucune écriture ni lecture Stripe n'a été faite pour cette revue (cf. §7).
+
+**Correctif suggéré** (l'un ou l'autre suffit, les deux valent mieux) :
+1. **Étape bloquante en lecture seule, avant la migration**, ajoutée aux Prérequis :
+   ```
+   stripe --api-key <clé TEST> prices list --active \
+     --lookup-keys exam_access --lookup-keys training_access \
+     --lookup-keys exam_access_promo --lookup-keys training_access_promo \
+     --lookup-keys premium_access
+   # puis la même chose avec la clé LIVE.
+   # Attendu des deux côtés : 5 prix, un par clé, en `cad`, `unit_amount` == products.price_cad.
+   ```
+   Refuser de dérouler la Task 1 tant que les deux modes ne rendent pas 5/5.
+2. **Repli pendant la phase 1** (la colonne `stripe_price_id` existe encore, `NOT NULL` — c'est tout l'intérêt de l'expand/contract) :
+   ```ts
+   const price = await resolveStripePrice(stripe, product.stripePriceLookupKey)
+   const priceId = price?.id ?? product.stripePriceId   // filet de la phase 1
+   if (!price) captureServerError(/* lookup_key introuvable, repli sur le price ID */)
+   ```
+   Le PR de suivi (`DROP COLUMN`) retire le repli en même temps que la colonne, **après** la vérification en production que le plan prévoit déjà. Coût : trois lignes. Bénéfice : l'échec devient une alerte Sentry au lieu d'une rupture de vente.
+
+---
+
+### F3 🟠 — La Task 4 casse un test existant que le plan déclare vert
+
+**Code**
+- `tests/features/cron-close-expired.test.ts:91-97` :
+  ```ts
+  await expect(res.json()).resolves.toEqual({
+    examParticipations: { closedCount: 2 },
+    trainingSessions: { closedCount: 0 },
+    anonymizedAccounts: { anonymizedCount: 0 },
+    notifications: { examResultsSent: 3, accessRemindersSent: 1 },
+    quizRateLimitCleanup: { deletedCount: 0 },
+  })
+  ```
+- Plan, Task 4 Step 5 : ajoute `priceDrift` au `Response.json` de `app/api/cron/close-expired/route.ts:117-123`.
+- Plan, Task 4 Step 6 : n'ajoute qu'un mock et un test d'isolation. Step 7 : « Expected: PASS sur les deux fichiers ».
+
+**Pourquoi c'est un vrai défaut.** `toEqual` sur un objet est une égalité **exacte** : une clé supplémentaire fait échouer. La Task 4 se termine donc en rouge, et un agent en mode « fais passer les tests » peut être tenté de retirer la clé du `Response.json` (perte du compte-rendu) plutôt que d'étendre l'assertion.
+
+**Régression ?** NON — défaut de couverture du plan, pas du produit.
+
+**Comment je l'ai prouvé.** Lecture directe de `tests/features/cron-close-expired.test.ts:79-98`, croisée avec `app/api/cron/close-expired/route.ts:117-123`.
+
+**Correctif suggéré.** Ajouter au Step 6 : « étendre l'assertion du test *bearer valide → 200 et compte-rendu de chaque tache* avec `priceDrift: { checked: 0, drifted: 0 }` ».
+
+> Contre-vérification faite : le test `chaque tache est capturee sous son propre tag` (lignes 135-150), lui aussi un `toEqual` **ordonné**, ne casse **pas** — la tâche mockée résout, donc n'ajoute aucun tag. Voir §4.
+
+---
+
+### F4 🟠 — « `presentment_details` n'est présent qu'en devise locale » : hypothèse non vérifiée qui porte la métrique du spec
+
+**Code**
+- `node_modules/stripe/esm/resources/Checkout/Sessions.d.ts:249` — `presentment_details?: Session.PresentmentDetails;` : **optionnel**, sans un mot sur les conditions de présence.
+- `node_modules/stripe/esm/resources/Checkout/Sessions.d.ts:624-633` — `presentment_amount: number` / `presentment_currency: string`, tous deux non nullables quand le hash existe.
+- Spec, §Fulfillment : « Le hash n'est présent **que si** le client a payé en devise locale (doc Adaptive Pricing) […] le taux de lignes non nulles *est* la proportion de clients passés par la conversion. »
+- Plan, Task 5 Step 3 : persiste dès que `presentmentAmount != null && presentmentCurrency`.
+- Plan, Task 6 Step 6 : affiche dès que les deux champs sont non nuls.
+
+**Pourquoi c'est un vrai défaut.** Le SDK installé, seule source d'autorité disponible en lecture seule ici, **ne confirme pas** la condition. Stripe peuple `presentment_details` sur `Charge`, `PaymentIntent`, `Refund` et `Subscription` (mêmes `.d.ts`) — un ensemble d'objets qui suggère un champ descriptif général plutôt qu'un marqueur de conversion. Si le hash arrive aussi pour un client canadien (`presentment_currency: "cad"`, `presentment_amount === amount_total`), alors :
+- le panneau admin affiche `+50,00 $ CA` **puis** `présenté : 50,00 $` — du bruit sur 100 % des lignes, alors que la ligne est censée être l'exception ;
+- la mesure annoncée (« taux de lignes non nulles = proportion de conversions ») vaut 100 % quoi qu'il arrive, c'est-à-dire rien.
+
+Le coût du doute est asymétrique : se tromper côté « toujours présent » pollue durablement la base et le panneau ; la garde coûte une comparaison.
+
+**Régression ?** NON — les deux colonnes sont neuves, `amountPaid`/`currency` ne bougent pas (invariant respecté : le bloc `reconcile` de `features/payments/stripe.ts:119-146` n'est modifié par aucune tâche).
+
+**Comment je l'ai prouvé.**
+```
+grep -n "presentment" node_modules/stripe/esm/resources/Checkout/Sessions.d.ts
+grep -rn "presentment_details" node_modules/stripe/esm/resources/*.d.ts node_modules/stripe/esm/resources/**/*.d.ts
+grep -n -i "presentment" node_modules/stripe/CHANGELOG.md   # une seule ligne, purement descriptive
+```
+Aucune de ces sources ne conditionne la présence du hash à une conversion. Le compte Stripe n'a pas été interrogé (cf. §7).
+
+**Correctif suggéré.** Ne persister (ou a minima n'afficher) que ce qui est réellement informatif :
+```ts
+const converted =
+  params.presentmentCurrency &&
+  params.presentmentCurrency.toLowerCase() !== (params.currency ?? "").toLowerCase()
+```
+et marquer explicitement l'hypothèse dans le spec, à confirmer au Step 4 de la Task 8 — ce test manuel est justement l'occasion de vérifier, dans le même passage, ce que reçoit un client **canadien**.
+
+---
+
+### F5 🟠 — La tâche cron peut faire échouer tout le cron, et son appel Stripe n'est pas borné
+
+**Code**
+- `app/api/cron/close-expired/route.ts:50-64` — `run()` positionne `failed = true` sur exception.
+- `app/api/cron/close-expired/route.ts:99` — `if (failed) return new Response("Cron handler error", { status: 500 })`.
+- `.github/workflows/cron-hourly.yml:56-62` — `curl --fail-with-body … --retry 3 --retry-delay 10 --retry-all-errors --max-time 60`.
+- `lib/stripe.ts:14-16` — `new Stripe(key, { apiVersion })` : ni `timeout` ni `maxNetworkRetries`.
+- `node_modules/stripe/esm/stripe.core.js:96` — `const DEFAULT_TIMEOUT = 80000;`
+- `node_modules/stripe/esm/stripe.core.js:168` — `maxNetworkRetries: validateInteger('maxNetworkRetries', props.maxNetworkRetries, 2)`.
+- Patron de référence que le plan dit suivre : `features/users/cron.ts:25-45` — la tâche **avale ses propres erreurs** (`try`/`catch` par ligne) et ne remonte jamais d'exception.
+
+**Pourquoi c'est un vrai défaut.** Trois conséquences enchaînées, toutes absentes du tableau « Coût — mesuré, pas supposé » du spec, qui ne chiffre que le chemin heureux :
+
+1. **Amplification.** `--retry-all-errors --retry 3` rejoue sur un 500. Une indisponibilité Stripe fait donc tourner **4 fois par heure** l'intégralité du cron — clôtures, anonymisation RGPD, notifications comprises. Le spec annonce « ~25 requêtes/jour » ; sous panne c'est ~100, et surtout ~96 exécutions supplémentaires des quatre autres tâches.
+2. **Durée.** Le SDK réessaie 2 fois par défaut, avec un timeout de 80 s par tentative : un `prices.list` peut occuper ~240 s. Le `--max-time 60` du workflow coupe bien avant — le job GitHub échoue pendant que la fonction continue de tourner.
+3. **Inversion de gravité.** Une tâche **strictement informative et en lecture seule** (elle n'écrit ni en base ni chez Stripe, le plan le dit lui-même) devient capable de marquer tout le cron en échec. La tâche existante la plus proche, `anonymizeExpiredDeletedAccounts`, fait exactement l'inverse : elle isole ses erreurs en interne pour ne jamais bloquer la file.
+
+Le plan **assume** ce choix : son test de la Task 4 Step 6 exige `expect(res.status).toBe(500)`. C'est là que je suis en désaccord : l'isolation par `run()` protège les tâches *suivantes*, pas le code de retour — et c'est le code de retour qui pilote le rejeu.
+
+**Régression ?** OUI — le comportement du cron entier change sur un chemin d'erreur externe qui n'existait pas (aucune tâche actuelle n'appelle un tiers réseau).
+
+**Comment je l'ai prouvé.** Lectures ci-dessus, plus :
+```
+grep -rn "maxNetworkRetries\|DEFAULT_TIMEOUT" node_modules/stripe/esm/stripe.core.js
+grep -n "maxDuration" -r app next.config.ts vercel.json   # aucun résultat : pas de borne applicative
+cat vercel.json                                            # cron quotidien "0 0 * * *", aucune clé `functions`
+```
+
+**Correctif suggéré.**
+```ts
+export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
+  try {
+    // … corps actuel …
+  } catch (error) {
+    captureServerError("[cron:price-drift]", error, { detail: "audit interrompu" })
+    return { checked: 0, drifted: 0 }   // un audit ne fait pas échouer le cron
+  }
+}
+```
+et borner l'appel : `stripe.prices.list({ … }, { timeout: 10_000, maxNetworkRetries: 0 })` (second argument `RequestOptions`, supporté par le SDK). Adapter le test de la Task 4 Step 6 : « échec de l'audit → **200**, les autres tâches ont tourné, une capture Sentry ».
+
+---
+
+### F6 🟠 — Le JSDoc de `resolveStripePrice` décrit un garde-fou qui n'existe pas
+
+**Code** — plan, Task 2 Step 3 :
+```
+ * […] `limit: 2` laisse néanmoins voir une éventuelle anomalie plutôt que de la masquer.
+```
+suivi de :
+```ts
+  const { data } = await stripe.prices.list({ lookup_keys: [lookupKey], active: true, limit: 2 })
+  return data[0] ?? null
+```
+
+**Pourquoi c'est un vrai défaut.** `data.length` n'est lu nulle part, ni dans l'implémentation ni dans le test de la Task 2 Step 1. `limit: 2` ne fait donc **rien** de plus que `limit: 1`. Le commentaire affirme le contraire de ce que fait le code — exactement la classe de défaut que la **Task 7 existe pour corriger** dans trois autres fichiers. Le prochain lecteur croira l'anomalie surveillée.
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé.** Lecture du bloc complet de la Task 2 Step 3 dans le plan ; aucune occurrence de `data.length` ni de `data[1]`.
+
+**Correctif suggéré.** Rendre le commentaire vrai (trois lignes) — ce qui répond aussi à la question ouverte n°3 :
+```ts
+  if (data.length > 1) {
+    captureServerError(
+      "[resolveStripePrice]",
+      new Error("plusieurs prix actifs pour une même lookup_key"),
+      { detail: `lookup_key ${lookupKey} · ${data.map((p) => p.id).join(", ")}` },
+    )
+  }
+```
+Sinon : `limit: 1` et suppression de la phrase.
+
+---
+
+### F7 🟡 — L'import prescrit viole l'ordre Prettier du projet
+
+**Code**
+- Plan, Task 3 Step 4 : « ajouter l'import (**bloc `@/`** de l'ordre Prettier) : `import { describePriceDrift, resolveStripePrice } from "./catalog"` ».
+- `features/payments/actions.ts:3-30` — ordre réel : npm (3-4), puis `@/` (5-11), puis **relatifs triés** (`./dal` 12-23, `./lib` 24, `./schemas` 25-30).
+- `AGENTS.md` §Gotchas : « **Prettier** : Import order enforce: 1) node/npm 2) `@/` 3) relatifs ».
+
+**Pourquoi c'est un vrai défaut.** `./catalog` appartient au groupe 3 et se trie **avant** `./dal`. Placé dans le bloc `@/` comme le plan le demande, `prettier --check .` échoue — donc `bun run check` (Task 7 Step 6, Task 8 Step 3) et la CI.
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé.** `sed -n '1,35p' features/payments/actions.ts` + la ligne Gotchas d'`AGENTS.md`.
+
+**Correctif suggéré.** « Insérer `import { describePriceDrift, resolveStripePrice } from "./catalog"` **juste avant** le bloc `from "./dal"` ».
+
+---
+
+### F8 🟡 — Le test de `formatPresentmentAmount` échoue tel qu'écrit
+
+**Code** — plan, Task 6 Step 1 :
+```ts
+  it("devise zéro-décimal : l'unité mineure EST l'unité", () => {
+    const out = formatPresentmentAmount(2280000, "xaf")
+    expect(out).toContain("2 280 000")
+```
+puis Step 4 : « Run: `bun run test tests/lib/format.test.ts` — Expected: **PASS** ».
+
+**Pourquoi c'est un vrai défaut.** `Intl.NumberFormat("fr-CA", { style: "currency", currency: "XAF" })` produit `"2 280 000 XAF"` avec des **U+00A0**, pas des espaces ASCII. L'assertion échoue. Le plan anticipe la gêne (« si `toContain` échoue, comparer via `out.replace(/\s/g, " ")` ») mais annonce quand même PASS — un agent voit un rouge inattendu au milieu d'un cycle TDD censé être déjà vert.
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé** (rejouable) :
+```
+node -e 'const f=(m,c)=>{const code=c.toUpperCase();const fm=new Intl.NumberFormat("fr-CA",{style:"currency",currency:code});const d=fm.resolvedOptions().maximumFractionDigits??2;return fm.format(m/10**d)};
+const o=f(2280000,"xaf");console.log(JSON.stringify(o),[...o].map(c=>c.charCodeAt(0).toString(16)).join(" "),o.includes("2 280 000"))'
+# "2 280 000 XAF"  32 a0 32 38 30 a0 30 30 30 a0 58 41 46  false
+```
+La logique de division, elle, est correcte : `xaf` → 0 décimale, `cad` → 2, `kwd` → 3 (vérifiés dans le même script). Le repli `\s` proposé par le plan fonctionne bien : ` ` **est** couvert par `\s` en JS.
+
+**Correctif suggéré.** Écrire l'assertion normalisée d'emblée :
+```ts
+const norm = (s: string) => s.replace(/\s/g, " ")   // \s couvre U+00A0 et U+202F
+expect(norm(formatPresentmentAmount(2280000, "xaf"))).toContain("2 280 000")
+```
+
+---
+
+### F9 🟡 — Ancre à une ligne près, et la garde d'affichage n'a pas de paire jumelle
+
+**Code**
+- `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx:166-173` — le `formatCurrency` local que le plan dit supprimer « (lignes 166-172) » ; l'accolade fermante `}` est en **173**. Un retrait par plage littérale laisse une accolade orpheline.
+- Même fichier, ligne 39 : `import { formatExpiration, formatMediumDate } from "@/lib/format"` ✅ conforme au plan ; bloc du montant en **216-218** ✅ (« ligne ~216 »).
+- `grep -rn "user-side-panel" tests/` → **vide** : aucun test ne rend ce composant.
+
+**Pourquoi c'est un vrai défaut.** Le spec impose : « Écrire les tests **par paires jumelles** : un cas où la garde doit passer, un cas où elle doit mordre. » La nouvelle garde `presentmentCurrency !== null && presentmentAmount !== null` est précisément une garde, et la section Tests du spec ne la couvre pas — elle ne teste que `formatPresentmentAmount`, en aval. Rien ne prouve que la ligne « présenté : … » disparaît pour un client canadien (ce qui est aussi le symptôme de F4).
+
+**Régression ?** NON.
+
+**Comment je l'ai prouvé.** Lecture de `user-side-panel.tsx:150-221` (numérotation vérifiée) ; `grep -rn "user-side-panel\|recentTransactions" tests/`.
+
+**Correctif suggéré.** Corriger l'ancre en `166-173`, et ajouter à la Task 6 un test de rendu de `TransactionItem` (deux cas : `presentmentCurrency` renseignée → la ligne apparaît ; nulle → elle n'apparaît pas). Le fichier n'entre pas dans l'`include` de couverture (`vitest.config.ts:39-45` ne couvre que `lib/**`, `hooks/**`, `components/**`, `schemas/**`, `email/**`), donc le seuil de 80 % ne le réclamera jamais : c'est bien un choix explicite à poser.
+
+---
+
+### F10 ℹ️ — Chiffres et ancres à corriger
+
+- « **~20 fichiers de tests** insèrent `stripePriceId` » : **17** fichiers, dont 1 en `.tsx` exclu du `sed` → **16 fichiers, 21 lignes** réellement touchées.
+  Preuve : `grep -rn "stripePriceId" tests/` → 22 lignes dont 1 `.tsx` ; `grep -rl "stripePriceId" tests/ | wc -l` → 17.
+- `scripts/audit-stripe-transactions.ts` — « remplacer les **trois premières lignes** du bloc » : le paragraphe visé s'étend sur les lignes **1-5**.
+- `features/payments/stripe.ts:140-155` (annoncé pour le `set` de l'`UPDATE`) : le `.set({…})` réel est en **148-157**.
+- Ancres **vérifiées exactes**, en revanche : `db/schema/payments.ts:35` ✅ · `features/payments/actions.ts:341` ✅ · `features/payments/actions.ts:399-404` ✅ · `features/payments/stripe.ts:52-70` (signature) ✅ · `features/payments/stripe.ts:46-50` (dernier paragraphe du JSDoc) ✅ · `app/api/stripe/webhook/route.ts:70-80` ✅ · `features/users/dal.ts:586-595` et `637-680` ✅ · `features/payments/dal.ts:107-140` ✅ · `tests/components/payments/PricingGrid.test.tsx:53-54` ✅ · `lib/format.ts:32-55` ✅ · `tests/integration/payments-stripe.test.ts:32-45` (`length: 11` + 11 noms) ✅ · `tests/integration/payments-stripe.test.ts:60-74` (`txStatus`) ✅ · `.claude/rules/payments.md:59-65` ✅ · numérotation `drizzle/0013_*` ✅ (le journal s'arrête à `0012_lowly_paper_doll`).
+- La branche `feat/stripe-catalogue-lookup-key` est 4 commits derrière `origin/main` : à rebaser avant de commencer.
+
+---
+
+### F11 ℹ️ — « `Intl` lève sur un code inconnu » : vrai seulement pour un code mal formé
+
+`new Intl.NumberFormat("fr-CA", { style: "currency", currency: "XYZ" })` ne lève **pas** : le `RangeError` ne survient que si le code n'est pas trois lettres ASCII. Prouvé par le même script que F8 : `"zz"` → `"1234 ZZ"` (repli) mais `"xyz"` → `"12,34 XYZ"` (divisé par 100 par défaut). Le test choisi (`"zz"`) valide donc le repli, pas le cas « code ISO inconnu ». Conséquence pratique nulle — `presentment_currency` vient de Stripe et sera toujours un code ISO réel — mais la phrase du spec est à rectifier pour ne pas induire le prochain lecteur.
+
+---
+
+### F12 ℹ️ — `catalog.ts` absent de la structure documentée
+
+`AGENTS.md` décrit `features/<domaine>/{schemas,dal,actions,lib,cron}.ts`. La Task 7 met `AGENTS.md` à jour (puce « Stripe en dev ») mais laisse la ligne de structure. Ajouter `catalog` à l'énumération, ou justifier le module dans `.claude/rules/payments.md`. La justification du plan (« ni base ni session, testable sans mock Drizzle ») est bonne — elle mérite de survivre au merge.
+
+---
+
+## 4. Faux positifs écartés
+
+| Soupçon | Verdict | Preuve |
+| --- | --- | --- |
+| Le `sed` de la Task 1 raterait des inserts multi-lignes ou différemment formatés | **Écarté** | Dry-run **sans `-i`** sur les 16 fichiers `.ts` : 21 insertions, soit exactement les 21 occurrences recensées par `grep -rn "stripePriceId" tests/`. Toutes sont mono-ligne et finissent par `,`. `find tests -name '*.ts'` ne matche pas `.tsx` — l'exclusion volontaire de `PricingGrid.test.tsx` annoncée par le plan est exacte. |
+| `restoreMocks: true` (`vitest.config.ts:33`) effacerait les implémentations posées dans `vi.hoisted`, cassant les mocks `prices.list` du plan | **Écarté** | Vitest **4.1.10** : `mockReset` restaure l'implémentation passée à `vi.fn(impl)`. Preuve empirique : `vi.mock("@/lib/auth-guards", () => ({ requireSession: vi.fn(async () => …) }))` (`tests/integration/payments-checkout.test.ts:24-29`) n'est jamais reposé et la suite est verte. |
+| Le retrait de `stripePriceId`/`stripeProductId` de `ProductView` casserait un composant ou un test | **Écarté** | `grep -rn "\.stripePriceId\|\.stripeProductId" app components features scripts lib` → seulement `features/payments/dal.ts:136-137` et `features/payments/actions.ts`. Aucun test n'annote un littéral en `ProductView` (`grep -rln "ProductView" tests/` → vide) : `tests/components/payments/PricingGrid.test.tsx:43-55` passe une **variable**, ce qui désactive le contrôle de propriétés excédentaires de TS. |
+| Passer au `formatCurrency` partagé changerait l'affichage XAF du panneau admin | **Écarté** | Comparaison des deux implémentations en Node : `"22 800 XAF"` des deux côtés, `"50 $"` / `"123,45 $"` identiques en CAD. Seul le codepoint de l'espace insécable diffère (`fr-CA` vs `fr-FR`), invisible à l'écran. |
+| Les tests de `getUserPanelData` construiraient un `PanelTransaction` littéral et casseraient sur les deux nouveaux champs | **Écarté** | `tests/features/users-dal.test.ts:186-204` lit `panel?.recentTransactions[0]?.product` uniquement ; `tests/integration/users-admin-dal.test.ts:298-309` idem. Aucun `toEqual` sur l'objet complet. La claim du plan (Task 6 Step 7) est exacte. |
+| Un second appel à `completeStripeTransaction` (paiement différé) oublierait `presentment_*` | **Écarté** | `app/api/stripe/webhook/route.ts:67-83` : `checkout.session.completed` et `checkout.session.async_payment_succeeded` **partagent** le même `case` et le même appel. L'invariant de `.claude/rules/payments.md` (« `async_payment_succeeded` DOIT rester branché sur le même chemin d'octroi ») est préservé. |
+| Le test `chaque tache est capturee sous son propre tag` (`toEqual` ordonné) casserait avec la nouvelle tâche | **Écarté** | `tests/features/cron-close-expired.test.ts:135-150` ne rejette que 4 tâches ; l'audit mocké résout et n'ajoute aucun tag. |
+| Un script de seed ou la route `app/api/e2e` insérerait des `products` et casserait sur la colonne `NOT NULL` | **Écarté** | `grep -rn "insert(products)" app features scripts lib e2e drizzle` → aucun résultat. `app/api/e2e/route.ts:258-260` fait un `select` seul. Seuls les tests insèrent. |
+| `scripts/audit-stripe-transactions.ts` dépendrait de `stripe_price_id` | **Écarté** | `grep -n "stripePriceId" scripts/audit-stripe-transactions.ts` → vide. Il ne lit que `amountPaid`/`currency`/`stripeSessionId`. Seul son en-tête est à corriger. |
+| Le `::text` de la migration serait décoratif (cast implicite enum→text) | **Écarté comme constat** | Le cast explicite est correct et sans coût ; la prudence du plan est justifiée. |
+| « `lookup_keys` accepte 10 clés » serait un chiffre inventé | **Écarté** | `node_modules/stripe/esm/resources/Prices.d.ts:667` — « You can specify **up to 10** lookup_keys ». Le `LOOKUP_KEYS_PER_CALL = 10` du plan est exact, et le découpage est réellement nécessaire à terme. |
+| Le mock `@/db/schema` du test cron (`products: { code: {}, … }`) ferait échouer `eq(products.isActive, true)` | **Écarté** | Le même motif existe déjà : `tests/features/payments-actions.test.ts:66-81` mocke `products: { id: {}, code: { enumValues } }` et `eq(products.code, …)` fonctionne. Suite verte. |
+| Le nouvel appel Stripe dans le cron ouvrirait une connexion Neon supplémentaire | **Écarté** | La tâche ne fait qu'un `db.select(...).limit(50)` **hors** transaction, dans un dispatcher séquentiel (`app/api/cron/close-expired/route.ts:40-44`). L'invariant « jamais de `db` global dans une `db.transaction` » (`.claude/rules/data-layer.md`) n'est pas approché. |
+| L'idempotence du fulfillment serait affaiblie par l'écriture des colonnes `presentment_*` | **Écarté** | Le plan les fusionne dans le `set` de l'`UPDATE` existant (`features/payments/stripe.ts:148-157`), lui-même sous `SELECT … FOR UPDATE` (75-79) et après les deux contrôles d'idempotence (82-94). Aucune écriture ni requête supplémentaire. |
+| `amountPaid`/`currency` seraient touchés | **Écarté** | Le bloc `reconcile` (`features/payments/stripe.ts:119-146`) n'est modifié par aucune tâche ; le spread `...(presentment ?? {})` est ajouté **après** `...(reconcile ?? {})` et ne partage aucune clé. |
+| Le retrait du `resource_missing` de `createStripeCheckout` casserait un test existant | **Écarté** | Aucun test unitaire ne couvre cette branche : `tests/features/payments-actions-errors.test.ts:46-50` ne teste `resource_missing` que pour `verifyStripeCheckout`. |
+
+---
+
+## 5. Réponses aux questions ouvertes
+
+### Q1 — Le backfill invérifié : le plan prévoit-il assez de garde-fous ?
+
+**Non, et c'est le point le plus grave du dossier.** Voir **F2**. En résumé :
+
+- Le seul prérequis listé est `prices:read` ; le plan va jusqu'à écrire « c'est le **seul** point qui casse tout le checkout », ce qui est factuellement faux.
+- La vérification prévue (Task 1 Step 6) ne regarde que Postgres. Elle ne peut structurellement pas détecter une clé absente du catalogue live.
+- Il n'existe **aucun repli** : `resolveStripePrice` → `null` → `return { error }`, fin.
+
+**Recommandation, dans cet ordre :**
+1. **Étape bloquante, lecture seule, avant la Task 1** : lister les 5 `lookup_key` en modes test **et** live ; exiger 5/5 des deux côtés, en `cad`, avec `unit_amount` égal à `products.price_cad`. Deux minutes, et l'hypothèse devient un fait.
+2. **Repli pendant la phase 1** (`price?.id ?? product.stripePriceId`), retiré par le PR `DROP COLUMN`. Le plan garde déjà la colonne pour l'expand/contract ; ne pas s'en servir comme filet est un gaspillage.
+3. **Ordre de déploiement réversible écrit noir sur blanc** : le rollback fonctionne déjà (la colonne survit, l'ancien code la relit), mais il faut nommer le signal à surveiller (`[createStripeCheckout]` / « aucun prix actif pour cette lookup_key » dans Sentry) et le délai au-delà duquel on revient en arrière.
+
+### Q2 — Alerter sans bloquer sur la dérive de prix : bon arbitrage ?
+
+**Oui, je maintiens l'arbitrage du spec** — mais l'argumentaire est incomplet, et la nuance manquante coûte peu.
+
+Pour, et c'est décisif : couper la vente d'un produit sur un écart de configuration transforme une erreur d'ops silencieuse en panne totale de revenu, avec un diagnostic plus long (« pourquoi personne n'achète ? ») qu'un écart facturé. Le repo a déjà tranché dans ce sens ailleurs : la réconciliation montant/devise « ne doit jamais faire échouer un paiement valide » (`.claude/rules/payments.md` ; `features/payments/stripe.ts:134-146`).
+
+Contre, l'argument le plus fort — celui du litige — **ne tient pas dans le sens invoqué**. Un client qui voit 300 $ affichés et se voit facturer 350 $ ne paie pas : Stripe Checkout montre le montant **avant** confirmation. Le vrai dommage est plus modeste : abandon de panier, méfiance, un ticket au support. Dans l'autre sens (base 350 $, Stripe 300 $), l'entreprise perd 50 $ par vente sans que personne ne s'en aperçoive — mais bloquer ne « sauve » rien : ça remplace 300 $ encaissés par 0 $.
+
+En revanche, deux durcissements bon marché manquent :
+- **Un plafond de tolérance.** Une dérive de +900 % n'est plus une erreur de tarif, c'est un `lookup_key` pointant sur un autre produit. Au-delà d'un seuil (écart relatif > 50 %, par exemple), le message « produit mal configuré » est *plus* juste que la vente.
+- **La devise devrait bloquer, pas seulement alerter.** `price.currency !== "cad"` signifie que le prix résolu n'appartient pas à l'intégration : le montant affiché en CAD et le montant facturé ne sont même plus comparables, et Adaptive Pricing se désactive sur cette devise (`.claude/rules/payments.md`). Vendre dans ce cas est un choix indéfendable a posteriori.
+
+### Q3 — Stripe garantit-il l'unicité de `lookup_key` parmi les prix actifs ?
+
+**Oui — le SDK installé le dit implicitement. Mais le code n'en tire pas la conséquence qu'il annonce.**
+
+Preuves dans `node_modules/stripe/esm/resources/Prices.d.ts` :
+- lignes 344 (create) et 579 (update) — `transfer_lookup_key` : « If set to true, will **atomically remove the lookup key from the existing price**, and assign it to this price. » Un transfert n'a de sens que si la clé ne peut appartenir qu'à un prix à la fois.
+- ligne 667 (list) — « Only return **the price** with these lookup_keys » (singulier).
+
+Donc `data.length > 1` ne devrait pas survenir avec `active: true`. **Mais** :
+1. C'est une garantie de service, pas une contrainte que l'app observe. Un `data[0]` silencieux sur une anomalie de facturation est exactement le genre de silence que ce PR combat par ailleurs.
+2. Le JSDoc prescrit **prétend déjà** qu'on la surveille (**F6**). Il faut soit tenir la promesse, soit la retirer.
+
+**Ma position : traiter `data.length > 1` comme une anomalie** — `captureServerError` puis continuer avec `data[0]` (ne pas bloquer, cohérent avec Q2). Trois lignes, et le commentaire redevient vrai.
+
+### Q4 — Supprimer `stripe_price_id` fait-il perdre la trace du prix facturé ?
+
+**Non — et la prémisse est fausse dès aujourd'hui.**
+
+1. **Aucune colonne n'a jamais enregistré le prix d'une transaction donnée.** `transactions` (`db/schema/payments.ts:53-100`) ne porte aucun champ de prix Stripe. `products.stripePriceId` est un pointeur **par produit**, mutable : si le tarif change, une ancienne transaction pointe rétroactivement sur le nouveau prix. La « trace » invoquée n'existe pas — elle est même trompeuse.
+2. **Le chemin de récupération existe et est stable.** `transactions.stripe_session_id` (`db/schema/payments.ts:69`, indexé ligne 93) permet `stripe.checkout.sessions.listLineItems(sessionId)`, qui rend le `price.id` **réellement facturé** pour cette session — plus fiable que le pointeur produit.
+3. **Aucun consommateur dans le dépôt.** `grep -n "stripePriceId" scripts/audit-stripe-transactions.ts` → vide ; le script ne lit que `amountPaid`/`currency`/`stripeSessionId`. Hors `db/schema`, `features/payments/dal.ts:136-137` et `features/payments/actions.ts:341/363/408`, plus rien ne le touche.
+
+**Réserve :** aucune. L'index `products_stripe_product_id_idx` (`db/schema/payments.ts:48`) porte sur `stripe_product_id`, qui reste — le `DROP COLUMN` de suivi est propre.
+
+### Q5 — Le silence du cron sans `STRIPE_SECRET_KEY` masque-t-il une misconfiguration de prod ?
+
+**Non, et le choix est bon.** Trois raisons vérifiées :
+
+1. `lib/env/schema.ts:43` — `STRIPE_SECRET_KEY: z.string().optional()`. L'app assume déjà de tourner sans Stripe ; faire échouer une tâche de fond sur ce motif contredirait le schéma d'env.
+2. `lib/stripe.ts:9-13` — `getStripe()` **lève** si la clé manque. Sans la garde, la tâche jetterait à chaque exécution et, via **F5**, ferait échouer tout le cron en environnement sans Stripe (preview, CI). Le remède serait pire que le mal.
+3. **Le symptôme réel est ailleurs, et il est assourdissant.** En production, une `STRIPE_SECRET_KEY` absente ne produit pas un cron silencieux : elle produit un **checkout entièrement cassé** (`getStripe()` lève dans `createStripeCheckout`, capturé en Sentry) et un webhook qui répond 500 (`app/api/stripe/webhook/route.ts:39-42`). Le `refine` de `lib/env/schema.ts:73-76` couple déjà les deux variables. Aucun masquage possible.
+
+Détail à corriger tout de même : `checked: 0` est renvoyé dans **deux** cas distincts (« pas de clé » et « aucun produit actif »), ce qui rend le compte-rendu JSON ambigu. Un troisième état (`skipped: true`) le lèverait sans complexité.
+
+### Q6 — Le nouvel aller-retour réseau dans un dispatcher séquentiel : risque de timeout ?
+
+**Oui, et le spec ne l'a pas mesuré.** C'est **F5**. Les chiffres réels :
+
+| Élément | Valeur mesurée | Source |
+| --- | --- | --- |
+| Timeout de requête du SDK Stripe | **80 000 ms** | `node_modules/stripe/esm/stripe.core.js:96` |
+| Réessais réseau du SDK (défaut, non surchargé) | **2** | `node_modules/stripe/esm/stripe.core.js:168` ; `lib/stripe.ts:14-16` ne passe ni `timeout` ni `maxNetworkRetries` |
+| Pire cas pour **un** `prices.list` | ~240 s | 3 tentatives × 80 s |
+| Fenêtre du déclencheur horaire | **60 s** | `.github/workflows/cron-hourly.yml:60` (`--max-time 60`) |
+| Rejeu sur erreur | **3 réessais, toutes erreurs** | `.github/workflows/cron-hourly.yml:58` |
+| `maxDuration` applicatif | **aucun** | `grep -rn "maxDuration" app next.config.ts vercel.json` → vide |
+
+En régime normal, la tâche ajoute ~200-500 ms : négligeable, le spec a raison sur ce point. Le problème est la **queue de distribution** : c'est le premier appel réseau tiers du cron, il n'est pas borné, et son échec est amplifié ×4 par le workflow. Correctif en F5 (borner l'appel + avaler l'erreur dans la tâche). À noter que le même raisonnement vaut, en plus modeste, sur le chemin utilisateur du checkout : `createStripeCheckout` passe de un à **deux** appels Stripe non bornés, donc de ~240 s à ~480 s de pire cas théorique. Fixer `timeout`/`maxNetworkRetries` sur la résolution du prix vaut aussi là-bas.
+
+### Q7 — `presentment_currency` en texte libre, normalisé à l'écriture seulement : suffisant ?
+
+**Suffisant pour l'affichage, insuffisant pour l'agrégation future.**
+
+- **Affichage : aucun risque.** `formatPresentmentAmount` refait `currency.toUpperCase()` (plan, Task 6 Step 3) : la casse en base n'a aucun effet. Et `Intl` ne lève que sur un code mal formé (**F11**), pour lequel le repli existe.
+- **Agrégation : le piège est réel.** La normalisation vit dans **une seule fonction applicative** (`completeStripeTransaction`). Rien au niveau du schéma n'empêche un `INSERT` manuel, un backfill, un futur import ou un second écrivain de poser `"xaf"`. Un `GROUP BY presentment_currency` rendrait alors deux lignes pour une même devise — la classe de bug la plus discrète qui soit.
+- **Le choix du `text` plutôt que d'un enum reste le bon** : l'argument du spec (150+ devises possibles vs un enum à deux valeurs) est solide, et contraindre ferait perdre exactement la donnée recherchée.
+
+**Correctif proposé** — une contrainte qui n'ôte aucune liberté et rend l'invariant indépendant du code appelant :
+```sql
+ALTER TABLE "transactions"
+  ADD CONSTRAINT transactions_presentment_currency_iso
+  CHECK ("presentment_currency" IS NULL OR "presentment_currency" ~ '^[A-Z]{3}$');
+```
+Elle documente le format, bloque la casse basse et les codes mal formés, et coûte une ligne dans la migration `0013`. À noter aussi : aucun index n'est prévu sur la colonne — correct au volume actuel, mais l'agrégation par devise sera un scan complet ; un choix à assumer plutôt qu'à découvrir.
+
+---
+
+## 6. Verdict
+
+### Le plan est-il sûr et complet à implémenter tel quel ? — **NON**
+
+La conception d'ensemble est bonne, et il faut le dire : la bascule vers `lookup_key` élimine réellement la classe « identifiant du mauvais mode » plutôt que de la détecter ; l'expand/contract est correctement raisonné face au `migrate-deploy` du build Vercel ; l'idempotence du fulfillment et l'invariant comptable `amountPaid`/`currency` sont préservés sans y toucher ; et **13 des 16 ancres de lignes citées sont exactes** dans l'arbre actuel. Le plan est nettement au-dessus de la moyenne sur la traçabilité.
+
+Deux points bloquent néanmoins :
+
+1. **F1** — l'édition de la Task 3 est incomplète : `features/payments/actions.ts:408` lit encore `product.stripePriceId` après le retrait du `select`. Le type-check casse au Step 5.
+2. **F2** — le cœur du changement (le backfill `lookup_key = code`) repose sur une affirmation invérifiée, appliquée en production sans étape de vérification bloquante et **sans repli**, alors que la colonne qui servirait de filet est justement conservée par le design.
+
+### Correctifs priorisés
+
+#### À corriger **avant** de coder
+
+| # | Correctif | Coût |
+| --- | --- | --- |
+| F2 | Ajouter aux Prérequis une **vérification bloquante en lecture seule** des 5 `lookup_key` en modes test **et** live (5/5, `cad`, `unit_amount` = `price_cad`). Ajouter le repli `price?.id ?? product.stripePriceId` pour la phase 1, retiré par le PR `DROP COLUMN`. Écrire la procédure de rollback et le signal Sentry à surveiller. | ~15 min de plan, 3 lignes de code |
+| F1 | Ajouter au Step 4 de la Task 3 l'édition de la ligne 408 (`detail:` → `stripePriceLookupKey`). | 1 ligne |
+| F3 | Ajouter au Step 6 de la Task 4 : étendre l'assertion `toEqual` de `tests/features/cron-close-expired.test.ts:91-97` avec `priceDrift`. | 1 ligne |
+| F5 | Envelopper `auditProductPriceDrift` dans son propre `try`/`catch` (patron `features/users/cron.ts:27-45`) et borner l'appel (`{ timeout: 10_000, maxNetworkRetries: 0 }`). Adapter le test d'isolation : 200, pas 500. | ~8 lignes |
+| F4 | Décider maintenant : persister/afficher `presentment_*` seulement si `presentment_currency ≠ currency` de session, **ou** marquer explicitement l'hypothèse dans le spec et la vérifier au Step 4 de la Task 8 avec un client **canadien**. | 2 lignes + une phrase de spec |
+| F7 | Corriger l'instruction d'import : `./catalog` va dans le groupe relatif, avant `./dal`. | 1 mot |
+
+#### À surveiller **pendant** l'implémentation
+
+| # | Point de vigilance |
+| --- | --- |
+| F6 | Rendre vrai le JSDoc de `resolveStripePrice` (capturer `data.length > 1`) ou retirer la phrase. |
+| F8 | Écrire l'assertion XAF déjà normalisée (`replace(/\s/g, " ")`) plutôt que de découvrir l'échec au Step 4. |
+| F9 | Ancre `166-173` (pas 166-172) ; ajouter la paire jumelle de tests sur la garde d'affichage. |
+| Q2 | Envisager un plafond de tolérance et un blocage sur devise ≠ `cad` (le reste alerte sans bloquer). |
+| Q6 | Le checkout passe de un à deux appels Stripe non bornés : borner aussi la résolution du prix. |
+| Q7 | Ajouter le `CHECK (presentment_currency ~ '^[A-Z]{3}$')` à la migration `0013`. |
+| — | **Rebaser `feat/stripe-catalogue-lookup-key` sur `origin/main`** (4 commits de retard) avant de commencer. |
+
+#### Cosmétique
+
+| # | Point |
+| --- | --- |
+| F10 | Corriger les chiffres (« ~20 fichiers » → 17/16) et les ancres `scripts/audit-stripe-transactions.ts:1-5`, `features/payments/stripe.ts:148-157`. |
+| F11 | Reformuler la phrase sur le `RangeError` d'`Intl` dans le spec. |
+| F12 | Ajouter `catalog` à la ligne de structure d'`AGENTS.md`. |
+| Q5 | Distinguer « Stripe non configuré » de « aucun produit actif » dans le retour de la tâche. |
+
+---
+
+## 7. Confirmations de sécurité opérationnelle
+
+**Ce que j'ai touché**
+- Lectures seules du dépôt (`cat`, `sed -n`, `grep`, `git show`, `git log`, `git diff --stat`, `git branch`) sur la branche courante et sur `feat/stripe-catalogue-lookup-key` via `git show`.
+- `bun run check` → exit **0**. `bun run test` (suite frontend, happy-dom) → exit **0**, 114 fichiers / 1300 tests.
+- Deux scripts `node -e` **purement locaux** (formatage `Intl`, comparaison des deux `formatCurrency`) — aucun accès réseau, aucune écriture disque.
+- Un dry-run du `sed` de la Task 1 **sans `-i`** (sortie comptée par `grep -c`, jamais réinjectée dans les fichiers).
+- Un seul fichier écrit : **ce rapport**, `docs/superpowers/reviews/2026-08-21-revue-design-stripe-catalogue-lookup-key.md`. **Non committé** — la session demandeuse décide de le garder ou non.
+
+**Ce que je n'ai pas touché**
+- **Aucune écriture** dans le dépôt hors ce rapport : ni code, ni spec, ni plan, ni `AGENTS.md`, ni `.claude/rules/**`.
+- **Aucun changement de branche** (`git checkout`/`switch`), aucun `stash`, aucun commit, aucun push.
+- **Base Neon intacte** : aucune connexion, aucune requête, aucune migration. `bun run db:migrate`, `bun run db:generate` et `bun run test:integration` (qui crée une branche Neon éphémère) n'ont **pas** été lancés.
+- **Compte Stripe intact** : aucun appel API, en live comme en test, en lecture comme en écriture. Aucun objet créé. Les affirmations sur le SDK proviennent exclusivement des fichiers `.d.ts` / `.js` / `CHANGELOG.md` de `node_modules/stripe` installés dans le dépôt.
+- **Aucun secret imprimé** : `.env.local` n'a jamais été lu ni affiché ; aucune variable portant une clé (`STRIPE_SECRET_KEY`, `CRON_SECRET`, `DATABASE_URL*`…) n'apparaît dans ce rapport autrement que par son nom.
+- **Aucun serveur de développement lancé** (`bun dev` ni équivalent), aucun test E2E, aucune commande destructive ni de déploiement.

--- a/docs/superpowers/reviews/2026-08-21-revue-implementation-stripe-catalogue-lookup-key.md
+++ b/docs/superpowers/reviews/2026-08-21-revue-implementation-stripe-catalogue-lookup-key.md
@@ -1,0 +1,517 @@
+# Revue adversariale d'implémentation — catalogue Stripe par `lookup_key`
+
+**Date** : 2026-08-21
+**Périmètre** : `git diff 54130ed..HEAD` (7 commits) sur `feat/stripe-catalogue-lookup-key`
+— 38 fichiers, +3 628 / −45.
+**Méthode** : lecture seule, posture hostile. Chaque constat est prouvé par une lecture
+de code citée `fichier:ligne` ou par une commande rejouable. Chaque suspicion a subi une
+tentative de réfutation ; celles qui n'ont pas survécu sont consignées en §4.
+**Référentiel de non-régression** : `origin/main` (état avant la branche).
+
+**État de la vérification**
+
+| Commande                 | Résultat                                            |
+| ------------------------ | --------------------------------------------------- |
+| `bun run check`          | **exit 0** (prettier + tsc + eslint)                |
+| `bun run test`           | **exit 0** — 117 fichiers, 1 330 tests, 0 échec     |
+| `bun run test:integration` | **non lancé** — aucun constat n'en dépend (voir §7) |
+
+---
+
+## 1. Ce qui est solide (pour ne pas noyer le signal)
+
+- **L'invariant comptable tient.** Le bloc `presentment` (`features/payments/stripe.ts:159-166`)
+  est un objet séparé, étalé après `...(reconcile ?? {})` dans le même `tx.update`
+  (`stripe.ts:167-177`) : il ne peut pas toucher `amountPaid`/`currency`. L'intégration
+  l'assert explicitement (`tests/integration/payments-stripe.test.ts:180-183`).
+- **L'idempotence est intacte.** L'écriture nouvelle est en aval du `FOR UPDATE`
+  (`stripe.ts:80-85`), du contrôle `stripeEventId` (`stripe.ts:88-93`) et du contrôle
+  `status === "completed"` (`stripe.ts:95-100`), dans la même transaction, en un seul UPDATE.
+- **La migration est propre.** Expand-only, backfill avant le `SET NOT NULL`, rejouable
+  à vide comme sur une base peuplée (§4.3), snapshot cohérent au bit près (§4.4).
+- **Retirer `stripePriceId`/`stripeProductId` de `ProductView` est un gain de sécurité**,
+  pas seulement du ménage : ces identifiants partaient dans la charge RSC de
+  `/tarifs`, `/abonnements` et des paywalls. Aucun lecteur nulle part (§5.7).
+- **La tâche cron ne lève jamais** et le dispatcher garde sa ceinture (`run()`), les deux
+  testés (`tests/features/payments-cron.test.ts:142-149`,
+  `tests/features/cron-close-expired.test.ts:110-121`).
+
+---
+
+## 2. Tableau des constats
+
+| #   | Sév | fichier:ligne                                | Problème                                                                                                                                        | Régression ? |
+| --- | --- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| F1  | 🟠  | `features/payments/actions.ts:364-392`       | Le repli de phase 1 ne couvre que « la clé ne résout rien ». Si `prices.list` **lève** (clé restreinte sans `prices:read`, 429, réseau), l'exception saute par-dessus le repli → 100 % des checkouts échouent, avec un message qui invite à réessayer indéfiniment. | **OUI**      |
+| F2  | 🟡  | `app/api/cron/close-expired/route.ts:93-106` | L'audit (informatif) est placé **avant** les notifications dans un dispatcher séquentiel dont l'appelant coupe à `--max-time 60` et relance tout. Jusqu'à ~16,5 s consommés aujourd'hui, ~80 s à 50 produits.                                                       | **OUI**      |
+| F3  | 🟡  | `features/payments/cron.ts:60`               | `limit: 10` suppose 1 prix actif par clé — hypothèse que `catalog.ts:35` réfute explicitement. Troncature silencieuse → faux « aucun prix actif ». Et le cron retient le **dernier** prix d'une clé dupliquée là où le checkout prend le **premier**.                | NON          |
+| F4  | 🟡  | `tests/features/stripe-webhook-errors.test.ts:145-151` | Le câblage webhook → `presentment_details` n'est couvert par rien, et l'assertion qui aurait dû le porter laisse passer les nouvelles clés (sémantique `toEqual` : `undefined` ≡ absent).                                                                | NON          |
+| F5  | ℹ️  | `features/payments/actions.ts:400`           | Le prix de repli n'est comparé à rien (ni montant, ni devise) — le chemin nominal refuserait ce que le repli accepte. **Jugé acceptable**, argumenté en §5.1.                                                                                                       | NON          |
+| F6  | ℹ️  | `features/payments/catalog.ts:31-35`         | `limit: 2` plafonne `count` : l'alerte Sentry dira toujours « 2 prix », même s'il y en a sept.                                                                                                                                                                       | NON          |
+| F7  | ℹ️  | `app/api/stripe/webhook/route.ts:87-90`      | La forme du payload webhook dépend de la version d'API **de l'endpoint dashboard**, pas du SDK. Épinglé avant `2025-03-31.basil` → colonnes éternellement nulles, en silence, indistinguable de « personne ne convertit ».                                            | NON          |
+| F8  | ℹ️  | `tests/features/payments-cron.test.ts:108-130` | Le test du découpage renvoie les 12 prix à chaque appel : il prouve « 2 appels », pas « le découpage évite la troncature ». Resterait vert avec `LOOKUP_KEYS_PER_CALL = 11`.                                                                                        | NON          |
+
+---
+
+## 3. Détail par constat
+
+### F1 🟠 — Le repli de phase 1 ne rattrape que la moitié des façons dont la résolution peut échouer
+
+**Code**
+
+- `features/payments/actions.ts:364-373` — `await resolveStripePrice(...)`, sans `try` local.
+- `features/payments/actions.ts:380-392` — le repli, conditionné à `if (!price)` : il ne
+  s'exécute que si l'appel a **réussi** en renvoyant zéro prix.
+- `features/payments/actions.ts:459-476` — le `catch` de la fonction : `resource_missing`
+  → message dédié ; **tout le reste** → `captureServerError` sans `detail` puis
+  `« Erreur lors de la création du paiement. Réessayez. »`.
+- `features/payments/actions.ts:34-37` — `isStripeResourceMissing` est un duck-check sur
+  `error.code === "resource_missing"` ; une `StripePermissionError` (HTTP 403, `type:
+  "invalid_request_error"`, pas de `code`) ne matche pas.
+
+**Pourquoi c'est un vrai bug.** `resolveStripePrice` peut échouer de trois façons, et le
+repli n'en couvre qu'une :
+
+| Mode d'échec                                  | Ce qui se passe                                            |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| La clé ne résout aucun prix actif             | ✅ repli sur `stripePriceId`, vente conservée, Sentry alerte |
+| La clé Stripe runtime n'a pas `prices:read`   | ❌ exception → **tous** les checkouts échouent, en permanence |
+| 429 / coupure réseau sur `prices.list`        | ❌ exception → checkout perdu, l'utilisateur voit « Réessayez » |
+
+Le cas médian n'est pas théorique : c'est le risque que le design nomme lui-même en
+premier (`docs/…-design.md:230-234` — « sinon **tous** les checkouts tombent en
+`permission_error` ») et que le plan traite par une case à cocher manuelle
+(`docs/…plan.md:70`, non cochée dans le dépôt). Créer une session Checkout avec un price
+ID n'exigeait pas ce droit ; `prices.list` si. Autrement dit, la branche introduit une
+permission requise **nouvelle**, et l'échec correspondant est routé vers la branche la
+moins utile du `catch` : un message qui invite à réessayer ce qui ne peut jamais aboutir,
+et une capture Sentry **sans `detail`** — donc sans le nom du produit ni la `lookup_key`,
+là où les deux autres captures les portent.
+
+Le troisième cas est une pure perte de disponibilité : `origin/main` faisait **un seul**
+appel Stripe dans `createStripeCheckout` (une écriture, `checkout.sessions.create`) ; la
+branche en ajoute un second, en **lecture**, et le rend bloquant. On peut objecter qu'une
+panne Stripe totale ferait de toute façon échouer la création de session — c'est vrai, et
+c'est pourquoi ce constat n'est pas 🔴. Mais `prices.list` est un endpoint distinct :
+une dégradation partielle ou un `permission_error` le frappe sans toucher
+`checkout.sessions.create`, et dans ces cas-là la vente est perdue alors que le pointeur
+historique, `stripe_price_id`, est encore en base, encore `NOT NULL`, encore éprouvé en
+production. C'est exactement ce que la colonne est censée couvrir pendant la phase 1.
+
+**Régression ? OUI.** Avant la branche, aucun de ces trois modes d'échec n'existait sur le
+chemin du checkout.
+
+**Comment je l'ai prouvé.**
+`sed -n '355,480p' features/payments/actions.ts` → le `try` englobe la résolution, aucun
+`catch` local ; le repli est bien sous `if (!price)` (ligne 380) et non dans un gestionnaire
+d'erreur. `grep -n -A 4 "isStripeResourceMissing" features/payments/actions.ts` → le
+duck-check ne porte que sur `resource_missing`. `grep -n "STRIPE_SECRET_KEY"
+lib/env/schema.ts` → la clé est libre (`.optional()`), rien dans le dépôt ne contraint ni
+n'atteste son type ni ses droits.
+
+**Correctif suggéré** (trois lignes, retirées avec le `DROP COLUMN` de la phase 2) :
+
+```ts
+let price: Stripe.Price | null = null
+try {
+  price = await resolveStripePrice(stripe, product.stripePriceLookupKey, onAmbiguous)
+} catch (error) {
+  // Phase 1 : la résolution est le chemin neuf, `stripe_price_id` le chemin éprouvé.
+  // Une lecture de prix indisponible ne doit pas coûter une vente.
+  captureServerError("[createStripeCheckout]", error, {
+    userId: session.user.id,
+    detail: `résolution de ${product.stripePriceLookupKey} impossible — repli sur stripe_price_id (produit ${productCode})`,
+  })
+}
+```
+
+À défaut : **prouver dans la PR** que la clé `STRIPE_SECRET_KEY` de Vercel Production
+porte `prices:read` (ou est une `sk_`). Le repli reste préférable — il rend le prérequis
+non bloquant au lieu de le déplacer dans la mémoire de quelqu'un.
+
+---
+
+### F2 🟡 — Un audit informatif s'intercale devant les notifications dans un budget de 60 s
+
+**Code**
+
+- `app/api/cron/close-expired/route.ts:93-98` — `priceDrift` est exécuté…
+- `app/api/cron/close-expired/route.ts:100-106` — …**juste avant** `sendPendingNotifications`.
+- `.github/workflows/cron-hourly.yml:52-56` — `curl --retry 3 --retry-delay 10
+  --retry-all-errors --max-time 60`.
+- `features/payments/cron.ts:20` et `:36-47` — `LOOKUP_KEYS_PER_CALL = 10`, `.limit(50)`
+  sur les produits → jusqu'à 5 appels séquentiels.
+- `features/payments/catalog.ts:12` / `features/payments/cron.ts:64` — `timeout: 8000,
+  maxNetworkRetries: 1`.
+
+**Pourquoi c'est un vrai bug.** Le dispatcher est séquentiel **volontairement** (commentaire
+`route.ts:42-46`, Sentry NOMAQBANQ-17) : chaque tâche consomme le budget de la suivante.
+Un `prices.list` qui traîne coûte `8 000 ms` + un retry avec backoff (~500 ms initial,
+`node_modules/stripe/esm/stripe.core.js:96,168` pour les valeurs par défaut ré-écrasées)
+≈ **16,5 s** — avec 5 produits, donc un seul lot. Si le catalogue atteint la borne
+`.limit(50)`, ce sont 5 lots, soit jusqu'à **~80 s**, plus que le budget entier de
+l'appelant. Ce temps est prélevé **avant** l'envoi des e-mails de résultats d'examen et
+de rappel d'accès, c'est-à-dire avant la seule tâche du cron que des utilisateurs
+attendent. Dépassement du `--max-time` → `curl` abandonne et rejoue **tout** le cron
+(jusqu'à 4 exécutions), ce que le commentaire de `features/payments/cron.ts:29-34`
+identifie précisément comme le scénario à éviter — et que ce placement rend plus probable.
+
+**Régression ? OUI**, au sens du budget : avant la branche, les 60 s étaient intégralement
+consacrées aux tâches utiles. Nuance honnête : la fonction serveur continue de tourner
+après l'abandon du client, donc les notifications ne sont pas *perdues* — elles sont
+retardées et le cron est rejoué.
+
+**Comment je l'ai prouvé.** `cat -n app/api/cron/close-expired/route.ts` (ordre des `run()`),
+`cat -n .github/workflows/cron-hourly.yml` (les chiffres du commentaire sont exacts —
+vérifiés, pas crus), `grep -n "DEFAULT_TIMEOUT\|maxNetworkRetries" node_modules/stripe/esm/stripe.core.js`
+(80 000 ms / 2 retries par défaut : le commentaire dit vrai).
+
+**Correctif suggéré.** Déplacer le bloc `priceDrift` **après** `sendPendingNotifications`.
+Un audit qui tourne 24×/jour n'a aucune raison de passer avant un e-mail. Une ligne.
+
+---
+
+### F3 🟡 — Le cron suppose une bijection clé → prix que le checkout, lui, refuse de supposer
+
+**Code**
+
+- `features/payments/cron.ts:53-61` — lots de 10 clés, `limit: LOOKUP_KEYS_PER_CALL` (=10).
+- `features/payments/cron.ts:66-68` — `byLookupKey.set(price.lookup_key, price)` : le
+  **dernier** gagne ; `has_more` est ignoré.
+- `features/payments/catalog.ts:31-36` — le checkout demande `limit: 2` **précisément pour
+  détecter** plusieurs prix actifs sous une même clé, et renvoie `data[0]` : le **premier**.
+
+**Pourquoi c'est un vrai bug.** Les deux garde-fous sont censés dire la même chose du même
+catalogue, et ils partent d'hypothèses contradictoires. Si une seule clé d'un lot porte
+deux prix actifs — l'anomalie que `resolveStripePrice` alerte explicitement — le lot rend
+11 prix pour `limit: 10` : la liste est tronquée, un produit se retrouve sans entrée dans
+`byLookupKey`, et le cron émet une alerte **fausse** « aucun prix actif pour cette
+lookup_key » (`cron.ts:81-88`). Pire pendant un `transfer_lookup_key` mal terminé : le
+cron audite le dernier prix renvoyé, le checkout facture le premier — les deux peuvent
+diverger sans que rien ne le signale. `limit` accepte 1 à 100 chez Stripe
+(`node_modules/stripe/esm/resources/Prices.d.ts:714`), la borne de 10 ne concerne que
+`lookup_keys` (`:667`) : rien n'oblige à les aligner.
+
+**Régression ? NON** — code entièrement nouveau.
+
+**Comment je l'ai prouvé.** `grep -n -B 6 "lookup_keys" node_modules/stripe/esm/resources/Prices.d.ts`
+(« up to 10 lookup_keys ») et `:712-716` (« limit can range between 1 and 100 ») ;
+lecture croisée de `cron.ts:53-68` et `catalog.ts:31-36`.
+
+**Correctif suggéré.** `limit: 100` sur l'appel du cron (la borne de 10 s'applique aux
+clés, pas aux résultats), et signaler une collision plutôt que l'écraser :
+
+```ts
+for (const price of data) {
+  if (!price.lookup_key) continue
+  if (byLookupKey.has(price.lookup_key)) { /* même alerte « plusieurs prix actifs » */ }
+  else byLookupKey.set(price.lookup_key, price)
+}
+```
+
+---
+
+### F4 🟡 — Le seul câblage non testé est celui qui transporte la nouvelle donnée, et le test existant l'absorbe en silence
+
+**Code**
+
+- `app/api/stripe/webhook/route.ts:86-90` — les deux champs passés à
+  `completeStripeTransaction`.
+- `tests/features/stripe-webhook-errors.test.ts:129-151` — l'unique assertion sur la forme
+  exacte de l'appel : `toHaveBeenCalledWith({ stripeSessionId, stripePaymentIntentId,
+  stripeEventId, amountTotal, currency })` — sans les deux nouvelles clés.
+
+**Pourquoi c'est un vrai bug.** L'appel réel passe désormais `presentmentAmount: undefined,
+presentmentCurrency: undefined` (le mock de l'événement n'a pas de `presentment_details`).
+`toHaveBeenCalledWith` compare avec la sémantique de `toEqual`, qui traite une propriété
+`undefined` comme absente : le test reste **vert** en ignorant les deux clés. Il ne
+« couvre » donc pas le câblage, il le masque. Et aucun autre test ne le couvre : le DAL
+est testé en intégration (`tests/integration/payments-stripe.test.ts:154-183`) en appelant
+`completeStripeTransaction` **directement**, ce qui saute exactement le morceau ajouté par
+la Task 5 Step 4. Le typage rattrape une faute de frappe sur un nom de champ Stripe ; il
+ne rattrape pas un mauvais champ correctement typé (`amount_total` au lieu de
+`presentment_amount`, par exemple — deux `number`).
+
+**Régression ? NON** — trou de couverture sur du code neuf.
+
+**Comment je l'ai prouvé.** `sed -n '129,151p' tests/features/stripe-webhook-errors.test.ts`
+comparé à `sed -n '73,91p' app/api/stripe/webhook/route.ts` ; `bun run test` passe
+(1 330/1 330) alors que l'objet attendu ne mentionne pas les clés effectivement passées.
+
+**Correctif suggéré.** Un cas de plus dans le fichier qui existe déjà — l'endroit exact que
+la question ouverte n°8 désignait :
+
+```ts
+it("presentment_details → transmis au fulfillment", async () => {
+  mocks.constructEventAsync.mockResolvedValueOnce({
+    id: "evt_present", type: "checkout.session.completed",
+    data: { object: { id: "cs_p", payment_status: "paid", payment_intent: "pi_p",
+      amount_total: 5000, currency: "cad",
+      presentment_details: { presentment_amount: 2280000, presentment_currency: "xaf" } } },
+  })
+  await POST(request())
+  expect(mocks.completeStripeTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({ presentmentAmount: 2280000, presentmentCurrency: "xaf" }),
+  )
+})
+```
+
+---
+
+### F5 ℹ️ — Le prix de repli n'est validé par rien (constat conservé, mais jugé acceptable)
+
+**Code** : `features/payments/actions.ts:400` — `const drift = price ?
+describePriceDrift(product.priceCad, price) : null`. Quand `price` est `null`,
+`resolvedPriceId` vaut `product.stripePriceId` (`:392`) et part en `line_items` (`:424`)
+sans qu'aucune devise ni aucun montant n'ait été comparé.
+
+**Pourquoi ce n'est pas un défaut à corriger.** Valider le prix de repli exigerait un
+`prices.retrieve(product.stripePriceId)` — donc **la permission `prices:read`**, c'est-à-dire
+précisément le droit dont l'absence est l'une des causes plausibles du repli (F1). Le
+contrôle s'auto-annulerait dans le cas qu'il prétend couvrir, au prix d'un troisième
+aller-retour Stripe sur un chemin où l'utilisateur attend. Par ailleurs le repli ne se
+déclenche jamais silencieusement : il est toujours précédé d'une alerte Sentry (`:381-390`),
+et la règle projet fait du silence de cette alerte la condition du `DROP COLUMN`
+(`.claude/rules/payments.md`). Le risque résiduel — un `stripe_price_id` périmé **et** en
+mauvaise devise **et** une `lookup_key` absente, simultanément — est plus petit que le
+coût du contrôle. **Laisser tel quel**, en documentant ce raisonnement dans le commentaire
+du repli.
+
+---
+
+### F6 ℹ️ — L'alerte d'ambiguïté ne peut pas dire la vérité sur le nombre
+
+`features/payments/catalog.ts:31-35` : `limit: 2` puis `onAmbiguous(lookupKey, data.length)`.
+`data.length` est borné à 2 par la requête, donc le détail Sentry
+(`actions.ts:371`, `` `${lookupKey} · ${count} prix` ``) affichera **toujours** « 2 prix ».
+En incident, ça se lit comme « exactement deux », alors que ça signifie « au moins deux ».
+Correctif : `` `${lookupKey} · au moins ${count} prix actifs` ``.
+
+---
+
+### F7 ℹ️ — La persistance dépend d'une version d'API qui ne se lit pas dans le dépôt
+
+`presentment_details` apparaît dans l'API Stripe en `2025-03-31.basil`
+(`node_modules/stripe/CHANGELOG.md:869` pour la version, `:922` pour l'ajout du champ). Le
+code épingle `2026-07-29.dahlia` (`lib/stripe-api-version.ts:17`), largement postérieur —
+côté SDK, tout va bien. **Mais** la charge utile d'un webhook est sérialisée dans la
+version d'API de l'**endpoint** configuré au dashboard, pas dans celle du SDK :
+`constructEventAsync` (`app/api/stripe/webhook/route.ts:48`) ne fait que vérifier une
+signature sur le corps brut reçu. Si l'endpoint est épinglé avant `basil`,
+`checkoutSession.presentment_details` est `undefined` en permanence, la garde
+`params.presentmentAmount != null` (`stripe.ts:160`) n'écrit jamais rien, et les colonnes
+restent nulles **sans une seule alerte** — indistinguable, par construction, de « aucun
+client ne convertit », puisque `.claude/rules/payments.md` pose déjà le taux de non-nuls
+comme une borne basse. À vérifier au dashboard avant/après le déploiement (je n'y ai pas
+touché : §7). Un contrôle post-déploiement possible : une transaction connue payée en
+devise locale doit ressortir avec `presentment_amount` non nul.
+
+---
+
+### F8 ℹ️ — Le test du découpage prouve le découpage, pas ce qu'il protège
+
+`tests/features/payments-cron.test.ts:114-124` : le mock renvoie les **12** prix à chaque
+appel, quel que soit le lot demandé. Le vrai Stripe n'en renverrait que les 10 réclamés.
+Le test assert `toHaveBeenCalledTimes(2)` — vrai aussi si `LOOKUP_KEYS_PER_CALL` valait 11,
+donc il ne mord pas sur la borne de l'API qu'il prétend défendre (commentaire `:105-107`).
+Correctif : filtrer le mock sur les `lookup_keys` réellement demandées, et asserter
+`drifted: 0` — ce qui échouerait alors si le lot dépassait 10.
+
+---
+
+## 4. Faux positifs écartés
+
+1. **`formatCurrency` local → partagé casserait l'affichage du panneau admin.**
+   Écarté. L'ancien formateur (`user-side-panel.tsx`, supprimé au diff) utilisait
+   `{ minimumFractionDigits: 0, maximumFractionDigits: currency === "XAF" ? 0 : 2 }` ; le
+   partagé (`lib/format.ts:31-53`) applique exactement `min 0 / max 2` en CAD, et rend le
+   XAF en décimal suffixé `" XAF"` — sortie équivalente à un `style: "currency"` fr-CA.
+   Aucune différence visible.
+
+2. **`resolvedPriceId` (`let` hors du `try`) partagerait de l'état entre invocations
+   concurrentes de la Server Action.** Écarté. `features/payments/actions.ts:359` : la
+   déclaration est **dans** le corps de `createStripeCheckout`, pas au niveau module —
+   une liaison par appel. Le `catch` ne peut pas non plus le lire dans un état trompeur :
+   il vaut `null` tant que la résolution n'a pas abouti (message « prix non résolu »), et
+   l'identifiant réellement envoyé ensuite.
+
+3. **La migration casserait le déploiement de production.** Écarté. `ADD COLUMN` nullable →
+   `UPDATE … = code::text` → `SET NOT NULL` (`drizzle/0013_sharp_gwen_stacy.sql:6-8`) :
+   sur base vierge la table est vide (UPDATE 0 ligne, `SET NOT NULL` passe), sur base
+   peuplée le backfill précède. Les deux colonnes `transactions` sont nullables sans
+   défaut → métadonnée seule en PG 11+. Et rien n'insère de `products` à l'exécution :
+   `grep -rn "insert(products)"` ne rend que des tests, `app/api/e2e/route.ts:258-260`
+   ne fait qu'un `select`. Phase expand pure : l'ancien code cohabite sans rien voir.
+
+4. **Le SQL écrit à la main aurait divergé de `drizzle/meta/`.** Écarté. Diff structurel
+   profond `0012_snapshot.json` ↔ `0013_snapshot.json` : **exactement 12 différences**,
+   toutes des attributs des trois colonnes attendues, aucune autre table touchée ;
+   `prevId` de 0013 = `id` de 0012 ; `_journal.json` idx 13 cohérent.
+
+5. **Le `sed` de la Task 1 aurait injecté `stripePriceLookupKey` dans un objet qui n'est
+   pas un insert `products`.** Écarté. 22 occurrences dans l'arbre, 22 dans le diff, aucune
+   ailleurs ; chacune suit immédiatement un `stripePriceId` à l'intérieur d'un
+   `db.insert(products).values(...)`. La 22ᵉ est la forme mockée de la table
+   (`tests/features/payments-cron.test.ts:35`), légitime. Le décompte « 21 » du brief est
+   inexact d'une unité — sans conséquence.
+
+6. **Retirer `stripePriceId`/`stripeProductId` de `ProductView` casserait un composant.**
+   Écarté. `grep -rn "stripePriceId\|stripeProductId"` sur `app components features hooks
+   e2e scripts tests lib db` : les seules occurrences hors tests/schéma sont
+   `features/payments/actions.ts:342` et `:392`, côté serveur. Les 14 consommateurs de
+   `ProductView` ne lisent que `code/name/priceCad/durationDays/accessType/isCombo`.
+
+7. **Les colonnes `presentment_*` pourraient contaminer l'encaissement.** Écarté (voir §1).
+
+8. **La nouvelle écriture casserait l'idempotence.** Écarté (voir §1) — même transaction,
+   même UPDATE, en aval des deux gardes sous verrou.
+
+9. **`presentment_currency` en texte libre serait exploitable dans le panneau admin.**
+   Écarté. La valeur vient de Stripe, React échappe le rendu (`user-side-panel.tsx:216-223`),
+   et `formatPresentmentAmount` a un `catch` (`lib/format.ts:78-80`). Aucune concaténation
+   HTML, aucun `dangerouslySetInnerHTML`.
+
+10. **Le seuil de couverture à 80 % serait menacé par la branche JSX non testée.** Écarté.
+    `vitest.config.ts:39-45` : la couverture ne `include` que `lib/**`, `hooks/**`,
+    `components/**`, `schemas/**`, `email/**` — ni `app/**` ni `features/**`. Le seul
+    ajout comptabilisé, `formatPresentmentAmount`, est testé (`tests/lib/format.test.ts:96-116`).
+
+11. **Le garde `if (!env.STRIPE_SECRET_KEY)` du cron serait du code mort.** Écarté :
+    `lib/env/schema.ts:43` — `z.string().optional()`.
+
+12. **Appel au `db` global dans une `db.transaction` (pool `max: 5`).** Écarté. Le `select`
+    du cron (`features/payments/cron.ts:39-47`) est hors transaction ; le fulfillment
+    n'utilise que `tx`.
+
+---
+
+## 5. Réponses aux questions ouvertes
+
+**1. Le repli court-circuite toute validation de prix — trou réel ou conséquence acceptable ?**
+**Acceptable, et à documenter comme tel** — mais pour une raison plus forte que celle
+avancée. Valider le prix de repli imposerait un `prices.retrieve`, donc `prices:read`,
+c'est-à-dire le droit dont l'absence est justement une cause plausible du repli : le
+contrôle serait absent exactement quand il servirait. Ajoutez qu'il coûterait un troisième
+aller-retour Stripe sur le chemin où l'utilisateur attend, et que le repli est toujours
+précédé d'une alerte Sentry. Voir F5. **En revanche, le vrai trou du repli est ailleurs** :
+il ne se déclenche pas quand l'appel *échoue*. C'est F1, et celui-là est à corriger.
+
+**2. `resolvedPriceId` — état partagé entre invocations concurrentes ?**
+**Non.** `actions.ts:359` : `let` dans le corps de la fonction, une liaison par appel ;
+aucun état de module. Le `catch` ne le lit jamais dans un état trompeur — `null` avant
+résolution (« prix non résolu »), l'identifiant effectivement envoyé après. Le seul
+reproche possible est stylistique. **Rien à changer.**
+
+**3. `checked: 0` quand Stripe échoue — ambigu en incident ?**
+**Non, pas assez pour induire en erreur** : `failed` est le discriminant, il est dans le
+JSON du cron (`route.ts:132`) et vaut `true` uniquement dans ce cas
+(`features/payments/cron.ts:74`) ; le nombre de lignes réellement lues survit d'ailleurs
+dans le `detail` Sentry (`cron.ts:71-73`). Reste que `{checked: 0, drifted: 0, failed: false}`
+recouvre deux situations (Stripe non configuré / aucun produit actif), toutes deux bénignes.
+Si vous voulez lever le doute pour zéro risque : renvoyer `checked: rows.length` même en
+échec, ou ajouter `read: rows.length`. **Amélioration cosmétique, pas un correctif.**
+
+**4. `presentmentCurrency` sans validation de format — exploitable ?**
+**Non, seulement inélégant.** La valeur vient de Stripe (jamais d'une entrée utilisateur),
+n'est lue que par un panneau admin gardé, et est rendue comme texte par React. `Intl` ne
+lève que si le code n'est pas trois lettres ASCII — un code bien formé mais inconnu ne
+lève **pas** et se voit divisé par 100 par défaut (fait déjà établi par la revue de design,
+§F11). Conséquence pratique nulle ici : Stripe n'émet que des codes ISO réels. Le `catch`
+de `lib/format.ts:78-80` couvre le reste. **Ne rien changer.**
+
+**5. `presentment_amount` à 0 (promo 100 % en devise locale) — voulu ?**
+**Oui, et c'est le bon comportement.** Le type Stripe rend `presentment_amount` obligatoire
+dès que l'objet existe (`node_modules/stripe/esm/resources/Checkout/Sessions.d.ts:624-633`) :
+les deux champs arrivent donc toujours ensemble, et un 0 signifie littéralement « le client
+a vu 0 dans sa devise » — une information réelle, pas une absence. La distinction « pas de
+conversion » vs « converti à zéro » est déjà portée par la nullité de la **paire** :
+`stripe.ts:159-166` n'écrit que si `presentmentAmount != null` **et** `presentmentCurrency`
+truthy. Un `!== undefined` aurait été plus littéral, mais `!= null` donne le même résultat
+ici. **Ne rien changer.**
+
+**6. Le `sed` a-t-il pollué un objet qui n'est pas un insert `products` ?**
+**Non.** 22 occurrences (le brief en annonce 21), 16 fichiers, toutes vérifiées une par
+une : 21 dans des `db.insert(products).values(...)`, la 22ᵉ dans la forme mockée de la
+table du test unitaire du cron. Détail à savoir, sans gravité : les valeurs injectées sont
+`` `price_${suffix}` ``, c'est-à-dire des **formes de price ID employées comme lookup_key**.
+En intégration rien n'appelle Stripe, donc c'est inoffensif — mais c'est un contre-exemple
+au message même de la branche (« une `lookup_key` n'est pas un `price_…` »). Cosmétique.
+
+**7. `stripePriceId`/`stripeProductId` retirés de `ProductView` — vraiment aucun lecteur ?**
+**Confirmé sur tout l'arbre**, pas seulement sur `app/ components/ features/ hooks/` :
+grep étendu à `e2e/`, `scripts/`, `tests/`, `lib/`, `db/` — zéro lecteur. Mieux : la
+suppression est un **gain de sécurité** non revendiqué par les commits. `ProductView` est
+consommé par 14 composants clients (`pricing-grid.tsx`, `tarifs-page-client.tsx`,
+`abonnements-client.tsx`, `training-paywall.tsx`, `manual-payment-modal.tsx`…) : ces deux
+identifiants Stripe partaient donc dans la charge RSC visible au navigateur. **Bon
+changement, à garder.**
+
+**8. Le câblage webhook → fulfillment n'a aucun test — trou qui compte ?**
+**Oui**, et c'est F4. Il compte d'autant plus que le test qui aurait dû l'attraper
+(`stripe-webhook-errors.test.ts:145-151`) l'**absorbe silencieusement** : la sémantique
+`toEqual` de `toHaveBeenCalledWith` traite `undefined` comme absent, si bien que l'ajout
+des deux clés n'a même pas fait broncher l'assertion. Le DAL est couvert en intégration,
+mais en appelant `completeStripeTransaction` directement — donc en sautant exactement le
+morceau ajouté par la Task 5 Step 4. Un cas de dix lignes dans le fichier existant ferme
+le trou.
+
+---
+
+## 6. Verdict
+
+### Cette implémentation peut-elle partir en PR vers `main` telle quelle ? — **NON**
+
+Le travail est d'excellente facture : l'invariant comptable, l'idempotence et la migration
+résistent à une lecture hostile, les tests par paires (concordant / divergent) mordent
+réellement, et la revue de design a bien été absorbée (le repli F2 réclamé y est). Un seul
+point bloque, et il bloque parce que **merger dans `main` déploie en production** :
+`vercel.json` fait tourner `build:vercel` → `scripts/migrate-deploy.ts`, qui applique les
+migrations sur la base de production dès que `VERCEL_ENV === "production"`.
+
+**Point bloquant unique — F1.** La branche crée une dépendance nouvelle à la permission
+`prices:read` et route son échec vers la pire branche du `catch` (« Réessayez » pour une
+panne permanente, capture Sentry sans `detail`). Deux issues acceptables, au choix :
+soit les trois lignes de `try/catch` autour de `resolveStripePrice` (recommandé — le
+prérequis cesse d'être une case à cocher dans la tête de quelqu'un), soit une preuve dans
+la PR que la clé `STRIPE_SECRET_KEY` de Vercel Production est une `sk_` ou porte
+`prices:read`.
+
+Rien d'autre ne justifie de retenir la PR. F2 et F3 sont des correctifs d'une à trois
+lignes qu'il serait dommage de reporter tant qu'on est dans le fichier ; F4 est un test.
+
+### Correctifs priorisés
+
+| Priorité                    | #      | Correctif                                                                                              | Coût     |
+| --------------------------- | ------ | ------------------------------------------------------------------------------------------------------- | -------- |
+| **Bloquant — avant merge**  | **F1** | `try/catch` autour de `resolveStripePrice` → repli sur `stripePriceId` + Sentry avec `detail`. OU preuve documentée que la clé runtime porte `prices:read`. | 3 lignes |
+| Avant le déploiement        | F2     | Déplacer `priceDrift` **après** `sendPendingNotifications` dans le dispatcher.                          | 1 ligne  |
+| Avant le déploiement        | F3     | `limit: 100` sur `prices.list` du cron ; signaler les collisions de clé au lieu de les écraser.         | 4 lignes |
+| Avant le déploiement        | F7     | Vérifier au dashboard que la version d'API de l'endpoint webhook ≥ `2025-03-31.basil`, puis contrôler après déploiement qu'une transaction convertie ressort avec `presentment_amount` non nul. | 5 min, hors dépôt |
+| Souhaitable (même PR)       | F4     | Cas de test `presentment_details` dans `tests/features/stripe-webhook-errors.test.ts`.                  | 10 lignes |
+| Cosmétique                  | F5     | Documenter dans le commentaire du repli **pourquoi** on ne valide pas le prix de repli (auto-annulation du contrôle). | 2 lignes |
+| Cosmétique                  | F6     | « au moins N prix actifs » dans le détail Sentry d'ambiguïté.                                           | 1 ligne  |
+| Cosmétique                  | F8     | Filtrer le mock du test de découpage sur les clés demandées.                                            | 5 lignes |
+
+---
+
+## 7. Confirmations de sécurité opérationnelle
+
+- **Lecture seule respectée.** Aucun fichier source modifié. Le seul fichier écrit est le
+  présent rapport. Aucun commit, aucun `git add`, aucune opération destructive.
+- **Base de données de production : intacte.** Aucune connexion, aucune requête, aucune
+  migration exécutée. `bun run test:integration` **n'a pas été lancé** (il crée et détruit
+  une branche Neon éphémère) : aucun constat n'en dépendait — la validité des inserts de
+  test est déjà garantie par le type-check (`bun run check` exit 0), qui exige la colonne
+  `NOT NULL` sur chaque `db.insert(products)`.
+- **Compte Stripe : intact.** Aucun appel API, aucun objet créé ni lu, ni en mode test ni
+  en mode live. Toutes les affirmations sur le comportement de l'API Stripe sont tirées du
+  SDK installé (`node_modules/stripe/`, v22.4.0) : types, CHANGELOG et valeurs par défaut.
+  Corollaire assumé : je **ne peux pas** confirmer que les cinq `lookup_key` existent
+  réellement en live, ni les droits de la clé runtime, ni la version d'API de l'endpoint
+  webhook (F1, F7) — ces trois points restent à vérifier hors dépôt.
+- **Secrets : jamais lus ni imprimés.** `.env.local` n'a été ni ouvert ni grepé ; aucune
+  valeur de clé n'apparaît dans ce rapport. Les seules références à `STRIPE_SECRET_KEY`
+  portent sur son schéma de validation (`lib/env/schema.ts:43`).
+- **Aucun serveur de développement lancé.** Seules commandes exécutées : `git diff` /
+  `git log`, lectures de fichiers, `grep`, `bun run check`, `bun run test`, et un `node -e`
+  local comparant deux snapshots JSON du dépôt.

--- a/docs/superpowers/specs/2026-08-18-pool-neon-retry-design.md
+++ b/docs/superpowers/specs/2026-08-18-pool-neon-retry-design.md
@@ -1,0 +1,117 @@
+# Spec — Résilience du pool pg aux réveils Neon (NOMAQBANQ-1F)
+
+- **Date** : 2026-08-18
+- **Statut** : DESIGN VALIDÉ (périmètre approuvé en session)
+- **Origine** : triage de `NOMAQBANQ-1F` (2026-08-18, `/tarifs`, 1 événement).
+
+## Le problème, prouvé bout à bout
+
+Le 2026-08-18 à 21:00:26 UTC, `GET /tarifs` a répondu 500 : `getAvailableProducts()`
+a échoué sur une erreur **Neon 53300** — `Failed to acquire permit to connect to
+the database. Too many database connection attempts are currently ongoing`
+(logs Vercel, digest `2620800449` identique à celui de l'événement Sentry client).
+La même route répondait 200 à 21:01:20. Un visiteur (Abidjan, connexion lente) a
+vu l'écran d'erreur générique sur la page des tarifs.
+
+**Cause de la cause** : le compute Neon de production (`ep-round-mouse-adhrcgd8`)
+a `suspend_timeout_seconds: 0` → défaut Neon = mise en veille après 5 min
+d'inactivité (observé suspendu en direct pendant l'audit). Au réveil, les
+tentatives de connexion simultanées des instances serverless peuvent dépasser le
+quota d'admission du proxy Neon → 53300.
+
+**Contrainte structurante** : palier Neon gratuit — pas de compute permanent, et
+un keep-alive cron doublerait l'`active_time` (~218 h ce mois-ci) au-delà du
+quota. Le réveil à 5 min est une donnée. Le correctif est donc côté code.
+
+## Correctif
+
+Deux changements, tous deux dans la couche pool (`db/`).
+
+### 1. `connectionTimeoutMillis: 10_000`
+
+Aujourd'hui absent : un connect qui stalle pend **indéfiniment** — c'est le
+résiduel documenté de #103 (`.claude/rules/data-layer.md` : cinq transactions
+concurrentes figent l'application entière). 10 s couvre largement un réveil Neon
+(~1-2 s) et transforme le gel infini en erreur franche.
+
+Effet de bord assumé : ce timeout s'applique AUSSI à l'attente d'un client libre
+quand le pool est saturé (`max: 5`). Une file d'attente de plus de 10 s devient
+une erreur au lieu d'un blocage silencieux — c'est voulu : avec des requêtes
+normalement en dizaines de ms, 10 s de file signale un problème réel.
+
+### 2. Retry de la phase d'ACQUISITION sur erreur de réveil Neon
+
+Une sous-classe `NeonRetryPool extends Pool` qui surcharge `connect()` — le
+point unique par lequel passent `pool.query()` (requêtes Drizzle one-shot,
+vérifié dans `pg-pool/index.js:449`) et `pool.connect()` (transactions).
+
+- **Erreurs retentées** (codes pg sur l'erreur brute de connexion) :
+  - `53300` — too_many_connections / permit refusé (le cas prouvé) ;
+  - `57P03` — cannot_connect_now, « the database system is starting up » (le
+    jumeau classique du réveil, même fenêtre, même innocuité).
+- **2 retries**, backoff 250 ms puis 1 s. Pire cas d'échec total :
+  3 × 10 s + 1,25 s ≈ 31 s avant le 500 — rare et acceptable (le défaut actuel
+  est un blocage infini).
+- **Pourquoi c'est inconditionnellement sûr, écritures comprises** : le refus de
+  « permit » survient à l'établissement de la connexion — AUCUNE requête n'a été
+  envoyée. Rejouer l'acquisition ne peut rien dupliquer. C'est ce qui distingue
+  ce retry d'un retry de requête, qui resterait réservé aux opérations
+  idempotentes.
+- **Ce qu'on ne retente PAS** : le timeout de file du pool local (« timeout
+  exceeded when trying to connect », sans code pg) — retenter aggraverait la
+  saturation ; et toute erreur pg d'une autre nature (auth, réseau, requête).
+
+La forme callback de `connect(cb)` doit être préservée à l'identique de pg-pool
+(`cb(undefined, client, client.release)`) : `pool.query` en dépend en interne.
+
+### Structure
+
+- `db/retry-pool.ts` (créer) : `NeonRetryPool` + prédicat `isNeonWakeupError`.
+  Retries et backoffs injectables au constructeur — testable sans fake timers,
+  aucune dépendance à `lib/env`.
+- `db/index.ts` (modifier) : instancier `NeonRetryPool` avec
+  `connectionTimeoutMillis`, conserver `pool.on("error")` et
+  `attachDatabasePool` tels quels.
+
+## Tests (unitaires, `tests/db/RetryPool.test.ts`, projet frontend)
+
+Le vrai 53300 n'est pas reproductible sur une branche Neon à la demande : on
+stubbe `Pool.prototype.connect` (le `super.connect` de la sous-classe).
+
+1. Rejet 53300 ×2 puis succès → `connect()` résout, 3 appels au parent.
+2. Rejet 53300 systématique → rejette après épuisement (3 appels, pas plus).
+3. Erreur non listée (ex. `28P01` auth) → rejette immédiatement, 1 seul appel.
+4. Forme callback : `connect(cb)` reçoit `(undefined, client, client.release)`
+   après un retry — le contrat de `pool.query`.
+5. `57P03` retenté comme 53300.
+
+Discriminance : les tests 1 et 4 doivent échouer si `NeonRetryPool` est remplacé
+par `Pool` nu.
+
+## Règles à mettre à jour
+
+`.claude/rules/data-layer.md` : la règle « jamais d'appel au `db` global dans une
+transaction » reste (une 2ᵉ acquisition imbriquée reste un interblocage jusqu'au
+timeout), mais sa description change : le pool A désormais un
+`connectionTimeoutMillis` — l'interblocage dure 10 s puis erreur, au lieu
+d'être indéfini.
+
+## Hors périmètre
+
+- **Trou d'observabilité Sentry serveur** (aucun événement `onRequestError` pour
+  les erreurs RSC en prod, prouvé sur -1F) : investigation dédiée, session
+  séparée. Sans elle on ne saura pas si CE correctif suffit — à traiter juste
+  après.
+- `error.tsx` de segment marketing : YAGNI tant que le retry n'a pas montré ses
+  limites (le boundary racine a déjà un bouton « Réessayer »).
+- Keep-alive cron : écarté (quota compute du palier gratuit).
+- `NOMAQBANQ-1D` : archivée (séquelle de l'ancien bug d'hydratation sur
+  l'ancienne release, fiber corrompu ; se rouvrira seule si récidive).
+
+## Vérification en production
+
+`NOMAQBANQ-1F` sera marquée résolue au déploiement. Le signal de succès : plus
+aucun 500 « Failed query …» avec cause 53300 dans les logs Vercel lors des
+réveils, et pas de réouverture de -1F. Attention : tant que le trou Sentry
+serveur n'est pas bouché, l'absence d'événement ne prouve PAS l'absence
+d'erreur — croiser avec les logs Vercel (rétention ~1 h) sur un réveil provoqué.

--- a/docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md
+++ b/docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md
@@ -23,8 +23,15 @@ l'événement arrive en `currency: "cad"` ; le montant local vit dans
 
 S'y ajoute une classe de bug structurelle : `price_…` et `prod_…` portent des
 préfixes **identiques en test et en live**. Un identifiant du mauvais mode ne se
-révèle qu'à la création de la session, en `resource_missing`. C'est ce qui laisse
-aujourd'hui 4 produits sur 5 intestables en local.
+révèle qu'à la création de la session, en `resource_missing`.
+
+> **Vérifié le 2026-08-21 (lecture seule, mode test) :** les 5 produits de la base
+> de dev pointent désormais tous sur un prix **test**, et leurs montants concordent
+> avec Stripe. Le point 4 de l'issue — « 4 produits sur 5 intestables en local » —
+> et le gotcha correspondant d'`AGENTS.md` sont **périmés** : quelqu'un a fait
+> l'`UPDATE` entre-temps. Ce que la présente campagne apporte n'est donc pas la
+> correction de cet état, mais l'impossibilité d'y retomber — un `UPDATE` manuel
+> reste réversible par le prochain, une `lookup_key` non.
 
 ## Décision structurante
 

--- a/docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md
+++ b/docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md
@@ -77,23 +77,32 @@ avant la création de la session :
 
 ```
 prices.list({ lookup_keys: [product.stripePriceLookupKey], active: true, limit: 2 })
-  → 0 résultat → « Ce produit est mal configuré. Contactez le support. » + Sentry
-  → 1 résultat → line_items: [{ price: price.id, quantity: 1 }]
+  → 0 résultat  → Sentry + repli de phase 1 sur products.stripePriceId
+  → 1 résultat  → line_items: [{ price: price.id, quantity: 1 }]
+  → 2 résultats → Sentry (anomalie : la clé devrait être unique), on prend le premier
 ```
 
-Le chemin d'erreur réutilise celui de `resource_missing` : même message utilisateur,
-même capture Sentry. Un `lookup_key` introuvable dans le mode de la clé active
-signifie la même chose qu'un price ID introuvable — produit mal configuré, aucune
-nouvelle tentative n'y changera rien.
+`limit: 2` n'a d'intérêt que si le second résultat est réellement lu : sinon une
+clé portée par deux prix actifs se règlerait au hasard, en silence. La requête est
+bornée à 8 s et un seul réessai — le SDK Stripe attend 80 s et réessaie 2 fois par
+défaut, ce qui est inacceptable sur un chemin où l'utilisateur attend.
 
 Le `Price` retourné porte `unit_amount` et `currency` : **la comparaison avec
-`product.priceCad` ne coûte aucun appel supplémentaire.** Écart de montant, ou
-devise du prix ≠ `cad` → `captureServerError`, **et la vente continue.**
+`product.priceCad` ne coûte aucun appel supplémentaire.** Mais les deux champs ne
+se traitent pas de la même façon.
 
-Bloquer serait pire que l'écart : une simple modification de tarif au dashboard
-couperait les ventes du produit jusqu'à ce que quelqu'un fasse l'`UPDATE` en base.
-Le client qui paie un montant différent de l'affiché est un incident ; zéro vente
-en est un plus grave, et plus long à diagnostiquer.
+**Un montant divergent alerte sans bloquer.** Chez Stripe, on ne modifie pas le
+montant d'un prix : on en crée un autre et on lui transfère la clé
+(`transfer_lookup_key`). Une divergence de montant est donc un état **transitoire
+légitime** — le temps que l'`UPDATE` de `products.priceCad` suive. Couper les
+ventes du produit pendant cette fenêtre coûterait plus cher que l'écart, d'autant
+que Checkout affiche le montant au client **avant** qu'il ne confirme : il n'y a
+pas de paiement à son insu, seulement une grille tarifaire périmée.
+
+**Une devise ≠ `cad` refuse la vente.** La devise d'un prix Stripe est
+**immuable** : elle ne peut pas avoir « changé » en attendant une mise à jour.
+Une devise inattendue signifie que la clé pointe sur le mauvais prix — il n'existe
+aucun scénario où continuer soit le bon choix.
 
 **Pas de cache sur cette résolution au départ.** Stripe le suggère (« you might
 want to add a caching layer to only reload the price occasionally ») et ce sera la
@@ -115,6 +124,14 @@ les 5 actifs.
 **Découpage par paquets de 10.** Le paramètre `lookup_keys` accepte au maximum
 10 clés par requête. À 5 produits actifs la contrainte ne mord pas, mais la tâche
 doit découper — sinon elle casse en silence le jour où le catalogue grandit.
+
+**La tâche ne fait jamais échouer le cron.** Le SDK Stripe attend 80 s et réessaie
+2 fois par défaut ; l'appelant GitHub Actions coupe à `--max-time 60` et relance
+sur erreur (`--retry 3 --retry-all-errors`). Un audit purement informatif qui
+laisserait remonter une panne Stripe provoquerait donc jusqu'à **4 exécutions
+complètes du cron par heure** — clôtures d'examens et notifications comprises. Deux
+garde-fous : l'appel Stripe est borné (8 s, 1 réessai), et l'échec se signale par un
+drapeau dans le compte-rendu plus une capture Sentry, jamais par une exception.
 
 ### Coût — mesuré, pas supposé
 
@@ -142,11 +159,17 @@ Même règle que la réconciliation montant/devise déjà en place : **valeur ab
 inexploitable → on n'écrit rien et on continue.** Un paiement valide ne doit jamais
 échouer pour un problème de traçabilité.
 
-Le hash n'est présent **que si le client a payé en devise locale** (doc Adaptive
-Pricing) : pour un client canadien, les deux colonnes restent nulles. C'est le
-comportement attendu, pas une anomalie — et c'est ce qui rend la mesure possible :
-le taux de lignes non nulles *est* la proportion de clients passés par la
-conversion.
+La doc Adaptive Pricing énonce que le hash **est présent quand le client paie en
+devise locale**. Elle n'énonce pas la réciproque — rien n'y garantit qu'il soit
+toujours absent autrement. Le taux de lignes non nulles est donc une **borne
+basse** de la proportion de clients passés par la conversion, pas une mesure
+exacte, et il ne faut pas le présenter autrement dans un tableau de bord. La
+première semaine de données tranchera : si des lignes non nulles apparaissent avec
+`presentment_currency = 'CAD'`, la réciproque est fausse et le calcul doit exclure
+les lignes où la devise présentée égale la devise d'encaissement.
+
+Pour un client canadien, les deux colonnes sont attendues nulles. C'est le
+comportement normal, pas une anomalie.
 
 ## Affichage admin
 
@@ -189,11 +212,28 @@ Le backfill depuis `code` remplit dev **et** prod en une migration : plus aucun
 
 ### Prérequis avant déploiement
 
+Deux choses cassent le checkout si elles sont manquées.
+
+**Les `lookup_key` doivent réellement exister, dans les deux modes.** Le backfill
+remplace un pointeur éprouvé en production par un pointeur qui repose sur une
+affirmation extérieure au dépôt (un commentaire d'issue du 2026-08-06). À
+revérifier en lecture seule sur le compte, en test et en live, **avant** la
+migration. D'où le repli décrit ci-dessous.
+
 **La clé Stripe runtime doit avoir la permission de lecture sur Prices.** Créer une
 session Checkout avec un price ID ne l'exigeait pas ; `prices.list` l'exige. Si
 `STRIPE_SECRET_KEY` porte une clé restreinte (`rk_`), ajouter `prices:read` **avant**
 le déploiement — sinon tous les checkouts tombent en `permission_error`. Une clé
 secrète (`sk_`) a la permission par défaut.
+
+### Repli de phase 1
+
+Tant que `stripe_price_id` existe, une `lookup_key` qui ne résout rien **ne coupe
+pas la vente** : le checkout retombe sur le pointeur historique et alerte. C'est
+l'usage même de la colonne qu'on conserve pendant la fenêtre expand/contract — le
+nouveau chemin est éprouvé en production avant que l'ancien ne soit retiré, et le
+silence de l'alerte est ce qui autorise la phase 2. Le repli disparaît avec la
+colonne : ensuite, une clé introuvable redevient un refus.
 
 ## Portée collatérale
 
@@ -242,7 +282,7 @@ elle doit mordre. Un test qui passe que la vérification existe ou non ne teste 
 - **Pas de backfill de `presentment_details`** sur l'historique : la mesure commence
   aujourd'hui.
 - **Pas d'affichage dans la table transactions admin ni dans l'historique client.**
-- **Pas de blocage de vente** sur dérive de prix.
+- **Pas de blocage de vente sur un écart de MONTANT** (la devise, elle, refuse).
 - **Pas de cache** sur la résolution du prix.
 
 ## Critères d'acceptation

--- a/docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md
+++ b/docs/superpowers/specs/2026-08-21-stripe-catalogue-lookup-key-design.md
@@ -1,0 +1,263 @@
+# Catalogue Stripe par `lookup_key` et traçabilité Adaptive Pricing
+
+> Issue [#138](https://github.com/RinKhimera/NOMAQbanq/issues/138) — `enhancement`, `tech-debt`.
+> Décisions de conception validées le 2026-08-21.
+
+## Problème
+
+Deux angles morts, tous deux invisibles au type-check comme aux tests.
+
+**Le prix affiché et le prix facturé viennent de deux sources.** La grille tarifaire
+et les paywalls lisent `products.priceCad` en Postgres ; Stripe facture ce que
+désigne `products.stripePriceId`. Les tarifs étant gérés au dashboard Stripe, une
+modification non répercutée par un `UPDATE` en base fait diverger les deux en
+silence : **le client lit un montant et en paie un autre.**
+
+**Rien en base ne dit ce que le client a réellement vu.** Adaptive Pricing est actif
+en production. La doc officielle est explicite : « The Checkout Session and the
+underlying `PaymentIntent` objects reflect what your customer paid in **your
+integration currency and amount** ». Un client camerounais voit des FCFA mais
+l'événement arrive en `currency: "cad"` ; le montant local vit dans
+`presentment_details`, que l'app ignore. Un client qui écrit « j'ai payé
+25 000 FCFA » n'est donc recoupable par personne.
+
+S'y ajoute une classe de bug structurelle : `price_…` et `prod_…` portent des
+préfixes **identiques en test et en live**. Un identifiant du mauvais mode ne se
+révèle qu'à la création de la session, en `resource_missing`. C'est ce qui laisse
+aujourd'hui 4 produits sur 5 intestables en local.
+
+## Décision structurante
+
+Le lien catalogue ↔ Stripe passe d'un **identifiant opaque, propre à un mode**, à
+une **clé stable partagée par les deux modes** : `lookup_key`.
+
+C'est le cas d'usage documenté par Stripe, mot pour mot : « Instead of hard-coding
+text like 10 USD per month on your pricing page and using a price ID on your
+backend, you can query for the price using the `standard_monthly` key »
+(`https://docs.stripe.com/products-prices/manage-prices#lookup-keys`). Le
+changement de tarif s'y fait par `transfer_lookup_key=true` — un prix n'est jamais
+modifié, il est remplacé et la clé migre sur le nouveau.
+
+Conséquence directe : la classe « identifiant du mauvais mode » devient
+**impossible** au lieu d'être seulement détectée. Le point 4 de l'issue (catalogue
+de dev à moitié en live) se dissout sans aucun `UPDATE` manuel — les 5 `lookup_key`
+existent déjà des deux côtés, avec la même chaîne.
+
+## Modèle de données
+
+```
+products
+  - stripe_price_id           text NOT NULL     ← supprimée en phase 2
+  + stripe_price_lookup_key   text NOT NULL     ← backfillée depuis `code`
+
+transactions
+  + presentment_amount        integer NULL      ← unité mineure de la devise présentée
+  + presentment_currency      text NULL         ← texte libre, PAS l'enum `currency`
+```
+
+**`presentment_currency` est du texte, délibérément.** L'enum `currency` ne connaît
+que `CAD` et `XAF` ; Adaptive Pricing couvre plus de 150 pays et peut présenter
+n'importe quelle devise de marché supporté. Contraindre ici ferait perdre la donnée
+qu'on cherche précisément à capturer.
+
+**`amount_paid` / `currency` ne bougent pas.** Ils restent le chiffre
+d'encaissement — c'est-à-dire le montant comptable. Aucune régression comptable
+n'est acceptable (critère d'acceptation n°3 de l'issue).
+
+**Une colonne dédiée plutôt qu'une dérivation depuis `code`.** Les `lookup_key`
+Stripe portent aujourd'hui exactement la même chaîne que `products.code`, ce qui
+rendait tentant un `prices.list({ lookup_keys: [product.code] })` sans colonne.
+Écarté : le couplage entre l'enum Postgres et le nommage Stripe deviendrait
+invisible dans le code, et un renommage d'un côté casserait l'autre sans signal.
+
+## Checkout — résolution et détection de dérive
+
+Dans `createStripeCheckout` (`features/payments/actions.ts`), le prix est résolu
+avant la création de la session :
+
+```
+prices.list({ lookup_keys: [product.stripePriceLookupKey], active: true, limit: 2 })
+  → 0 résultat → « Ce produit est mal configuré. Contactez le support. » + Sentry
+  → 1 résultat → line_items: [{ price: price.id, quantity: 1 }]
+```
+
+Le chemin d'erreur réutilise celui de `resource_missing` : même message utilisateur,
+même capture Sentry. Un `lookup_key` introuvable dans le mode de la clé active
+signifie la même chose qu'un price ID introuvable — produit mal configuré, aucune
+nouvelle tentative n'y changera rien.
+
+Le `Price` retourné porte `unit_amount` et `currency` : **la comparaison avec
+`product.priceCad` ne coûte aucun appel supplémentaire.** Écart de montant, ou
+devise du prix ≠ `cad` → `captureServerError`, **et la vente continue.**
+
+Bloquer serait pire que l'écart : une simple modification de tarif au dashboard
+couperait les ventes du produit jusqu'à ce que quelqu'un fasse l'`UPDATE` en base.
+Le client qui paie un montant différent de l'affiché est un incident ; zéro vente
+en est un plus grave, et plus long à diagnostiquer.
+
+**Pas de cache sur cette résolution au départ.** Stripe le suggère (« you might
+want to add a caching layer to only reload the price occasionally ») et ce sera la
+bonne réponse si la latence se mesure un jour. Mais c'est un appel de plus sur un
+chemin qui appelle déjà Stripe pour créer la session, et un cache introduit sa
+propre classe de bug : un prix périmé servi après correction. Différé, pas oublié.
+
+## Cron — dérive sur les produits que personne n'achète
+
+Nouvelle tâche `auditProductPriceDrift` dans `features/payments/cron.ts`, branchée
+dans le dispatcher existant `app/api/cron/close-expired/route.ts`. Elle suit la
+forme des 4 tâches en place : isolée par le helper `run()`, un échec ne bloque pas
+les suivantes (notamment l'anonymisation RGPD).
+
+La vérification au checkout ne voit que les produits qu'on achète. Un produit peu
+demandé peut dériver des semaines sans que personne ne l'apprenne : le cron couvre
+les 5 actifs.
+
+**Découpage par paquets de 10.** Le paramètre `lookup_keys` accepte au maximum
+10 clés par requête. À 5 produits actifs la contrainte ne mord pas, mais la tâche
+doit découper — sinon elle casse en silence le jour où le catalogue grandit.
+
+### Coût — mesuré, pas supposé
+
+| Poste | Coût |
+| --- | --- |
+| Stripe | 1 requête `prices.list` par exécution. Le cron part 1×/h (GitHub, best-effort) + 1×/jour (Vercel, plancher) → **~25 requêtes/jour**. Limite documentée : 100 req/s en live, 25 req/s par endpoint. On est à 0,0003 req/s. Les appels API ne sont pas facturés. |
+| Neon | 1 `SELECT` de 5 lignes sur index. **Aucune connexion nouvelle** : le dispatcher est séquentiel (invariant NOMAQBANQ-17), la tâche réutilise la connexion déjà ouverte par les tâches précédentes. Pas de réveil Neon supplémentaire. |
+| Sentry | Le seul poste non nul. Voir ci-dessous. |
+
+**Bruit Sentry — choix assumé.** Tant qu'une dérive n'est pas corrigée, la tâche
+alerte à chaque exécution : jusqu'à ~25 événements/jour, groupés sur une seule
+issue mais consommant le quota un par un. Un mécanisme anti-répétition (garde
+horaire, état de dernière alerte) a été écarté : une dérive de prix est une erreur
+d'ops qui se corrige le jour même, et l'anti-répétition ajouterait de l'état
+persistant pour un problème qui ne dure pas. Si le bruit devient réel, la réponse
+est de corriger la dérive, pas de baisser le volume de l'alarme.
+
+## Fulfillment — persistance de `presentment_details`
+
+Le webhook transmet `checkoutSession.presentment_details` à
+`completeStripeTransaction`, qui écrit les deux colonnes dans le **même `UPDATE`**
+que le reste du fulfillment — aucune écriture supplémentaire, aucun aller-retour.
+
+Même règle que la réconciliation montant/devise déjà en place : **valeur absente ou
+inexploitable → on n'écrit rien et on continue.** Un paiement valide ne doit jamais
+échouer pour un problème de traçabilité.
+
+Le hash n'est présent **que si le client a payé en devise locale** (doc Adaptive
+Pricing) : pour un client canadien, les deux colonnes restent nulles. C'est le
+comportement attendu, pas une anomalie — et c'est ce qui rend la mesure possible :
+le taux de lignes non nulles *est* la proportion de clients passés par la
+conversion.
+
+## Affichage admin
+
+Dans `app/(admin)/admin/utilisateurs/_components/user-side-panel.tsx`, sous le
+montant encaissé :
+
+```
++50,00 $ CA
+présenté : 228 000 XAF
+```
+
+La ligne n'apparaît que si `presentment_currency` est renseignée.
+
+Nouveau helper `formatPresentmentAmount` dans `lib/format.ts`. Il ne peut pas
+diviser par 100 en dur : la devise présentée est arbitraire et peut être
+zéro-décimal (XAF, JPY), auquel cas 228 000 FCFA s'afficheraient en « 2 280 ». Le
+nombre de décimales se dérive de `Intl.NumberFormat(...).resolvedOptions()`, ce qui
+évite d'embarquer une liste de devises zéro-décimal qui vieillirait mal. Code ISO
+inconnu d'`Intl` (qui lève `RangeError`) → repli sur `<montant> <DEVISE>`.
+
+`formatCurrency` n'est pas touché : il est appelé partout ailleurs avec des cents.
+
+## Déploiement — expand/contract obligatoire
+
+Les migrations Drizzle tournent **au build Vercel, avant l'activation du
+déploiement** (`build:vercel` → `migrate-deploy`). Un `DROP COLUMN
+stripe_price_id` dans la même migration casserait le checkout de l'ancien code
+pendant toute la durée du build — l'ancien `SELECT` référencerait une colonne
+disparue. D'où deux temps :
+
+1. **Ce PR** — `ADD COLUMN stripe_price_lookup_key` (nullable), `UPDATE products
+   SET stripe_price_lookup_key = code`, puis `SET NOT NULL`. Le code bascule sur
+   la résolution par `lookup_key`. `stripe_price_id` reste en base, plus lue par
+   personne.
+2. **PR de suivi, après vérification en production** — `DROP COLUMN
+   stripe_price_id`.
+
+Le backfill depuis `code` remplit dev **et** prod en une migration : plus aucun
+`UPDATE` manuel, plus de produit intestable en local.
+
+### Prérequis avant déploiement
+
+**La clé Stripe runtime doit avoir la permission de lecture sur Prices.** Créer une
+session Checkout avec un price ID ne l'exigeait pas ; `prices.list` l'exige. Si
+`STRIPE_SECRET_KEY` porte une clé restreinte (`rk_`), ajouter `prices:read` **avant**
+le déploiement — sinon tous les checkouts tombent en `permission_error`. Une clé
+secrète (`sk_`) a la permission par défaut.
+
+## Portée collatérale
+
+- **Trois commentaires à corriger** (point 3 de l'issue), qui affirment aujourd'hui
+  le contraire de la doc : `features/payments/stripe.ts` (bloc JSDoc de
+  `completeStripeTransaction`), `app/api/stripe/webhook/route.ts` (« Montant/devise
+  réellement facturés (promo, Adaptive Pricing) »),
+  `scripts/audit-stripe-transactions.ts` (en-tête). **Seuls les codes promo** font
+  effectivement diverger `amount_total` de `priceCad` ; la branche de conversion
+  XAF ×100 reste correcte mais n'est jamais atteinte sous Adaptive Pricing.
+- **`.claude/rules/payments.md`** — la section « Catalogue produits » décrit
+  `stripePriceId` comme la source de facturation et les préfixes `price_` comme le
+  piège de mode. Les deux deviennent faux : à réécrire autour du `lookup_key`.
+- **`AGENTS.md`** — le gotcha « seul `exam_access` pointe sur un prix test »
+  disparaît.
+- **`ProductView`** (`features/payments/dal.ts`) — `stripePriceId` et
+  `stripeProductId` traversent la frontière serveur → client alors qu'aucun
+  composant ne les lit. Retirés au passage.
+- **~20 fichiers de tests** insèrent `stripePriceId` dans des lignes `products` :
+  renommage mécanique mais large.
+
+## Tests
+
+- **Unitaire** — résolution `lookup_key` (0 résultat → erreur « mal configuré » ;
+  1 résultat → price ID passé aux `line_items`) ; détection de dérive sur le
+  montant et sur la devise ; `formatPresentmentAmount` (XAF zéro-décimal, CAD,
+  code ISO invalide).
+- **Intégration `payments-checkout.test.ts`** — la session est créée avec le price
+  ID résolu ; `lookup_key` introuvable → message dédié, aucune transaction
+  `pending` créée.
+- **Intégration `payments-stripe.test.ts`** — le fulfillment persiste
+  `presentment_amount`/`presentment_currency` ; absence de `presentment_details` →
+  colonnes nulles **et** `amountPaid`/`currency` inchangés.
+- **Cron** — écart détecté → alerte émise, aucune écriture en base.
+
+Écrire les tests par paires jumelles : un cas où la garde doit passer, un cas où
+elle doit mordre. Un test qui passe que la vérification existe ou non ne teste rien.
+
+## Hors périmètre
+
+- **Aucun prix en XAF.** Adaptive Pricing exige que la devise des prix soit une
+  devise de règlement du compte, et la conversion est désactivée pour toute devise
+  déjà présente dans `currency_options`. Créer un prix XAF « pour aider » couperait
+  la conversion automatique sur cette devise. Les six pays de la zone XAF sont tous
+  dans les marchés supportés : la configuration actuelle est la bonne.
+- **Pas de backfill de `presentment_details`** sur l'historique : la mesure commence
+  aujourd'hui.
+- **Pas d'affichage dans la table transactions admin ni dans l'historique client.**
+- **Pas de blocage de vente** sur dérive de prix.
+- **Pas de cache** sur la résolution du prix.
+
+## Critères d'acceptation
+
+| Critère de l'issue | Couverture |
+| --- | --- |
+| Écart `priceCad` ↔ prix Stripe détecté sans intervention manuelle | Checkout (au moment où ça compte) + cron (horaire best-effort, quotidien garanti) pour les produits non achetés |
+| Montant et devise présentés persistés et consultables côté admin | Colonnes `presentment_*` + panneau utilisateur admin |
+| `amountPaid` / `currency` restent le montant d'encaissement | Aucune modification du chemin de réconciliation ; test dédié |
+| Les trois commentaires trompeurs corrigés | Portée collatérale |
+| Les 5 produits achetables en mode test depuis la base dev | Dissous par le `lookup_key` : la clé de test résout le prix de test |
+
+## Astuce de test
+
+Pour voir Checkout en FCFA sans quitter le Québec, suffixer l'email du code pays :
+`customer_email: "test+location_CM@example.com"`. Stripe présente alors la session
+comme pour un client camerounais — et `presentment_details` apparaît sur
+l'événement.

--- a/drizzle/0013_sharp_gwen_stacy.sql
+++ b/drizzle/0013_sharp_gwen_stacy.sql
@@ -1,0 +1,10 @@
+-- Ajout en trois temps : Drizzle génère un `ADD COLUMN ... NOT NULL` sans défaut,
+-- qui échoue sur une table déjà peuplée. Le backfill vient du `code` produit : le
+-- catalogue Stripe porte, dans les DEUX modes, une `lookup_key` égale au code
+-- (vérifié en test et en live le 2026-08-21). Le `::text` est nécessaire, `code`
+-- étant de type enum `product_code`.
+ALTER TABLE "products" ADD COLUMN "stripe_price_lookup_key" text;--> statement-breakpoint
+UPDATE "products" SET "stripe_price_lookup_key" = "code"::text;--> statement-breakpoint
+ALTER TABLE "products" ALTER COLUMN "stripe_price_lookup_key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "presentment_amount" integer;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "presentment_currency" text;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2705 @@
+{
+  "id": "6c2d781a-2cb9-42a3-9a42-c95345fd0218",
+  "prevId": "a021d1d3-6d26-4d02-be51-6884fb920bc7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_key_idx": {
+          "name": "rate_limit_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_exam_results": {
+          "name": "notify_exam_results",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_access_expiry": {
+          "name": "notify_access_expiry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymized_at": {
+          "name": "anonymized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_role_idx": {
+          "name": "user_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_answers": {
+      "name": "exam_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer": {
+          "name": "selected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_flagged": {
+          "name": "is_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_answers_participation_id_idx": {
+          "name": "exam_answers_participation_id_idx",
+          "columns": [
+            {
+              "expression": "participation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_answers_question_id_idx": {
+          "name": "exam_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_answers_participation_id_exam_participations_id_fk": {
+          "name": "exam_answers_participation_id_exam_participations_id_fk",
+          "tableFrom": "exam_answers",
+          "tableTo": "exam_participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_answers_question_id_questions_id_fk": {
+          "name": "exam_answers_question_id_questions_id_fk",
+          "tableFrom": "exam_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exam_answers_participation_question_unique": {
+          "name": "exam_answers_participation_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participation_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_audience": {
+      "name": "exam_audience",
+      "schema": "",
+      "columns": {
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_audience_user_id_idx": {
+          "name": "exam_audience_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_audience_exam_id_exams_id_fk": {
+          "name": "exam_audience_exam_id_exams_id_fk",
+          "tableFrom": "exam_audience",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_audience_user_id_user_id_fk": {
+          "name": "exam_audience_user_id_user_id_fk",
+          "tableFrom": "exam_audience",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exam_audience_exam_id_user_id_pk": {
+          "name": "exam_audience_exam_id_user_id_pk",
+          "columns": [
+            "exam_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_participations": {
+      "name": "exam_participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "exam_participation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results_notified_at": {
+          "name": "results_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_started_at": {
+          "name": "pause_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pause_duration_ms": {
+          "name": "total_pause_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exam_participations_exam_id_idx": {
+          "name": "exam_participations_exam_id_idx",
+          "columns": [
+            {
+              "expression": "exam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_user_id_idx": {
+          "name": "exam_participations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_status_idx": {
+          "name": "exam_participations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exam_participations_results_pending_idx": {
+          "name": "exam_participations_results_pending_idx",
+          "columns": [
+            {
+              "expression": "exam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"exam_participations\".\"status\" in ('completed', 'auto_submitted') and \"exam_participations\".\"results_notified_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_participations_exam_id_exams_id_fk": {
+          "name": "exam_participations_exam_id_exams_id_fk",
+          "tableFrom": "exam_participations",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_participations_user_id_user_id_fk": {
+          "name": "exam_participations_user_id_user_id_fk",
+          "tableFrom": "exam_participations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exam_participations_exam_user_unique": {
+          "name": "exam_participations_exam_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "exam_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exam_questions": {
+      "name": "exam_questions",
+      "schema": "",
+      "columns": {
+        "exam_id": {
+          "name": "exam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "exam_questions_question_id_idx": {
+          "name": "exam_questions_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exam_questions_exam_id_exams_id_fk": {
+          "name": "exam_questions_exam_id_exams_id_fk",
+          "tableFrom": "exam_questions",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_questions_question_id_questions_id_fk": {
+          "name": "exam_questions_question_id_questions_id_fk",
+          "tableFrom": "exam_questions",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exam_questions_exam_id_question_id_pk": {
+          "name": "exam_questions_exam_id_question_id_pk",
+          "columns": [
+            "exam_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "exam_questions_exam_position_unique": {
+          "name": "exam_questions_exam_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "exam_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exams": {
+      "name": "exams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_time": {
+          "name": "completion_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_pause": {
+          "name": "enable_pause",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pause_duration_minutes": {
+          "name": "pause_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "exam_audience_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribers'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exams_is_active_idx": {
+          "name": "exams_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_start_date_idx": {
+          "name": "exams_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_end_date_idx": {
+          "name": "exams_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_is_active_start_date_idx": {
+          "name": "exams_is_active_start_date_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exams_created_by_idx": {
+          "name": "exams_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exams_created_by_user_id_fk": {
+          "name": "exams_created_by_user_id_fk",
+          "tableFrom": "exams",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_explanations": {
+      "name": "question_explanations",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_explanations_question_id_questions_id_fk": {
+          "name": "question_explanations_question_id_questions_id_fk",
+          "tableFrom": "question_explanations",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_images": {
+      "name": "question_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "question_image_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'statement'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_images_question_id_idx": {
+          "name": "question_images_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_images_question_kind_idx": {
+          "name": "question_images_question_kind_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_images_question_id_questions_id_fk": {
+          "name": "question_images_question_id_questions_id_fk",
+          "tableFrom": "question_images",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objectif_cmc": {
+          "name": "objectif_cmc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_domain_idx": {
+          "name": "questions_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_objectif_cmc_idx": {
+          "name": "questions_objectif_cmc_idx",
+          "columns": [
+            {
+              "expression": "objectif_cmc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_bookmarks": {
+      "name": "question_bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_bookmarks_user_id_idx": {
+          "name": "question_bookmarks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_bookmarks_user_id_user_id_fk": {
+          "name": "question_bookmarks_user_id_user_id_fk",
+          "tableFrom": "question_bookmarks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_bookmarks_question_id_questions_id_fk": {
+          "name": "question_bookmarks_question_id_questions_id_fk",
+          "tableFrom": "question_bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_bookmarks_user_question_unique": {
+          "name": "question_bookmarks_user_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_session_items": {
+      "name": "training_session_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer": {
+          "name": "selected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "training_session_items_session_id_idx": {
+          "name": "training_session_items_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_session_items_question_id_idx": {
+          "name": "training_session_items_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_session_items_session_id_training_sessions_id_fk": {
+          "name": "training_session_items_session_id_training_sessions_id_fk",
+          "tableFrom": "training_session_items",
+          "tableTo": "training_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_session_items_question_id_questions_id_fk": {
+          "name": "training_session_items_question_id_questions_id_fk",
+          "tableFrom": "training_session_items",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "training_session_items_session_question_unique": {
+          "name": "training_session_items_session_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "question_id"
+          ]
+        },
+        "training_session_items_session_position_unique": {
+          "name": "training_session_items_session_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_sessions": {
+      "name": "training_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "training_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "training_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'test'"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectif_cmc": {
+          "name": "objectif_cmc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_sessions_user_status_idx": {
+          "name": "training_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_user_started_at_idx": {
+          "name": "training_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_status_idx": {
+          "name": "training_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_sessions_status_expires_at_idx": {
+          "name": "training_sessions_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_sessions_user_id_user_id_fk": {
+          "name": "training_sessions_user_id_user_id_fk",
+          "tableFrom": "training_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "product_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cad": {
+          "name": "price_cad",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_days": {
+          "name": "duration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_lookup_key": {
+          "name": "stripe_price_lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_combo": {
+          "name": "is_combo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "products_code_idx": {
+          "name": "products_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stripe_product_id_idx": {
+          "name": "products_stripe_product_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_is_active_idx": {
+          "name": "products_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presentment_amount": {
+          "name": "presentment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presentment_currency": {
+          "name": "presentment_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_days": {
+          "name": "duration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_stripe_event_id_unique": {
+          "name": "transactions_stripe_event_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_id_idx": {
+          "name": "transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_session_id_idx": {
+          "name": "transactions_stripe_session_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_type_idx": {
+          "name": "transactions_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_access_type_idx": {
+          "name": "transactions_user_access_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_created_at_idx": {
+          "name": "transactions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_product_id_products_id_fk": {
+          "name": "transactions_product_id_products_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_recorded_by_user_id_fk": {
+          "name": "transactions_recorded_by_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_access": {
+      "name": "user_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_reminder_sent_at": {
+          "name": "expiry_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transaction_id": {
+          "name": "last_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_access_user_id_idx": {
+          "name": "user_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_access_expires_at_idx": {
+          "name": "user_access_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_access_expiry_reminder_pending_idx": {
+          "name": "user_access_expiry_reminder_pending_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_access\".\"expiry_reminder_sent_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_access_user_id_user_id_fk": {
+          "name": "user_access_user_id_user_id_fk",
+          "tableFrom": "user_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_access_last_transaction_id_transactions_id_fk": {
+          "name": "user_access_last_transaction_id_transactions_id_fk",
+          "tableFrom": "user_access",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "last_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_access_user_access_type_unique": {
+          "name": "user_access_user_access_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "access_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rate_limits": {
+      "name": "quiz_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quiz_rate_limits_key_action_unique": {
+          "name": "quiz_rate_limits_key_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_rate_limits": {
+      "name": "upload_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_type": {
+          "name": "upload_type",
+          "type": "upload_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upload_rate_limits_user_id_idx": {
+          "name": "upload_rate_limits_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_rate_limits_user_id_user_id_fk": {
+          "name": "upload_rate_limits_user_id_user_id_fk",
+          "tableFrom": "upload_rate_limits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "upload_rate_limits_user_type_unique": {
+          "name": "upload_rate_limits_user_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "upload_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_type": {
+      "name": "access_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "training"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "CAD",
+        "XAF"
+      ]
+    },
+    "public.exam_audience_type": {
+      "name": "exam_audience_type",
+      "schema": "public",
+      "values": [
+        "subscribers",
+        "restricted"
+      ]
+    },
+    "public.exam_participation_status": {
+      "name": "exam_participation_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "auto_submitted"
+      ]
+    },
+    "public.exam_pause_phase": {
+      "name": "exam_pause_phase",
+      "schema": "public",
+      "values": [
+        "before_pause",
+        "during_pause",
+        "after_pause"
+      ]
+    },
+    "public.product_code": {
+      "name": "product_code",
+      "schema": "public",
+      "values": [
+        "exam_access",
+        "training_access",
+        "exam_access_promo",
+        "training_access_promo",
+        "premium_access"
+      ]
+    },
+    "public.question_image_kind": {
+      "name": "question_image_kind",
+      "schema": "public",
+      "values": [
+        "statement",
+        "explanation"
+      ]
+    },
+    "public.training_mode": {
+      "name": "training_mode",
+      "schema": "public",
+      "values": [
+        "tutor",
+        "test"
+      ]
+    },
+    "public.training_status": {
+      "name": "training_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "abandoned"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed",
+        "refunded"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "manual"
+      ]
+    },
+    "public.upload_type": {
+      "name": "upload_type",
+      "schema": "public",
+      "values": [
+        "avatar",
+        "question-image"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785644443900,
       "tag": "0012_lowly_paper_doll",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1787327354153,
+      "tag": "0013_sharp_gwen_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/features/payments/actions.ts
+++ b/features/payments/actions.ts
@@ -9,6 +9,7 @@ import { getBaseUrl } from "@/lib/base-url"
 import { createId } from "@/lib/ids"
 import { captureServerError } from "@/lib/observability"
 import { getStripe } from "@/lib/stripe"
+import { describePriceDrift, resolveStripePrice } from "./catalog"
 import {
   type AccessImpact,
   type AccessStatus,
@@ -339,6 +340,7 @@ export const createStripeCheckout = async (input: {
     .select({
       id: products.id,
       stripePriceId: products.stripePriceId,
+      stripePriceLookupKey: products.stripePriceLookupKey,
       priceCad: products.priceCad,
       accessType: products.accessType,
       durationDays: products.durationDays,
@@ -352,15 +354,74 @@ export const createStripeCheckout = async (input: {
   if (!product) return { error: "Produit introuvable" }
   if (!product.isActive) return { error: "Ce produit n'est plus disponible" }
 
+  // Déclaré hors du `try` : le `catch` en a besoin pour nommer le prix réellement
+  // envoyé à Stripe, qui peut venir de la résolution comme du repli.
+  let resolvedPriceId: string | null = null
   try {
     const stripe = getStripe()
     const base = appBase()
+
+    const price = await resolveStripePrice(
+      stripe,
+      product.stripePriceLookupKey,
+      (lookupKey, count) =>
+        captureServerError(
+          "[createStripeCheckout]",
+          new Error("plusieurs prix actifs pour une même lookup_key"),
+          { userId: session.user.id, detail: `${lookupKey} · ${count} prix` },
+        ),
+    )
+
+    // Repli de phase 1 (expand/contract). `stripe_price_id` est le pointeur
+    // historique, éprouvé en production ; la `lookup_key` ne l'est pas encore.
+    // Tant que la colonne existe, une clé qui ne résout rien ne doit PAS couper
+    // la vente — elle alerte. Ce repli disparaît en phase 2, avec la colonne :
+    // tant que l'alerte ne se déclenche pas, la bascule est vérifiée.
+    if (!price) {
+      captureServerError(
+        "[createStripeCheckout]",
+        new Error(
+          "aucun prix actif pour cette lookup_key — repli sur stripe_price_id",
+        ),
+        {
+          userId: session.user.id,
+          detail: `lookup_key ${product.stripePriceLookupKey} absente du mode de la clé active (produit ${productCode})`,
+        },
+      )
+    }
+    resolvedPriceId = price?.id ?? product.stripePriceId
+
+    // Devise et montant ne se traitent PAS de la même façon. La devise d'un prix
+    // Stripe est immuable : elle ne peut pas avoir changé légitimement, donc une
+    // devise ≠ cad signifie que la clé pointe sur le mauvais prix → refus. Un
+    // montant, lui, diverge normalement le temps qu'un changement de tarif soit
+    // répercuté en base → alerte seule. Le client voit de toute façon le montant
+    // sur Checkout avant de confirmer.
+    const drift = price ? describePriceDrift(product.priceCad, price) : null
+    if (drift) {
+      captureServerError(
+        "[createStripeCheckout]",
+        new Error(
+          drift.currencyMismatch
+            ? "devise du prix Stripe inattendue"
+            : "prix affiché divergent du prix Stripe",
+        ),
+        {
+          userId: session.user.id,
+          detail: `produit ${productCode} · ${drift.message}`,
+        },
+      )
+      if (drift.currencyMismatch) {
+        return { error: "Ce produit est mal configuré. Contactez le support." }
+      }
+    }
+
     const checkout = await stripe.checkout.sessions.create({
       mode: "payment",
       customer_email: session.user.email,
       // Force la création d'un customer Stripe (nécessaire au portail de facturation).
       customer_creation: "always",
-      line_items: [{ price: product.stripePriceId, quantity: 1 }],
+      line_items: [{ price: resolvedPriceId, quantity: 1 }],
       metadata: {
         userId: session.user.id,
         productId: product.id,
@@ -396,16 +457,16 @@ export const createStripeCheckout = async (input: {
 
     return { checkoutUrl: checkout.url }
   } catch (error) {
-    // `resource_missing` à la CRÉATION (≠ verifyStripeCheckout, où il vient d'une
-    // URL périmée) : le `stripe_price_id` en base n'existe pas dans le mode de la
-    // clé active — identifiant live sous clé test, ou l'inverse. Les préfixes
-    // `price_`/`prod_` étant identiques dans les deux modes, c'est le seul moment
-    // où l'incohérence devient visible. Aucune nouvelle tentative n'y changera
-    // rien : le message générique enverrait chercher une panne réseau.
+    // `resource_missing` à la CRÉATION de la session (≠ verifyStripeCheckout, où
+    // il vient d'une URL périmée). Le prix étant désormais résolu en amont, ce
+    // cas ne peut plus venir d'un identifiant du mauvais mode : il signale un
+    // objet Stripe supprimé entre la résolution et la création. Aucune nouvelle
+    // tentative n'y changera rien : le message générique enverrait chercher une
+    // panne réseau.
     if (isStripeResourceMissing(error)) {
       captureServerError("[createStripeCheckout]", error, {
         userId: session.user.id,
-        detail: `price ${product.stripePriceId} absent du mode de la clé active (produit ${productCode})`,
+        detail: `prix ${resolvedPriceId ?? "non résolu"} (lookup_key ${product.stripePriceLookupKey}) introuvable (produit ${productCode})`,
       })
       return { error: "Ce produit est mal configuré. Contactez le support." }
     }

--- a/features/payments/actions.ts
+++ b/features/payments/actions.ts
@@ -2,6 +2,7 @@
 
 import { asc, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
+import type Stripe from "stripe"
 import { db } from "@/db"
 import { products, transactions, user } from "@/db/schema"
 import { requireRole, requireSession } from "@/lib/auth-guards"
@@ -361,33 +362,43 @@ export const createStripeCheckout = async (input: {
     const stripe = getStripe()
     const base = appBase()
 
-    const price = await resolveStripePrice(
-      stripe,
-      product.stripePriceLookupKey,
-      (lookupKey, count) =>
-        captureServerError(
-          "[createStripeCheckout]",
-          new Error("plusieurs prix actifs pour une même lookup_key"),
-          { userId: session.user.id, detail: `${lookupKey} · ${count} prix` },
-        ),
-    )
-
     // Repli de phase 1 (expand/contract). `stripe_price_id` est le pointeur
     // historique, éprouvé en production ; la `lookup_key` ne l'est pas encore.
-    // Tant que la colonne existe, une clé qui ne résout rien ne doit PAS couper
-    // la vente — elle alerte. Ce repli disparaît en phase 2, avec la colonne :
-    // tant que l'alerte ne se déclenche pas, la bascule est vérifiée.
-    if (!price) {
-      captureServerError(
-        "[createStripeCheckout]",
-        new Error(
-          "aucun prix actif pour cette lookup_key — repli sur stripe_price_id",
-        ),
-        {
-          userId: session.user.id,
-          detail: `lookup_key ${product.stripePriceLookupKey} absente du mode de la clé active (produit ${productCode})`,
-        },
+    // Tant que la colonne existe, la résolution ne doit JAMAIS couper la vente —
+    // ni quand la clé ne résout rien, ni quand l'appel LUI-MÊME échoue (droit
+    // `prices:read` absent de la clé restreinte, 429, réseau). Sans ce catch,
+    // l'exception sauterait par-dessus le repli jusqu'au message générique
+    // « Réessayez », qui invite à retenter une panne permanente. Deux messages
+    // distincts : les deux causes appellent des remèdes opposés.
+    let price: Stripe.Price | null = null
+    try {
+      price = await resolveStripePrice(
+        stripe,
+        product.stripePriceLookupKey,
+        (lookupKey, count) =>
+          captureServerError(
+            "[createStripeCheckout]",
+            new Error("plusieurs prix actifs pour une même lookup_key"),
+            { userId: session.user.id, detail: `${lookupKey} · ${count} prix` },
+          ),
       )
+      if (!price) {
+        captureServerError(
+          "[createStripeCheckout]",
+          new Error(
+            "aucun prix actif pour cette lookup_key — repli sur stripe_price_id",
+          ),
+          {
+            userId: session.user.id,
+            detail: `lookup_key ${product.stripePriceLookupKey} absente du mode de la clé active (produit ${productCode})`,
+          },
+        )
+      }
+    } catch (error) {
+      captureServerError("[createStripeCheckout]", error, {
+        userId: session.user.id,
+        detail: `résolution de la lookup_key ${product.stripePriceLookupKey} impossible — repli sur stripe_price_id (produit ${productCode})`,
+      })
     }
     resolvedPriceId = price?.id ?? product.stripePriceId
 

--- a/features/payments/catalog.ts
+++ b/features/payments/catalog.ts
@@ -1,0 +1,74 @@
+import "server-only"
+import type Stripe from "stripe"
+
+type PriceShape = Pick<Stripe.Price, "id" | "unit_amount" | "currency">
+
+/**
+ * Requête bornée. Le SDK Stripe attend 80 s par défaut et réessaie 2 fois : un
+ * appel qui pend peut donc durer ~4 min. Inacceptable sur le chemin du checkout,
+ * où l'utilisateur attend, comme dans le cron, dont l'appelant coupe à
+ * `--max-time 60` puis relance — soit jusqu'à 4 exécutions complètes par heure.
+ */
+const PRICE_REQUEST_OPTIONS = { timeout: 8000, maxNetworkRetries: 1 }
+
+/**
+ * Résout le prix Stripe d'un produit par sa `lookup_key`. Contrairement à un
+ * `price_…`, une `lookup_key` est identique en test et en live : c'est ce qui
+ * rend impossible l'usage d'un identifiant du mauvais mode.
+ *
+ * `onAmbiguous` est appelé si PLUSIEURS prix actifs portent la clé — cas que
+ * Stripe n'est pas censé produire, et qu'on refuse de trancher au hasard en
+ * silence. Le premier prix est renvoyé quand même : alerter ne doit pas couper
+ * la vente.
+ *
+ * `null` = aucun prix actif ne porte cette clé dans le mode de la clé API.
+ */
+export const resolveStripePrice = async (
+  stripe: Stripe,
+  lookupKey: string,
+  onAmbiguous?: (lookupKey: string, count: number) => void,
+): Promise<Stripe.Price | null> => {
+  const { data } = await stripe.prices.list(
+    { lookup_keys: [lookupKey], active: true, limit: 2 },
+    PRICE_REQUEST_OPTIONS,
+  )
+  if (data.length > 1) onAmbiguous?.(lookupKey, data.length)
+  return data[0] ?? null
+}
+
+export type PriceDrift = {
+  /**
+   * La devise du prix Stripe n'est pas le CAD. Traité à part du montant : la
+   * devise d'un prix Stripe est IMMUABLE (on ne modifie pas un prix, on en crée
+   * un autre), donc elle ne peut pas avoir « changé » légitimement — c'est une
+   * erreur de configuration, pas un état transitoire. Un montant, lui, diverge
+   * normalement le temps qu'un `transfer_lookup_key` soit répercuté en base.
+   */
+  currencyMismatch: boolean
+  message: string
+}
+
+/**
+ * Écart entre le prix AFFICHÉ (`products.priceCad`, en cents, lu par la grille
+ * tarifaire et les paywalls) et le prix que Stripe FACTURERA. Les deux vivent
+ * dans des systèmes différents ; sans cette comparaison, une modification de
+ * tarif au dashboard non répercutée en base passe inaperçue.
+ *
+ * `null` = ils concordent.
+ */
+export const describePriceDrift = (
+  priceCad: number,
+  price: PriceShape,
+): PriceDrift | null => {
+  const currencyMismatch = price.currency !== "cad"
+  const parts: string[] = []
+  if (currencyMismatch) parts.push(`devise Stripe ${price.currency} ≠ cad`)
+  if (price.unit_amount !== priceCad) {
+    parts.push(
+      `montant Stripe ${price.unit_amount ?? "null"} ≠ base ${priceCad}`,
+    )
+  }
+  return parts.length > 0
+    ? { currencyMismatch, message: `${price.id} : ${parts.join(" · ")}` }
+    : null
+}

--- a/features/payments/cron.ts
+++ b/features/payments/cron.ts
@@ -1,0 +1,105 @@
+import { eq } from "drizzle-orm"
+import "server-only"
+import type Stripe from "stripe"
+import { db } from "@/db"
+import { products } from "@/db/schema"
+import { env } from "@/lib/env/server"
+import { captureServerError } from "@/lib/observability"
+import { getStripe } from "@/lib/stripe"
+import { describePriceDrift } from "./catalog"
+
+export type PriceDriftResult = {
+  checked: number
+  drifted: number
+  failed: boolean
+}
+
+// Borne de l'API Stripe : `prices.list` accepte au plus 10 `lookup_keys` par
+// requête. Au-delà, la liste serait tronquée en silence et les produits
+// surnuméraires passeraient pour « sans prix actif ».
+const LOOKUP_KEYS_PER_CALL = 10
+
+/**
+ * Compare le prix AFFICHÉ (`products.priceCad`) au prix que Stripe FACTURERAIT,
+ * pour tous les produits actifs. Le contrôle équivalent au checkout ne couvre
+ * que les produits qu'on achète : un produit peu demandé peut dériver des
+ * semaines sans que personne ne l'apprenne.
+ *
+ * Lecture seule : aucune écriture en base, aucune écriture chez Stripe.
+ *
+ * **Ne lève JAMAIS.** Une panne Stripe ferait répondre 500 au dispatcher, or
+ * l'appelant GitHub Actions relance sur erreur (`--retry 3 --retry-all-errors`) :
+ * un audit informatif provoquerait jusqu'à 4 exécutions complètes du cron par
+ * heure, clôtures et notifications comprises. L'échec se signale par `failed`
+ * et par Sentry, pas par une exception.
+ */
+export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
+  if (!env.STRIPE_SECRET_KEY) return { checked: 0, drifted: 0, failed: false }
+
+  const rows = await db
+    .select({
+      code: products.code,
+      priceCad: products.priceCad,
+      lookupKey: products.stripePriceLookupKey,
+    })
+    .from(products)
+    .where(eq(products.isActive, true))
+    .limit(50)
+  if (rows.length === 0) return { checked: 0, drifted: 0, failed: false }
+
+  const byLookupKey = new Map<string, Stripe.Price>()
+  try {
+    const stripe = getStripe()
+    for (let i = 0; i < rows.length; i += LOOKUP_KEYS_PER_CALL) {
+      const { data } = await stripe.prices.list(
+        {
+          lookup_keys: rows
+            .slice(i, i + LOOKUP_KEYS_PER_CALL)
+            .map((r) => r.lookupKey),
+          active: true,
+          limit: LOOKUP_KEYS_PER_CALL,
+        },
+        // Mêmes bornes qu'au checkout : le SDK attend 80 s et réessaie 2 fois par
+        // défaut, contre un `--max-time 60` côté appelant.
+        { timeout: 8000, maxNetworkRetries: 1 },
+      )
+      for (const price of data) {
+        if (price.lookup_key) byLookupKey.set(price.lookup_key, price)
+      }
+    }
+  } catch (error) {
+    captureServerError("[cron:price-drift]", error, {
+      detail: `lecture des prix Stripe impossible (${rows.length} produits non audités)`,
+    })
+    return { checked: 0, drifted: 0, failed: true }
+  }
+
+  let drifted = 0
+  for (const row of rows) {
+    const price = byLookupKey.get(row.lookupKey)
+    if (!price) {
+      drifted++
+      captureServerError(
+        "[cron:price-drift]",
+        new Error("aucun prix actif pour cette lookup_key"),
+        { detail: `produit ${row.code} · lookup_key ${row.lookupKey}` },
+      )
+      continue
+    }
+    const drift = describePriceDrift(row.priceCad, price)
+    if (drift) {
+      drifted++
+      captureServerError(
+        "[cron:price-drift]",
+        new Error(
+          drift.currencyMismatch
+            ? "devise du prix Stripe inattendue"
+            : "prix affiché divergent du prix Stripe",
+        ),
+        { detail: `produit ${row.code} · ${drift.message}` },
+      )
+    }
+  }
+
+  return { checked: rows.length, drifted, failed: false }
+}

--- a/features/payments/cron.ts
+++ b/features/payments/cron.ts
@@ -57,7 +57,13 @@ export async function auditProductPriceDrift(): Promise<PriceDriftResult> {
             .slice(i, i + LOOKUP_KEYS_PER_CALL)
             .map((r) => r.lookupKey),
           active: true,
-          limit: LOOKUP_KEYS_PER_CALL,
+          // PAS `LOOKUP_KEYS_PER_CALL` : une clé peut porter plusieurs prix
+          // actifs (`resolveStripePrice` prévoit ce cas), donc la réponse peut
+          // compter plus de lignes que de clés demandées. Un `limit` égal au
+          // nombre de clés tronquerait alors la liste, et les clés absentes du
+          // tronçon seraient signalées à tort comme « aucun prix actif ». 100 est
+          // le maximum accepté par l'API.
+          limit: 100,
         },
         // Mêmes bornes qu'au checkout : le SDK attend 80 s et réessaie 2 fois par
         // défaut, contre un `--max-time 60` côté appelant.

--- a/features/payments/dal.ts
+++ b/features/payments/dal.ts
@@ -113,8 +113,6 @@ export type ProductView = {
   durationDays: number
   accessType: "exam" | "training"
   isCombo: boolean
-  stripeProductId: string
-  stripePriceId: string
 }
 
 /**
@@ -133,8 +131,6 @@ export const getAvailableProducts = cache(async (): Promise<ProductView[]> => {
       durationDays: products.durationDays,
       accessType: products.accessType,
       isCombo: products.isCombo,
-      stripeProductId: products.stripeProductId,
-      stripePriceId: products.stripePriceId,
     })
     .from(products)
     .where(eq(products.isActive, true))

--- a/features/payments/stripe.ts
+++ b/features/payments/stripe.ts
@@ -44,8 +44,12 @@ const CURRENCY_BY_STRIPE = new Map<string, "CAD" | "XAF">([
  * et répond 200 (pas de retry utile).
  *
  * `amountTotal`/`currency` (session Checkout) écrasent les valeurs provisoires du
- * pending (prix catalogue CAD) : codes promo et Adaptive Pricing (XAF) rendent le
- * montant réellement facturé différent. Valeurs inexploitables (`amount_total`
+ * pending (prix catalogue CAD) : seuls les CODES PROMO font effectivement diverger
+ * le montant facturé du prix catalogue. Adaptive Pricing, lui, ne change ni la
+ * devise ni le montant de la session — le montant local vit dans
+ * `presentment_details`, persisté à part. La conversion XAF ×100 ci-dessous reste
+ * correcte (le XAF est zéro-décimal chez Stripe) mais n'est atteinte que si un
+ * prix est RÉELLEMENT libellé en XAF. Valeurs inexploitables (`amount_total`
  * null, devise hors enum) → on conserve le provisoire et on logue — un paiement
  * valide ne doit jamais échouer pour un problème de réconciliation.
  */

--- a/features/payments/stripe.ts
+++ b/features/payments/stripe.ts
@@ -55,6 +55,8 @@ export async function completeStripeTransaction(params: {
   stripeEventId: string
   amountTotal?: number | null
   currency?: string | null
+  presentmentAmount?: number | null
+  presentmentCurrency?: string | null
 }): Promise<CompleteStripeResult> {
   return db.transaction(async (tx) => {
     // Transaction pending (pour obtenir l'userId à verrouiller).
@@ -145,6 +147,19 @@ export async function completeStripeTransaction(params: {
       )
     }
 
+    // Adaptive Pricing : présent UNIQUEMENT si le client a payé dans sa devise
+    // locale. Absent pour un client canadien — les colonnes restent nulles, et
+    // c'est ce qui rend la proportion de conversions mesurable. Ne jamais faire
+    // échouer un paiement valide sur de la traçabilité : valeurs partielles
+    // ⇒ on n'écrit rien.
+    const presentment =
+      params.presentmentAmount != null && params.presentmentCurrency
+        ? {
+            presentmentAmount: params.presentmentAmount,
+            presentmentCurrency: params.presentmentCurrency.toUpperCase(),
+          }
+        : null
+
     await tx
       .update(transactions)
       .set({
@@ -154,6 +169,7 @@ export async function completeStripeTransaction(params: {
         accessExpiresAt: txAccessExpiresAt,
         completedAt: now,
         ...(reconcile ?? {}),
+        ...(presentment ?? {}),
       })
       .where(eq(transactions.id, pending.id))
 

--- a/features/users/dal.ts
+++ b/features/users/dal.ts
@@ -589,6 +589,9 @@ export type PanelTransaction = {
   status: (typeof transactions.status.enumValues)[number]
   amountPaid: number
   currency: "CAD" | "XAF"
+  /** Unité mineure de `presentmentCurrency`. Nul hors Adaptive Pricing. */
+  presentmentAmount: number | null
+  presentmentCurrency: string | null
   /** Epoch ms. */
   createdAt: number
   product: { name: string } | null
@@ -641,6 +644,8 @@ export const getUserPanelData = async (
         status: transactions.status,
         amountPaid: transactions.amountPaid,
         currency: transactions.currency,
+        presentmentAmount: transactions.presentmentAmount,
+        presentmentCurrency: transactions.presentmentCurrency,
         createdAt: transactions.createdAt,
         productName: products.name,
       })
@@ -672,6 +677,8 @@ export const getUserPanelData = async (
       status: r.status,
       amountPaid: r.amountPaid,
       currency: r.currency,
+      presentmentAmount: r.presentmentAmount,
+      presentmentCurrency: r.presentmentCurrency,
       createdAt: r.createdAt.getTime(),
       product: r.productName ? { name: r.productName } : null,
     })),

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -55,6 +55,34 @@ export const formatCurrency = (
 }
 
 /**
+ * Montant présenté au client par Adaptive Pricing, dans SA devise.
+ *
+ * Ne pas confondre avec `formatCurrency`, qui divise toujours par 100 parce que
+ * l'app stocke ses montants en centièmes. Ici la devise est arbitraire (plus de
+ * 150 pays) et peut être zéro-décimal — XAF, JPY : l'unité mineure y EST
+ * l'unité. Le facteur se dérive d'`Intl` plutôt que d'une liste de devises
+ * zéro-décimal écrite en dur, qui vieillirait sans que rien ne le signale.
+ */
+export const formatPresentmentAmount = (
+  minorUnits: number,
+  currency: string,
+): string => {
+  const code = currency.toUpperCase()
+  try {
+    const formatter = new Intl.NumberFormat("fr-CA", {
+      style: "currency",
+      currency: code,
+    })
+    const digits = formatter.resolvedOptions().maximumFractionDigits ?? 2
+    return formatter.format(minorUnits / 10 ** digits)
+  } catch {
+    // Intl lève un RangeError sur un code non conforme : mieux vaut un affichage
+    // brut qu'un panneau admin qui plante sur une devise exotique.
+    return `${minorUnits} ${code}`
+  }
+}
+
+/**
  * Formate un timestamp en date lisible
  */
 export const formatExpiration = (timestamp: number): string => {

--- a/scripts/audit-stripe-transactions.ts
+++ b/scripts/audit-stripe-transactions.ts
@@ -1,8 +1,10 @@
 /**
  * Audit LECTURE SEULE des transactions Stripe historiques. Compare
  * `amountPaid`/`currency` en base avec `amount_total`/`currency` des sessions
- * Checkout réelles — les codes promo et l'Adaptive Pricing XAF sont les deux
- * sources de divergence. AUCUNE écriture : selects + GET Stripe.
+ * Checkout réelles. Source de divergence attendue : les CODES PROMO. Adaptive
+ * Pricing n'en est PAS une — il laisse la session dans la devise d'intégration
+ * (le montant local vit dans `presentment_details`). AUCUNE écriture : selects
+ * + GET Stripe.
  *
  * Usage :
  *   AUDIT_DATABASE_URL=... STRIPE_AUDIT_KEY=rk_live_... bun scripts/audit-stripe-transactions.ts

--- a/tests/components/payments/PricingGrid.test.tsx
+++ b/tests/components/payments/PricingGrid.test.tsx
@@ -50,8 +50,6 @@ const products = [
     durationDays: 30,
     accessType: "exam" as const,
     isCombo: false,
-    stripeProductId: "prod_test",
-    stripePriceId: "price_test",
   },
 ]
 

--- a/tests/db/RetryPool.test.ts
+++ b/tests/db/RetryPool.test.ts
@@ -1,0 +1,95 @@
+import { Pool } from "pg"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NeonRetryPool, isNeonWakeupError } from "@/db/retry-pool"
+
+const pgError = (code: string) =>
+  Object.assign(new Error(`pg ${code}`), { code })
+
+// Client minimal : seule `release` est consommée par pg-pool/drizzle.
+const fakeClient = () => ({ release: vi.fn() }) as never
+
+const makePool = () =>
+  new NeonRetryPool(
+    { connectionString: "postgres://test@localhost/test" },
+    { backoffsMs: [0, 0] },
+  )
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("isNeonWakeupError", () => {
+  it("reconnaît 53300 et 57P03, refuse le reste", () => {
+    expect(isNeonWakeupError(pgError("53300"))).toBe(true)
+    expect(isNeonWakeupError(pgError("57P03"))).toBe(true)
+    expect(isNeonWakeupError(pgError("28P01"))).toBe(false)
+    expect(isNeonWakeupError(new Error("timeout exceeded"))).toBe(false)
+    expect(isNeonWakeupError(null)).toBe(false)
+  })
+})
+
+describe("NeonRetryPool", () => {
+  it("réussit au 3e essai quand Neon refuse deux permits", async () => {
+    const client = fakeClient()
+    const spy = vi
+      .spyOn(Pool.prototype, "connect")
+      .mockRejectedValueOnce(pgError("53300"))
+      .mockRejectedValueOnce(pgError("53300"))
+      .mockResolvedValueOnce(client)
+
+    await expect(makePool().connect()).resolves.toBe(client)
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  it("abandonne après épuisement des retries", async () => {
+    const spy = vi
+      .spyOn(Pool.prototype, "connect")
+      .mockRejectedValue(pgError("53300"))
+
+    await expect(makePool().connect()).rejects.toMatchObject({ code: "53300" })
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  it("ne retente pas une erreur étrangère au réveil", async () => {
+    const spy = vi
+      .spyOn(Pool.prototype, "connect")
+      .mockRejectedValue(pgError("28P01"))
+
+    await expect(makePool().connect()).rejects.toMatchObject({ code: "28P01" })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it("retente aussi 57P03 (database system is starting up)", async () => {
+    const client = fakeClient()
+    vi.spyOn(Pool.prototype, "connect")
+      .mockRejectedValueOnce(pgError("57P03"))
+      .mockResolvedValueOnce(client)
+
+    await expect(makePool().connect()).resolves.toBe(client)
+  })
+
+  it("préserve le contrat callback de pg-pool après un retry", async () => {
+    const client: { release: ReturnType<typeof vi.fn> } = { release: vi.fn() }
+    vi.spyOn(Pool.prototype, "connect")
+      .mockRejectedValueOnce(pgError("53300"))
+      .mockResolvedValueOnce(client as never)
+
+    const cb = vi.fn()
+    makePool().connect(cb)
+
+    await vi.waitFor(() =>
+      expect(cb).toHaveBeenCalledWith(undefined, client, client.release),
+    )
+  })
+
+  it("propage l'échec à la forme callback", async () => {
+    vi.spyOn(Pool.prototype, "connect").mockRejectedValue(pgError("53300"))
+
+    const cb = vi.fn()
+    makePool().connect(cb)
+
+    await vi.waitFor(() =>
+      expect(cb).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "53300" }),
+      ),
+    )
+  })
+})

--- a/tests/features/cron-close-expired.test.ts
+++ b/tests/features/cron-close-expired.test.ts
@@ -15,6 +15,11 @@ const { mocks } = vi.hoisted(() => ({
       anonymizedCount: 0,
     })),
     cleanupQuizRateLimits: vi.fn(async () => ({ deletedCount: 0 })),
+    auditProductPriceDrift: vi.fn(async () => ({
+      checked: 0,
+      drifted: 0,
+      failed: false,
+    })),
     sendPendingNotifications: vi.fn(async () => ({
       examResultsSent: 0,
       accessRemindersSent: 0,
@@ -33,6 +38,9 @@ vi.mock("@/features/users/cron", () => ({
 }))
 vi.mock("@/features/notifications/cron", () => ({
   sendPendingNotifications: mocks.sendPendingNotifications,
+}))
+vi.mock("@/features/payments/cron", () => ({
+  auditProductPriceDrift: mocks.auditProductPriceDrift,
 }))
 vi.mock("@/lib/quiz-rate-limit", () => ({
   cleanupQuizRateLimits: mocks.cleanupQuizRateLimits,
@@ -94,7 +102,21 @@ describe("execution des taches", () => {
       anonymizedAccounts: { anonymizedCount: 0 },
       notifications: { examResultsSent: 3, accessRemindersSent: 1 },
       quizRateLimitCleanup: { deletedCount: 0 },
+      priceDrift: { checked: 0, drifted: 0, failed: false },
     })
+  })
+
+  // La tache est ecrite pour ne jamais lever, mais le dispatcher doit rester la
+  // ceinture de securite si un jour elle le fait.
+  it("echec de l'audit de prix → les autres taches tournent quand meme", async () => {
+    mocks.auditProductPriceDrift.mockRejectedValueOnce(new Error("Stripe down"))
+
+    const res = await call("Bearer s3cret")
+
+    expect(res.status).toBe(500)
+    expect(mocks.anonymizeExpiredDeletedAccounts).toHaveBeenCalled()
+    expect(mocks.sendPendingNotifications).toHaveBeenCalled()
+    expect(mocks.captureServerError).toHaveBeenCalled()
   })
 
   // Les notifications doivent voir les `auto_submitted` du meme run.

--- a/tests/features/payments-actions.test.ts
+++ b/tests/features/payments-actions.test.ts
@@ -110,6 +110,7 @@ vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }))
 const ACTIVE_PRODUCT = {
   id: "p1",
   stripePriceId: "price_1",
+  stripePriceLookupKey: "price_1",
   priceCad: 5000,
   accessType: "exam",
   durationDays: 90,

--- a/tests/features/payments-actions.test.ts
+++ b/tests/features/payments-actions.test.ts
@@ -31,6 +31,12 @@ const { mocks } = vi.hoisted(() => ({
           cancel_url: string
         }) => Promise<{ id: string; url: string | null }>
       >(),
+    pricesList:
+      vi.fn<
+        () => Promise<{
+          data: { id: string; unit_amount: number | null; currency: string }[]
+        }>
+      >(),
     customersList: vi.fn<() => Promise<{ data: { id: string }[] }>>(),
     portalCreate:
       vi.fn<(arg: { return_url: string }) => Promise<{ url: string }>>(),
@@ -103,6 +109,7 @@ vi.mock("@/lib/stripe", () => ({
     checkout: { sessions: { create: mocks.checkoutCreate } },
     customers: { list: mocks.customersList },
     billingPortal: { sessions: { create: mocks.portalCreate } },
+    prices: { list: mocks.pricesList },
   }),
 }))
 vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }))
@@ -110,7 +117,7 @@ vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }))
 const ACTIVE_PRODUCT = {
   id: "p1",
   stripePriceId: "price_1",
-  stripePriceLookupKey: "price_1",
+  stripePriceLookupKey: "exam_access",
   priceCad: 5000,
   accessType: "exam",
   durationDays: 90,
@@ -138,6 +145,9 @@ const rejectWith = (message: string) =>
 
 beforeEach(() => {
   mocks.productRows.current = [ACTIVE_PRODUCT]
+  mocks.pricesList.mockResolvedValue({
+    data: [{ id: "price_resolved", unit_amount: 5000, currency: "cad" }],
+  })
 })
 
 describe("recordManualPayment", () => {
@@ -284,6 +294,85 @@ describe("createStripeCheckout", () => {
     const res = await createStripeCheckout(input)
     expect(res).toEqual({ error: "Ce produit n'est plus disponible" })
     expect(mocks.checkoutCreate).not.toHaveBeenCalled()
+  })
+
+  it("facture le prix resolu par lookup_key, pas un identifiant stocke", async () => {
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+    await createStripeCheckout(input)
+
+    expect(mocks.pricesList).toHaveBeenCalledWith(
+      { lookup_keys: ["exam_access"], active: true, limit: 2 },
+      { timeout: 8000, maxNetworkRetries: 1 },
+    )
+    const arg = mocks.checkoutCreate.mock.calls[0]![0] as unknown as {
+      line_items: { price: string }[]
+    }
+    expect(arg.line_items[0].price).toBe("price_resolved")
+  })
+
+  // Phase 1 : la lookup_key n'est pas encore eprouvee en production, le pointeur
+  // historique l'est. Une cle qui ne resout rien alerte mais ne coupe pas la vente.
+  it("lookup_key sans prix actif → repli sur stripe_price_id, vente conservee", async () => {
+    mocks.pricesList.mockResolvedValue({ data: [] })
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/pay" })
+    const arg = mocks.checkoutCreate.mock.calls[0]![0] as unknown as {
+      line_items: { price: string }[]
+    }
+    expect(arg.line_items[0].price).toBe("price_1")
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  // Un montant diverge legalement le temps qu'un changement de tarif Stripe soit
+  // repercute en base : alerter suffit, couper les ventes couterait plus cher.
+  it("montant Stripe divergent → alerte mais la vente aboutit", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [{ id: "price_resolved", unit_amount: 9900, currency: "cad" }],
+    })
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/pay" })
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  // La devise d'un prix Stripe est immuable : un ecart de devise n'est jamais un
+  // etat transitoire legitime, c'est une cle qui pointe sur le mauvais prix.
+  it("devise Stripe ≠ cad → refus, aucune session ni pending", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [{ id: "price_resolved", unit_amount: 5000, currency: "usd" }],
+    })
+
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({
+      error: "Ce produit est mal configuré. Contactez le support.",
+    })
+    expect(mocks.checkoutCreate).not.toHaveBeenCalled()
+    expect(mocks.insertValues).not.toHaveBeenCalled()
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  it("prix Stripe conforme → aucune alerte", async () => {
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+    await createStripeCheckout(input)
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
   })
 
   it("session Stripe sans url → erreur, aucun pending insere", async () => {

--- a/tests/features/payments-actions.test.ts
+++ b/tests/features/payments-actions.test.ts
@@ -31,12 +31,11 @@ const { mocks } = vi.hoisted(() => ({
           cancel_url: string
         }) => Promise<{ id: string; url: string | null }>
       >(),
-    pricesList:
-      vi.fn<
-        () => Promise<{
-          data: { id: string; unit_amount: number | null; currency: string }[]
-        }>
-      >(),
+    pricesList: vi.fn<
+      () => Promise<{
+        data: { id: string; unit_amount: number | null; currency: string }[]
+      }>
+    >(),
     customersList: vi.fn<() => Promise<{ data: { id: string }[] }>>(),
     portalCreate:
       vi.fn<(arg: { return_url: string }) => Promise<{ url: string }>>(),

--- a/tests/features/payments-actions.test.ts
+++ b/tests/features/payments-actions.test.ts
@@ -331,6 +331,30 @@ describe("createStripeCheckout", () => {
     expect(mocks.captureServerError).toHaveBeenCalled()
   })
 
+  // Le repli doit couvrir l'ECHEC de l'appel autant que la cle absente : sans ca,
+  // une cle restreinte sans `prices:read` (ou un 429) renverrait « Reessayez »
+  // pour une panne permanente, au lieu de vendre via le pointeur historique.
+  it("resolution en echec (permission, 429) → repli sur stripe_price_id, vente conservee", async () => {
+    mocks.pricesList.mockRejectedValue(
+      Object.assign(new Error("permission denied"), {
+        code: "more_permissions_required",
+      }),
+    )
+    mocks.checkoutCreate.mockResolvedValueOnce({
+      id: "cs_1",
+      url: "https://stripe.test/pay",
+    })
+
+    const res = await createStripeCheckout(input)
+
+    expect(res).toEqual({ checkoutUrl: "https://stripe.test/pay" })
+    const arg = mocks.checkoutCreate.mock.calls[0]![0] as unknown as {
+      line_items: { price: string }[]
+    }
+    expect(arg.line_items[0].price).toBe("price_1")
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
   // Un montant diverge legalement le temps qu'un changement de tarif Stripe soit
   // repercute en base : alerter suffit, couper les ventes couterait plus cher.
   it("montant Stripe divergent → alerte mais la vente aboutit", async () => {

--- a/tests/features/payments-catalog.test.ts
+++ b/tests/features/payments-catalog.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  describePriceDrift,
+  resolveStripePrice,
+} from "@/features/payments/catalog"
+
+// `describePriceDrift` est pur : c'est lui qui decide si le prix affiche en base
+// et le prix que Stripe facturera racontent la meme chose. Chaque cas est ecrit
+// par paire — une version qui concorde, une version qui diverge — sinon rien ne
+// prouve que la comparaison mord reellement.
+const PRICE = {
+  id: "price_1",
+  unit_amount: 5000,
+  currency: "cad",
+} as const
+
+describe("describePriceDrift", () => {
+  it("montant et devise concordants → aucune derive", () => {
+    expect(describePriceDrift(5000, PRICE)).toBeNull()
+  })
+
+  // Un montant diverge legalement : `transfer_lookup_key` deplace la cle sur un
+  // nouveau prix quand le tarif change. On alerte, on ne bloque pas.
+  it("montant divergent → derive NON bloquante, decrite avec les deux valeurs", () => {
+    const drift = describePriceDrift(3000, PRICE)
+    expect(drift?.currencyMismatch).toBe(false)
+    expect(drift?.message).toContain("5000")
+    expect(drift?.message).toContain("3000")
+  })
+
+  // La devise d'un prix Stripe est immuable : elle ne peut pas avoir « change ».
+  // Une devise ≠ cad signifie que la cle pointe sur le mauvais prix.
+  it("devise du prix Stripe ≠ cad → derive bloquante", () => {
+    const drift = describePriceDrift(5000, { ...PRICE, currency: "usd" })
+    expect(drift?.currencyMismatch).toBe(true)
+    expect(drift?.message).toContain("usd")
+  })
+
+  it("unit_amount null (prix a montant libre) → derive non bloquante", () => {
+    const drift = describePriceDrift(5000, { ...PRICE, unit_amount: null })
+    expect(drift).not.toBeNull()
+    expect(drift?.currencyMismatch).toBe(false)
+  })
+})
+
+describe("resolveStripePrice", () => {
+  it("interroge Stripe sur la cle, en prix actifs seulement, requete bornee", async () => {
+    const list = vi.fn(async () => ({ data: [PRICE] }))
+    const stripe = { prices: { list } } as never
+
+    const price = await resolveStripePrice(stripe, "exam_access")
+
+    expect(price).toEqual(PRICE)
+    expect(list).toHaveBeenCalledWith(
+      { lookup_keys: ["exam_access"], active: true, limit: 2 },
+      { timeout: 8000, maxNetworkRetries: 1 },
+    )
+  })
+
+  it("aucun prix actif pour la cle → null (et non une exception)", async () => {
+    const stripe = { prices: { list: async () => ({ data: [] }) } } as never
+    expect(await resolveStripePrice(stripe, "inconnu")).toBeNull()
+  })
+
+  // `limit: 2` n'a d'interet que si quelqu'un lit le second element : sans ca,
+  // une cle portee par deux prix actifs se reglerait au hasard, en silence.
+  it("deux prix actifs pour la meme cle → anomalie signalee", async () => {
+    const onAmbiguous = vi.fn()
+    const stripe = {
+      prices: {
+        list: async () => ({ data: [PRICE, { ...PRICE, id: "price_2" }] }),
+      },
+    } as never
+
+    const price = await resolveStripePrice(stripe, "exam_access", onAmbiguous)
+
+    expect(price).toEqual(PRICE)
+    expect(onAmbiguous).toHaveBeenCalledWith("exam_access", 2)
+  })
+})

--- a/tests/features/payments-cron.test.ts
+++ b/tests/features/payments-cron.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { auditProductPriceDrift } from "@/features/payments/cron"
+
+// La verification au checkout ne voit que les produits qu'on achete. Cette tache
+// couvre ceux qui dorment — un produit peu demande peut deriver des semaines.
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    captureServerError: vi.fn(),
+    productRows: { current: [] as unknown[] },
+    pricesList:
+      vi.fn<
+        () => Promise<{
+          data: {
+            id: string
+            lookup_key: string | null
+            unit_amount: number | null
+            currency: string
+          }[]
+        }>
+      >(),
+    env: { STRIPE_SECRET_KEY: "sk_test_x" as string | undefined },
+  },
+}))
+
+const selectChain = () => {
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    limit: async () => mocks.productRows.current,
+  }
+  return chain
+}
+
+vi.mock("@/db", () => ({ db: { select: () => selectChain() } }))
+vi.mock("@/db/schema", () => ({
+  products: { code: {}, priceCad: {}, stripePriceLookupKey: {}, isActive: {} },
+}))
+vi.mock("@/lib/env/server", () => ({ env: mocks.env }))
+vi.mock("@/lib/observability", () => ({
+  captureServerError: mocks.captureServerError,
+}))
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({ prices: { list: mocks.pricesList } }),
+}))
+
+// Les cles sont celles de l'ALIAS du `select` Drizzle (`lookupKey`), pas les noms
+// de colonnes : c'est ce que la vraie requete retourne.
+const PRODUCT = {
+  code: "exam_access",
+  priceCad: 5000,
+  lookupKey: "exam_access",
+}
+
+beforeEach(() => {
+  mocks.env.STRIPE_SECRET_KEY = "sk_test_x"
+  mocks.productRows.current = [PRODUCT]
+  vi.spyOn(console, "error").mockImplementation(() => {})
+})
+
+describe("auditProductPriceDrift", () => {
+  it("prix conforme → aucune alerte", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [
+        {
+          id: "price_1",
+          lookup_key: "exam_access",
+          unit_amount: 5000,
+          currency: "cad",
+        },
+      ],
+    })
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 1, drifted: 0, failed: false })
+    expect(mocks.captureServerError).not.toHaveBeenCalled()
+  })
+
+  it("prix divergent → une alerte, le produit est compte comme derive", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [
+        {
+          id: "price_1",
+          lookup_key: "exam_access",
+          unit_amount: 9900,
+          currency: "cad",
+        },
+      ],
+    })
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 1, drifted: 1, failed: false })
+    expect(mocks.captureServerError).toHaveBeenCalledTimes(1)
+  })
+
+  it("lookup_key sans prix actif → alerte dediee", async () => {
+    mocks.pricesList.mockResolvedValue({ data: [] })
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 1, drifted: 1, failed: false })
+    expect(mocks.captureServerError).toHaveBeenCalledTimes(1)
+  })
+
+  // `lookup_keys` accepte 10 cles par requete : au-dela, une seule liste
+  // tronquerait en silence et les produits surnumeraires passeraient pour
+  // « sans prix actif ».
+  it("plus de 10 produits → decoupage en plusieurs appels", async () => {
+    mocks.productRows.current = Array.from({ length: 12 }, (_, i) => ({
+      code: `p${i}`,
+      priceCad: 5000,
+      lookupKey: `key_${i}`,
+    }))
+    mocks.pricesList.mockImplementation(async () => ({
+      data: mocks.productRows.current.map((r) => {
+        const row = r as { lookupKey: string }
+        return {
+          id: `price_${row.lookupKey}`,
+          lookup_key: row.lookupKey,
+          unit_amount: 5000,
+          currency: "cad",
+        }
+      }),
+    }))
+
+    const res = await auditProductPriceDrift()
+
+    expect(mocks.pricesList).toHaveBeenCalledTimes(2)
+    expect(res).toEqual({ checked: 12, drifted: 0, failed: false })
+  })
+
+  it("Stripe non configure → tache neutre, aucun appel", async () => {
+    mocks.env.STRIPE_SECRET_KEY = undefined
+    const res = await auditProductPriceDrift()
+    expect(res).toEqual({ checked: 0, drifted: 0, failed: false })
+    expect(mocks.pricesList).not.toHaveBeenCalled()
+  })
+
+  // Invariant capital : un audit informatif ne doit JAMAIS faire repondre 500 au
+  // cron. L'appelant GitHub Actions relance sur erreur — une panne Stripe
+  // rejouerait clotures et notifications jusqu'a 4 fois par heure.
+  it("Stripe en panne → echec signale, aucune exception propagee", async () => {
+    mocks.pricesList.mockRejectedValue(new Error("Stripe down"))
+
+    const res = await auditProductPriceDrift()
+
+    expect(res).toEqual({ checked: 0, drifted: 0, failed: true })
+    expect(mocks.captureServerError).toHaveBeenCalled()
+  })
+
+  it("borne la requete Stripe (le SDK attend 80 s et reessaie 2 fois par defaut)", async () => {
+    mocks.pricesList.mockResolvedValue({
+      data: [
+        {
+          id: "price_1",
+          lookup_key: "exam_access",
+          unit_amount: 5000,
+          currency: "cad",
+        },
+      ],
+    })
+
+    await auditProductPriceDrift()
+
+    expect(mocks.pricesList).toHaveBeenCalledWith(expect.anything(), {
+      timeout: 8000,
+      maxNetworkRetries: 1,
+    })
+  })
+})

--- a/tests/features/payments-cron.test.ts
+++ b/tests/features/payments-cron.test.ts
@@ -7,17 +7,16 @@ const { mocks } = vi.hoisted(() => ({
   mocks: {
     captureServerError: vi.fn(),
     productRows: { current: [] as unknown[] },
-    pricesList:
-      vi.fn<
-        () => Promise<{
-          data: {
-            id: string
-            lookup_key: string | null
-            unit_amount: number | null
-            currency: string
-          }[]
-        }>
-      >(),
+    pricesList: vi.fn<
+      () => Promise<{
+        data: {
+          id: string
+          lookup_key: string | null
+          unit_amount: number | null
+          currency: string
+        }[]
+      }>
+    >(),
     env: { STRIPE_SECRET_KEY: "sk_test_x" as string | undefined },
   },
 }))

--- a/tests/features/stripe-webhook-errors.test.ts
+++ b/tests/features/stripe-webhook-errors.test.ts
@@ -151,6 +151,39 @@ describe("webhook Stripe — contrat HTTP", () => {
     })
   })
 
+  // Adaptive Pricing : sans ce test, rien ne verifie que la route transmet le
+  // hash au fulfillment. L'assertion voisine ne l'attrape pas — `toEqual` ignore
+  // les proprietes `undefined`, donc elle passe que le cablage existe ou non.
+  it("presentment_details → transmis au fulfillment", async () => {
+    mocks.constructEventAsync.mockResolvedValueOnce({
+      id: "evt_present",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_present",
+          payment_status: "paid",
+          payment_intent: "pi_present",
+          amount_total: 5000,
+          currency: "cad",
+          presentment_details: {
+            presentment_amount: 2280000,
+            presentment_currency: "xaf",
+          },
+        },
+      },
+    })
+
+    const res = await POST(request())
+
+    expect(res.status).toBe(200)
+    expect(mocks.completeStripeTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presentmentAmount: 2280000,
+        presentmentCurrency: "xaf",
+      }),
+    )
+  })
+
   it("async_payment_failed → failStripeTransaction, 200", async () => {
     mocks.constructEventAsync.mockResolvedValueOnce({
       id: "evt_async_ko",

--- a/tests/integration/admin-dashboard-dal.test.ts
+++ b/tests/integration/admin-dashboard-dal.test.ts
@@ -108,6 +108,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
   await db.insert(exams).values({
     id: E,

--- a/tests/integration/dashboard-dal.test.ts
+++ b/tests/integration/dashboard-dal.test.ts
@@ -65,6 +65,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
   const txId = createId()
   await db.insert(transactions).values({

--- a/tests/integration/exam-audience.test.ts
+++ b/tests/integration/exam-audience.test.ts
@@ -138,6 +138,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_aud_${suffix}`,
     stripePriceId: `price_aud_${suffix}`,
+    stripePriceLookupKey: `price_aud_${suffix}`,
   })
   // outsider + subscriber ont un abonnement examen actif ; member/member2/nosub n'en ont pas.
   await grantExamAccess(OUTSIDER_ID)

--- a/tests/integration/exam-runner.test.ts
+++ b/tests/integration/exam-runner.test.ts
@@ -71,6 +71,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_er_${suffix}`,
     stripePriceId: `price_er_${suffix}`,
+    stripePriceLookupKey: `price_er_${suffix}`,
   })
   const txId = createId()
   await db.insert(transactions).values({

--- a/tests/integration/exams.test.ts
+++ b/tests/integration/exams.test.ts
@@ -136,6 +136,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
   await grantExamAccess(STUDENT_ID)
   await grantExamAccess(INTRUDER_ID)

--- a/tests/integration/notifications-cron.test.ts
+++ b/tests/integration/notifications-cron.test.ts
@@ -166,6 +166,7 @@ describe("sendAccessExpiryReminders", () => {
       accessType: "exam",
       stripeProductId: `prod_${pid}`,
       stripePriceId: `price_${pid}`,
+      stripePriceLookupKey: `price_${pid}`,
     })
     await db.insert(transactions).values({
       id: tid,
@@ -233,6 +234,7 @@ describe("reset du marqueur de rappel au renouvellement", () => {
       accessType: "exam",
       stripeProductId: `prod_${pid}`,
       stripePriceId: `price_${pid}`,
+      stripePriceLookupKey: `price_${pid}`,
     })
     // Transaction initiale + accès existant DÉJÀ notifié (marqueur posé).
     await db.insert(transactions).values({
@@ -309,6 +311,7 @@ describe("reset du marqueur de rappel au renouvellement", () => {
       accessType: "exam",
       stripeProductId: `prod_${pid}`,
       stripePriceId: `price_${pid}`,
+      stripePriceLookupKey: `price_${pid}`,
     })
     // Transaction initiale (FK de l'accès existant) + accès DÉJÀ notifié.
     await db.insert(transactions).values({
@@ -383,6 +386,7 @@ describe("reset du marqueur de rappel au renouvellement", () => {
       isCombo: true,
       stripeProductId: `prod_${pid}`,
       stripePriceId: `price_${pid}`,
+      stripePriceLookupKey: `price_${pid}`,
     })
     await db.insert(transactions).values([
       {

--- a/tests/integration/passation-anti-cheat.test.ts
+++ b/tests/integration/passation-anti-cheat.test.ts
@@ -96,6 +96,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_ac_${suffix}`,
     stripePriceId: `price_ac_${suffix}`,
+    stripePriceLookupKey: `price_ac_${suffix}`,
   })
   const txId = createId()
   await db.insert(transactions).values({

--- a/tests/integration/payments-actions.test.ts
+++ b/tests/integration/payments-actions.test.ts
@@ -88,6 +88,7 @@ beforeAll(async () => {
     isCombo: true,
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
   mocks.adminId.current = ADMIN_ID
 })

--- a/tests/integration/payments-admin-dal.test.ts
+++ b/tests/integration/payments-admin-dal.test.ts
@@ -85,6 +85,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
 
   const now = Date.now()

--- a/tests/integration/payments-checkout.test.ts
+++ b/tests/integration/payments-checkout.test.ts
@@ -14,14 +14,13 @@ const { mocks } = vi.hoisted(() => ({
           metadata: { userId: string }
         }) => Promise<{ id: string; url: string | null }>
       >(),
-    pricesList:
-      vi.fn<
-        () => Promise<{
-          data: { id: string; unit_amount: number | null; currency: string }[]
-        }>
-      >(async () => ({
-        data: [{ id: "price_resolved", unit_amount: 5000, currency: "cad" }],
-      })),
+    pricesList: vi.fn<
+      () => Promise<{
+        data: { id: string; unit_amount: number | null; currency: string }[]
+      }>
+    >(async () => ({
+      data: [{ id: "price_resolved", unit_amount: 5000, currency: "cad" }],
+    })),
   },
 }))
 

--- a/tests/integration/payments-checkout.test.ts
+++ b/tests/integration/payments-checkout.test.ts
@@ -14,6 +14,14 @@ const { mocks } = vi.hoisted(() => ({
           metadata: { userId: string }
         }) => Promise<{ id: string; url: string | null }>
       >(),
+    pricesList:
+      vi.fn<
+        () => Promise<{
+          data: { id: string; unit_amount: number | null; currency: string }[]
+        }>
+      >(async () => ({
+        data: [{ id: "price_resolved", unit_amount: 5000, currency: "cad" }],
+      })),
   },
 }))
 
@@ -28,7 +36,10 @@ vi.mock("@/lib/auth-guards", () => ({
   requireRole: vi.fn(),
 }))
 vi.mock("@/lib/stripe", () => ({
-  getStripe: () => ({ checkout: { sessions: { create: mocks.create } } }),
+  getStripe: () => ({
+    checkout: { sessions: { create: mocks.create } },
+    prices: { list: mocks.pricesList },
+  }),
 }))
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
 
@@ -96,6 +107,37 @@ describe("createStripeCheckout", () => {
     expect(tx.type).toBe("stripe")
     expect(tx.userId).toBe(USER_ID)
     expect(tx.stripeSessionId).toBe(sessionId)
+  })
+
+  // La devise d'un prix Stripe est immuable : un ecart ne peut pas etre un etat
+  // transitoire legitime. C'est le seul cas de refus restant au checkout.
+  it("devise Stripe ≠ cad → aucune transaction pending creee", async () => {
+    mocks.create.mockClear()
+    mocks.pricesList.mockResolvedValueOnce({
+      data: [{ id: "price_resolved", unit_amount: 5000, currency: "usd" }],
+    })
+
+    const before = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_ID))
+
+    const res = await createStripeCheckout({
+      productCode: "exam_access",
+      successPath: "/tableau-de-bord",
+      cancelPath: "/tarifs",
+    })
+
+    expect(res).toEqual({
+      error: "Ce produit est mal configuré. Contactez le support.",
+    })
+    expect(mocks.create).not.toHaveBeenCalled()
+
+    const after = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_ID))
+    expect(after.length).toBe(before.length)
   })
 
   it("refuse un productCode inconnu (pas d'appel Stripe)", async () => {

--- a/tests/integration/payments-checkout.test.ts
+++ b/tests/integration/payments-checkout.test.ts
@@ -53,6 +53,7 @@ beforeAll(async () => {
     isCombo: false,
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
   mocks.sessionUserId.current = USER_ID
 })

--- a/tests/integration/payments-dal.test.ts
+++ b/tests/integration/payments-dal.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: "prod_it",
     stripePriceId: "price_it",
+    stripePriceLookupKey: "price_it",
   })
 
   // 3 transactions complétées au MÊME createdAt → force le tie-break (createdAt, id)

--- a/tests/integration/payments-manual.test.ts
+++ b/tests/integration/payments-manual.test.ts
@@ -84,6 +84,7 @@ beforeAll(async () => {
       accessType: "exam",
       stripeProductId: `prod_exam_${suffix}`,
       stripePriceId: `price_exam_${suffix}`,
+      stripePriceLookupKey: `price_exam_${suffix}`,
     },
     {
       id: pCombo.id,
@@ -96,6 +97,7 @@ beforeAll(async () => {
       isCombo: true,
       stripeProductId: `prod_combo_${suffix}`,
       stripePriceId: `price_combo_${suffix}`,
+      stripePriceLookupKey: `price_combo_${suffix}`,
     },
   ])
   // Accès exam pré-existant à +10 jours (scénario cumul) et +200 jours (comboMax).

--- a/tests/integration/payments-stripe.test.ts
+++ b/tests/integration/payments-stripe.test.ts
@@ -121,6 +121,7 @@ beforeAll(async () => {
       isCombo: false,
       stripeProductId: `prod_e_${suffix}`,
       stripePriceId: `price_e_${suffix}`,
+      stripePriceLookupKey: `price_e_${suffix}`,
     },
     {
       id: PCOMBO,
@@ -133,6 +134,7 @@ beforeAll(async () => {
       isCombo: true,
       stripeProductId: `prod_c_${suffix}`,
       stripePriceId: `price_c_${suffix}`,
+      stripePriceLookupKey: `price_c_${suffix}`,
     },
   ])
 })

--- a/tests/integration/payments-stripe.test.ts
+++ b/tests/integration/payments-stripe.test.ts
@@ -29,7 +29,7 @@ const suffix = createId().slice(0, 8)
 
 const PEXAM = createId() // produit exam non-combo
 const PCOMBO = createId() // produit combo (exam + training)
-const U = Array.from({ length: 11 }, () => createId())
+const U = Array.from({ length: 13 }, () => createId())
 const [
   U_HAPPY,
   U_CUMUL,
@@ -42,6 +42,8 @@ const [
   U_DEGUSD,
   U_PROMO100,
   U_RACE,
+  U_PRESENT,
+  U_NOPRESENT,
 ] = U
 
 const accessOf = (userId: string, accessType: "exam" | "training") =>
@@ -67,6 +69,8 @@ const txStatus = (id: string) =>
       accessExpiresAt: transactions.accessExpiresAt,
       amountPaid: transactions.amountPaid,
       currency: transactions.currency,
+      presentmentAmount: transactions.presentmentAmount,
+      presentmentCurrency: transactions.presentmentCurrency,
     })
     .from(transactions)
     .where(eq(transactions.id, id))
@@ -147,6 +151,65 @@ afterAll(async () => {
 })
 
 describe("completeStripeTransaction", () => {
+  // Adaptive Pricing : le client voit des FCFA, l'evenement arrive en CAD. Le
+  // montant local ne vit que dans `presentment_details` — sans persistance, un
+  // client qui ecrit « j'ai paye 228 000 FCFA » n'est recoupable par personne.
+  it("persiste le montant présenté sans toucher au montant encaissé", async () => {
+    const txId = createId()
+    const sid = `sess_present_${suffix}`
+    await seedPending({
+      id: txId,
+      userId: U_PRESENT,
+      productId: PEXAM,
+      sessionId: sid,
+      accessType: "exam",
+      durationDays: 90,
+    })
+
+    await completeStripeTransaction({
+      stripeSessionId: sid,
+      stripePaymentIntentId: "pi_present",
+      stripeEventId: `evt_present_${suffix}`,
+      amountTotal: 5000,
+      currency: "cad",
+      presentmentAmount: 2280000,
+      presentmentCurrency: "xaf",
+    })
+
+    const tx = await txStatus(txId)
+    expect(tx?.presentmentAmount).toBe(2280000)
+    expect(tx?.presentmentCurrency).toBe("XAF")
+    // Invariant comptable : l'encaissement reste le CAD.
+    expect(tx?.amountPaid).toBe(5000)
+    expect(tx?.currency).toBe("CAD")
+  })
+
+  it("client sans conversion (pas de presentment_details) → colonnes nulles", async () => {
+    const txId = createId()
+    const sid = `sess_nopresent_${suffix}`
+    await seedPending({
+      id: txId,
+      userId: U_NOPRESENT,
+      productId: PEXAM,
+      sessionId: sid,
+      accessType: "exam",
+      durationDays: 90,
+    })
+
+    await completeStripeTransaction({
+      stripeSessionId: sid,
+      stripePaymentIntentId: "pi_nopresent",
+      stripeEventId: `evt_nopresent_${suffix}`,
+      amountTotal: 5000,
+      currency: "cad",
+    })
+
+    const tx = await txStatus(txId)
+    expect(tx?.presentmentAmount).toBeNull()
+    expect(tx?.presentmentCurrency).toBeNull()
+    expect(tx?.amountPaid).toBe(5000)
+  })
+
   it("non-combo : complète la transaction et crédite l'accès (now + durée)", async () => {
     const txId = createId()
     const sid = `sess_happy_${suffix}`

--- a/tests/integration/training.test.ts
+++ b/tests/integration/training.test.ts
@@ -481,6 +481,7 @@ describe("anti-triche : correction training masquée pendant un examen ouvert", 
       accessType: "training",
       stripeProductId: `prod_t_${suffix}`,
       stripePriceId: `price_t_${suffix}`,
+      stripePriceLookupKey: `price_t_${suffix}`,
     })
     await db.insert(transactions).values({
       id: TXID2,

--- a/tests/integration/users-admin-dal.test.ts
+++ b/tests/integration/users-admin-dal.test.ts
@@ -108,6 +108,7 @@ beforeAll(async () => {
     accessType: "exam",
     stripeProductId: `prod_${suffix}`,
     stripePriceId: `price_${suffix}`,
+    stripePriceLookupKey: `price_${suffix}`,
   })
 
   const now = Date.now()

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -18,6 +18,7 @@ import {
   formatLongDateTime,
   formatMediumDate,
   formatPaddedMediumDate,
+  formatPresentmentAmount,
   formatShortDate,
   formatTimeOnly,
   formatTimeRemaining,
@@ -89,6 +90,28 @@ describe("formatCurrency", () => {
     it("gère les montants à zéro", () => {
       expect(normalizeSpaces(formatCurrency(0, "XAF"))).toBe("0 XAF")
     })
+  })
+})
+
+describe("formatPresentmentAmount", () => {
+  // Toute espace Unicode (insecable, fine) est normalisee : Intl varie selon la
+  // version d'ICU, et ce n'est pas ce qu'on teste ici.
+  const flat = (s: string) => s.replace(/\s/g, " ")
+
+  // Le piege : `formatCurrency` divise toujours par 100. Le XAF n'a pas de
+  // sous-unite — 228 000 FCFA s'afficheraient en « 2 280 ».
+  it("devise zéro-décimal : l'unité mineure EST l'unité", () => {
+    const out = flat(formatPresentmentAmount(2280000, "xaf"))
+    expect(out).toContain("2 280 000")
+    expect(out).not.toContain("22 800")
+  })
+
+  it("devise à deux décimales : division par 100", () => {
+    expect(flat(formatPresentmentAmount(5000, "cad"))).toContain("50")
+  })
+
+  it("code de devise inconnu d'Intl → repli lisible, pas d'exception", () => {
+    expect(formatPresentmentAmount(1234, "zz")).toBe("1234 ZZ")
   })
 })
 


### PR DESCRIPTION
Deux campagnes indépendantes, réunies dans une seule PR à la demande : le catalogue
Stripe (#138) et le retry du pool Neon (NOMAQBANQ-1F).

---

## 1. Catalogue Stripe par `lookup_key` — closes #138

### Le problème

`price_…` et `prod_…` portent des **préfixes identiques en test et en live**. Un
identifiant du mauvais mode ne se révèle qu'à la création de la session, en
`resource_missing`. Par ailleurs, le prix **affiché** (`products.priceCad`, Postgres)
et le prix **facturé** (Stripe) viennent de deux sources qui peuvent diverger en
silence. Enfin, rien en base ne disait ce que le client avait réellement vu : sous
Adaptive Pricing, un client camerounais paie des FCFA mais l'événement arrive en
`currency: "cad"`.

### Ce que fait cette PR

**Le checkout résout le prix par `lookup_key`**, une clé identique dans les deux
modes (`prices.list({ lookup_keys })`). La classe « identifiant du mauvais mode »
devient **impossible** au lieu d'être seulement détectée. C'est le cas d'usage
documenté par Stripe, et le changement de tarif s'y fait par `transfer_lookup_key`.

**La dérive de prix est détectée à deux endroits.** Au checkout, la comparaison
`unit_amount` ↔ `priceCad` ne coûte aucun appel supplémentaire ; une tâche cron
couvre en plus les produits que personne n'achète. Devise et montant ne sont PAS
traités pareil :

| Écart | Réaction | Pourquoi |
| --- | --- | --- |
| Montant | Alerte Sentry, **la vente passe** | Un tarif diverge légitimement le temps que l'`UPDATE` suive, et Checkout affiche le montant avant confirmation |
| Devise ≠ `cad` | **Refus** | La devise d'un prix Stripe est immuable : ce n'est jamais un état transitoire, c'est la mauvaise clé |

**`presentment_details` est persisté** (`presentment_amount` / `presentment_currency`,
nullables, devise en texte libre) et affiché au panneau admin. `amountPaid`/`currency`
restent le chiffre d'encaissement — aucune régression comptable.

### Migration en deux temps (expand/contract)

Les migrations tournent **au build Vercel, avant l'activation du déploiement**. Un
`DROP COLUMN stripe_price_id` ici casserait le checkout de l'ancien code pendant le
build. Cette PR ajoute donc `stripe_price_lookup_key` (backfillée depuis `code`) et
**conserve** `stripe_price_id` comme repli : une clé qui ne résout pas — ou dont la
résolution échoue — retombe dessus et alerte, au lieu de couper la vente.

**Le silence de cette alerte en production autorise la phase 2** (`DROP COLUMN` +
retrait du repli), à ouvrir dans une PR de suivi après 24-48 h de surveillance.

### ⚠️ Prérequis de déploiement

`prices.list` exige la permission **`prices:read`** sur la clé Stripe runtime, ce que
la création d'une session avec un price ID n'exigeait pas. Le droit a été ajouté à
`nomaqbanq-prod-app` le 2026-08-21 et vérifié par une lecture live réussie. **À
reconfirmer que c'est bien cette clé qui alimente `STRIPE_SECRET_KEY` en production**
avant de merger : sans ce droit, tous les checkouts tombent en `permission_error`.

### Vérifications

Les 5 `lookup_key` ont été vérifiées **en test et en live** (lecture seule) : elles
existent, portent les mêmes montants, et concordent avec `products.price_cad`.

Test navigateur de bout en bout (`customer_email: test+location_CM@example.com`) :

- Checkout affiché **84 634 FCFA / 200,00 $CA**, taux 1 CAD = 423,17 XAF
- Nickname du prix résolu visible → c'est bien la `lookup_key` qui a facturé
- Après paiement : `status=completed`, `amountPaid=20000 CAD`,
  `presentmentAmount=84634 XAF`
- Panneau admin : « +200 $ / présenté : 84 634 XAF »

Le `84634` sans centimes valide au passage que `formatPresentmentAmount` ne doit pas
diviser par 100 — le XAF est zéro-décimal.

### Effet de bord bienvenu

Le gotchá d'`AGENTS.md` « seul `exam_access` pointe sur un prix test » était **périmé
depuis le 2026-08-03** sans que personne ne l'ait mis à jour. Il disparaît :
la `lookup_key` rend les 5 produits achetables en local sans configuration.

---

## 2. Retry d'acquisition de connexion sur réveil Neon — NOMAQBANQ-1F

Le palier gratuit de Neon suspend la base après 5 minutes d'inactivité, et cette
suspension n'est pas désactivable. Le réveil fait échouer l'acquisition de connexion
en `53300` / `57P03`. Le pool retente désormais **l'acquisition seulement** — sûr,
puisqu'aucune requête n'est encore partie — et est borné à 10 s.

**Ne jamais étendre ce retry aux requêtes elles-mêmes** ni au timeout de file local :
retenter les aggraverait. C'est écrit dans `.claude/rules/data-layer.md`.

---

## Revues

Les deux campagnes ont passé une revue adversariale en session séparée, rapports
archivés dans `docs/superpowers/reviews/`.

La revue de conception (#138) a trouvé deux bloquants — une édition incomplète qui
aurait cassé `tsc`, et un backfill sans vérification préalable de sa propre prémisse
— tous deux corrigés avant d'écrire une ligne de code. La revue d'implémentation en a
trouvé un troisième, le plus important : le repli ne couvrait que la moitié des
échecs. Il s'exécutait sous `if (!price)`, donc uniquement quand `prices.list`
réussissait en rendant zéro prix ; une exception (droit manquant, 429, réseau)
sautait par-dessus jusqu'au message générique « Réessayez » — pour une panne
permanente. Corrigé par `d50be18`.

## Tests

- 1332 tests frontend (117 fichiers), couverture > 80 % sur les quatre axes
- 331 tests d'intégration (34 fichiers) sur branche Neon éphémère — la migration y
  est rejouée à neuf à chaque exécution
- `bun run check` vert
